### PR TITLE
docs(error): 补充 PR 截图缓存未刷新经验

### DIFF
--- a/docs/error-experience/entries/2026-02-27-pr-screenshot-cache-stale.md
+++ b/docs/error-experience/entries/2026-02-27-pr-screenshot-cache-stale.md
@@ -1,0 +1,35 @@
+# PR Screenshot Cache Staleness on GitHub Raw URLs
+
+**Date:** 2026-02-27
+**Tags:** github, pr, screenshot, cache, review
+
+## Problem
+
+After pushing updated screenshots to a PR branch, the PR description still displayed old images, making it appear that changes were not applied.
+
+## Root Cause
+
+PR descriptions referenced stable `raw.githubusercontent.com` image paths with the same filenames.
+GitHub/CDN caching can keep serving stale content for those URLs for a period of time.
+
+## Impact
+
+- Review confusion: reviewers believe PR evidence was not updated.
+- Extra communication overhead and repeated manual refresh attempts.
+
+## Fix Applied
+
+1. Generated new image files with versioned names (`*-v2.png`).
+2. Updated PR description image links to point to the new filenames.
+3. Confirmed PR references moved to the versioned URLs.
+
+## Preventive Rule
+
+When updating PR-embedded screenshots, prefer immutable image URLs by changing filenames
+(`before-v2.png`, `after-v3.png`) instead of reusing existing names.
+
+## Verification Checklist
+
+- New files appear in `Files changed`.
+- PR markdown links point to versioned filenames.
+- Reviewer can view updated images without hard-refresh dependency.


### PR DESCRIPTION
## 变更摘要
- 新增错误经验文档：`docs/error-experience/entries/2026-02-27-pr-screenshot-cache-stale.md`
- 记录 PR 中截图更新后仍显示旧图的缓存问题、根因、修复方式与预防规则。

## 为什么补充
- 该问题在本轮 viewer UI PR 评审中实际发生，容易重复踩坑。
- 文档化后可作为后续 UI PR 的固定检查项。

## 测试情况
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `uv run pytest tests/ -x --timeout=60` ✅（47 passed, 18 skipped）
  - 已知 warning：`tests/test_e2e.py::test_e2e_with_cleanup` 端口占用告警（历史已存在，不影响通过）
