### PR TITLE
fix: remove 1MB request body size limit for proxy

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -138,7 +138,7 @@ async def async_main(args: argparse.Namespace):
 
     session = aiohttp.ClientSession(auto_decompress=False)
 
-    app = web.Application()
+    app = web.Application(client_max_size=0)  # No body size limit (proxy must forward everything)
     app["trace_ctx"] = {
         "target_url": args.target,
         "writer": writer,


### PR DESCRIPTION
## Summary
- aiohttp's `web.Application` defaults `client_max_size` to 1MB (1,048,576 bytes), causing **413 Maximum request body size exceeded** errors when Claude Code sends requests larger than 1MB
- Large requests are common when conversations include extensive code context or long history (e.g. actual body size 1,309,298 bytes)
- Set `client_max_size=0` to disable the limit — as a proxy, body size should be enforced by the upstream API (Anthropic), not the proxy layer

## Test plan
- [ ] Run claude-tap with a long conversation that generates >1MB request bodies
- [ ] Verify no more 413 errors from the proxy
- [ ] Confirm requests are correctly forwarded to upstream API

🤖 Generated with [Claude Code](https://claude.ai/code)