### PR TITLE
fix: sort imports to satisfy ruff linter

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -11,9 +11,9 @@ import shutil
 import signal
 import subprocess
 import sys
+import threading
 import urllib.error
 import urllib.request
-import threading
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path


### PR DESCRIPTION
Fix ruff I001 (unsorted imports) — `import threading` was out of alphabetical order.

🤖 Generated with [Claude Code](https://claude.ai/code)