### PR TITLE
feat: add --tap-host flag to configure bind address

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -97,7 +97,7 @@ async def async_main(args: argparse.Namespace):
     # Start live viewer server if requested
     live_server: LiveViewerServer | None = None
     if args.live_viewer:
-        live_server = LiveViewerServer(trace_path, port=args.live_port)
+        live_server = LiveViewerServer(trace_path, port=args.live_port, host=args.host)
         await live_server.start()
         print(f"🌐 Live viewer: {live_server.url}")
         webbrowser.open(live_server.url)
@@ -125,7 +125,7 @@ async def async_main(args: argparse.Namespace):
 
     runner = web.AppRunner(app)
     await runner.setup()
-    site = web.TCPSite(runner, "127.0.0.1", args.port)
+    site = web.TCPSite(runner, args.host, args.port)
     await site.start()
 
     # Resolve actual port (site._server is a private API; fall back to args.port)
@@ -133,7 +133,7 @@ async def async_main(args: argparse.Namespace):
         actual_port = site._server.sockets[0].getsockname()[1]
     except (AttributeError, IndexError, OSError):
         actual_port = args.port
-    print(f"🔍 claude-tap v{__version__} listening on http://127.0.0.1:{actual_port}")
+    print(f"🔍 claude-tap v{__version__} listening on http://{args.host}:{actual_port}")
     print(f"📁 Trace file: {trace_path}")
 
     # Background update check
@@ -243,6 +243,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     tap_parser.add_argument("--tap-port", type=int, default=0, dest="port", help="Proxy port (default: 0 = auto)")
     tap_parser.add_argument(
+        "--tap-host",
+        default=None,
+        dest="host",
+        help="Bind address for proxy and live viewer (default: 0.0.0.0 in --tap-no-launch mode, 127.0.0.1 otherwise)",
+    )
+    tap_parser.add_argument(
         "--tap-target",
         default="https://api.anthropic.com",
         dest="target",
@@ -291,6 +297,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     if claude_args and claude_args[0] == "--":
         claude_args = claude_args[1:]
     args.claude_args = claude_args
+    # Default host: 0.0.0.0 in --tap-no-launch mode (proxy-only, typically remote),
+    # 127.0.0.1 otherwise (launching Claude Code locally).
+    if args.host is None:
+        args.host = "0.0.0.0" if args.no_launch else "127.0.0.1"
     return args
 
 

--- a/claude_tap/live.py
+++ b/claude_tap/live.py
@@ -12,9 +12,10 @@ from aiohttp import web
 class LiveViewerServer:
     """HTTP server for real-time trace viewing via SSE."""
 
-    def __init__(self, trace_path: Path, port: int = 0):
+    def __init__(self, trace_path: Path, port: int = 0, host: str = "127.0.0.1"):
         self.trace_path = trace_path
         self.port = port
+        self.host = host
         self._sse_clients: list[web.StreamResponse] = []
         self._records: list[dict] = []
         self._lock = asyncio.Lock()
@@ -31,7 +32,7 @@ class LiveViewerServer:
 
         self._runner = web.AppRunner(app)
         await self._runner.setup()
-        site = web.TCPSite(self._runner, "127.0.0.1", self.port)
+        site = web.TCPSite(self._runner, self.host, self.port)
         await site.start()
 
         try:
@@ -75,7 +76,7 @@ class LiveViewerServer:
     @property
     def url(self) -> str:
         """Return the viewer URL."""
-        return f"http://127.0.0.1:{self._actual_port}"
+        return f"http://{self.host}:{self._actual_port}"
 
     async def _handle_index(self, request: web.Request) -> web.Response:
         """Serve the viewer HTML with live mode enabled."""


### PR DESCRIPTION
## Summary

- Add `--tap-host` CLI flag to configure the bind address for both the proxy server and the live viewer server
- Smart defaults based on mode:
  - `--tap-no-launch` mode → defaults to `0.0.0.0` (proxy-only mode is typically used on remote servers)
  - Normal mode → defaults to `127.0.0.1` (launching Claude Code locally)
- Users can always explicitly override with `--tap-host <address>`

## Motivation

When running `claude-tap --tap-no-launch` on a remote server, the proxy and live viewer bind to `127.0.0.1`, making them inaccessible from a local browser without SSH tunneling. Since `--tap-no-launch` is the typical proxy-only/remote usage pattern, defaulting to `0.0.0.0` in that mode is both safe and convenient.

## Usage

```bash
# Proxy-only mode: defaults to 0.0.0.0 (accessible from network)
claude-tap --tap-no-launch --tap-port 8080

# Normal mode: defaults to 127.0.0.1 (localhost only)
claude-tap

# Explicit override
claude-tap --tap-no-launch --tap-port 8080 --tap-host 127.0.0.1
```

## Changes

- `claude_tap/cli.py`: Add `--tap-host` argument with smart default based on `--tap-no-launch`, pass `args.host` to `TCPSite` and `LiveViewerServer`
- `claude_tap/live.py`: Accept `host` parameter in `LiveViewerServer.__init__`, use it for `TCPSite` bind and URL display

## Test plan

- [x] `--tap-no-launch` mode defaults to `0.0.0.0`, accessible from remote
- [x] Normal mode defaults to `127.0.0.1`, unchanged behavior
- [x] `--tap-host 127.0.0.1` overrides the default in `--tap-no-launch` mode
- [x] Live viewer also respects the host setting

🤖 Generated with [Claude Code](https://claude.ai/code)