### PR TITLE
fix: non-blocking browser open, sidebar timestamps, scroll preservation

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
+import threading
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +33,11 @@ if hasattr(sys.stdout, "reconfigure"):
 log = logging.getLogger("claude-tap")
 
 __version__ = "0.1.7"
+
+
+def _open_browser(url: str) -> None:
+    """Open URL in browser without blocking. Silently ignores failures in headless environments."""
+    threading.Thread(target=lambda: webbrowser.open(url), daemon=True).start()
 
 
 async def run_claude(port: int, extra_args: list[str]) -> int:
@@ -120,7 +126,7 @@ async def async_main(args: argparse.Namespace):
         live_server = LiveViewerServer(trace_path, port=args.live_port, host=args.host)
         await live_server.start()
         print(f"🌐 Live viewer: {live_server.url}")
-        webbrowser.open(live_server.url)
+        _open_browser(live_server.url)
 
     writer = TraceWriter(trace_path, live_server=live_server)
 
@@ -244,7 +250,7 @@ async def async_main(args: argparse.Namespace):
         # Open viewer in browser if requested
         if args.open_viewer and html_path.exists():
             print("\n🌐 Opening viewer in browser...")
-            webbrowser.open(f"file://{html_path.absolute()}")
+            _open_browser(f"file://{html_path.absolute()}")
 
     return exit_code
 

--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -183,6 +183,7 @@ body { font-family: var(--sans); background: var(--bg); color: var(--text); heig
 .sidebar-item .si-row2 { display: flex; gap: 10px; font-size: 11px; }
 .sidebar-item .si-tok { color: var(--green); font-family: var(--mono); font-weight: 500; }
 .sidebar-item .si-dur { color: var(--amber); font-family: var(--mono); font-weight: 500; }
+.sidebar-item .si-time { color: var(--text-tertiary); font-family: var(--mono); font-weight: 500; margin-left: auto; }
 .sidebar-item .si-path {
   font-size: 10px; color: var(--text-tertiary); font-family: var(--mono);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis; margin-top: 3px;
@@ -1444,6 +1445,7 @@ function createSidebarItem(e, i) {
   const model = e.request?.body?.model || '';
   const shortModel = model.replace(/^claude-/, '').replace(/-\d{8}$/, '');
   const badge = modelBadge(model);
+  const timeStr = e.timestamp ? new Date(e.timestamp).toLocaleTimeString() : '';
   item.innerHTML = `
     <div class="si-row1">
       <span class="si-turn">${t('turn')} ${e.turn || '?'}</span>
@@ -1452,6 +1454,7 @@ function createSidebarItem(e, i) {
     <div class="si-row2">
       <span class="si-tok">${(inTok + outTok).toLocaleString()} ${t('tok')}</span>
       <span class="si-dur">${fmtDuration(e.duration_ms || 0)}</span>
+      <span class="si-time">${esc(timeStr)}</span>
     </div>
     <div class="si-path">${esc((e.request?.method || '') + ' ' + (e.request?.path || ''))}</div>`;
   item.onclick = () => selectEntry(i);
@@ -1459,7 +1462,9 @@ function createSidebarItem(e, i) {
 }
 
 function renderSidebar(preserveDetail) {
-  const sb = $('#sidebar'); sb.innerHTML = '';
+  const sb = $('#sidebar');
+  const prevScrollTop = sb.scrollTop;
+  sb.innerHTML = '';
   const groups = new Map();
   filtered.forEach((e, i) => {
     const model = e.request?.body?.model || 'unknown';
@@ -1511,6 +1516,8 @@ function renderSidebar(preserveDetail) {
   } else {
     activeIdx = -1; $('#detail').innerHTML = `<div class="empty-state">${t('empty_state')}</div>`;
   }
+  // Restore sidebar scroll position after rebuild (e.g. during live updates)
+  if (preserveDetail) sb.scrollTop = prevScrollTop;
 }
 
 function selectEntry(idx, opts) {


### PR DESCRIPTION
## Summary
- **Fix headless blocking**: `webbrowser.open()` blocks in headless environments, preventing the proxy from starting when `--tap-live` is used. Now runs in a daemon thread.
- **Sidebar timestamps**: Each sidebar entry now shows the request timestamp (e.g. `10:14:27`) for easier navigation.
- **Scroll preservation**: Sidebar scroll position is preserved during live mode re-renders instead of resetting to top.

## Test plan
- [ ] Start `claude-tap --tap-live` in a headless environment — verify proxy starts without hanging
- [ ] Check sidebar entries show timestamps
- [ ] In live mode, scroll down in sidebar, wait for new entry — verify scroll position is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)