### PR TITLE
docs: translate internal markdown docs to Chinese

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,31 +1,31 @@
-# AGENTS Index
+# AGENTS 索引
 
-This file is the entry point for contributor rules. Detailed policy text lives in `docs/standards/*.md`.
+本文件是贡献者规则的入口。详细策略文本位于 `docs/standards/*.md`。
 
-## Non-negotiable Rules
+## 不可协商规则
 
-These are mandatory and enforced in review:
+以下规则是强制性的，并会在 review 中执行：
 
-1. Run gate checks before every commit: `uv run ruff check .`, `uv run ruff format --check .`, `uv run pytest tests/ -x --timeout=60`.
-2. UI changes require PR screenshots with `raw.githubusercontent.com` absolute URLs.
-3. One concern per commit (no mixed refactor + feature/fix in the same commit).
-4. English only for code/comments/docs/commits, except `README_zh.md`.
-5. Evidence must use real trace data from `.traces/` (no synthetic mock screenshots/demos).
-6. Run pre-work checklist before coding and pre-PR checklist before opening a PR.
-7. Do not leave local-only work; you must `git add`, `git commit`, and `git push`.
-8. You must open a GitHub PR with `gh pr create`.
+1. 每次 commit 前运行 gate 检查：`uv run ruff check .`、`uv run ruff format --check .`、`uv run pytest tests/ -x --timeout=60`。
+2. UI 变更要求在 PR 中提供使用 `raw.githubusercontent.com` 绝对 URL 的截图。
+3. 每个 commit 只处理一个关注点（不要在同一 commit 中混合 refactor 与 feature/fix）。
+4. 代码/注释/文档/commit 仅使用英文，`README_zh.md` 除外。
+5. 证据必须使用 `.traces/` 中的真实 trace 数据（禁止合成 mock 截图/演示）。
+6. 编码前必须执行 pre-work checklist，开 PR 前必须执行 pre-PR checklist。
+7. 不要留下仅本地存在的工作；你必须执行 `git add`、`git commit` 和 `git push`。
+8. 你必须使用 `gh pr create` 打开 GitHub PR。
 
-## Standards Catalog
+## 标准目录
 
-- Hard rules and repository policies: `docs/standards/hard-rules.md`
-- Validation gates and required commands: `docs/standards/validation-and-gates.md`
-- E2E and screenshot evidence requirements: `docs/standards/e2e-and-evidence.md`
-- Screenshot capture and validation standards: `docs/standards/screenshot-standards.md`
-- Coding and runtime safety rules: `docs/standards/coding-and-runtime.md`
-- Workflow, review, and Brain/Hands protocol: `docs/standards/workflow-and-review.md`
-- Debugging methodology and anti-patterns: `docs/standards/debugging-standards.md`
-- Metadata and maintenance process for standards docs: `docs/standards/README.md`
+- 硬性规则与仓库策略：`docs/standards/hard-rules.md`
+- 验证 gate 与必需命令：`docs/standards/validation-and-gates.md`
+- E2E 与截图证据要求：`docs/standards/e2e-and-evidence.md`
+- 截图采集与验证标准：`docs/standards/screenshot-standards.md`
+- 编码与运行时安全规则：`docs/standards/coding-and-runtime.md`
+- 工作流、review 与 Brain/Hands 协议：`docs/standards/workflow-and-review.md`
+- 调试方法论与反模式：`docs/standards/debugging-standards.md`
+- 标准文档元数据与维护流程：`docs/standards/README.md`
 
-## Legibility Checks
+## 可读性检查
 
-Deterministic legibility checks are implemented in `scripts/check_legibility.py` and run in CI via `.github/workflows/legibility.yml`.
+确定性的可读性检查由 `scripts/check_legibility.py` 实现，并在 CI 中通过 `.github/workflows/legibility.yml` 运行。

--- a/docs/error-experience/entries/2026-02-25-pr1-stale-base.md
+++ b/docs/error-experience/entries/2026-02-25-pr1-stale-base.md
@@ -1,38 +1,36 @@
-# PR #1 Stale Base Branch Caused CI Failure
+# PR #1 过期基线分支导致 CI 失败
 
-**Date:** 2026-02-25
-**Severity:** Medium
-**Tags:** git, CI, uv.lock, rebase
+**日期：** 2026-02-25
+**严重级别：** 中
+**标签：** git, CI, uv.lock, rebase
 
-## What Happened
+## 发生了什么
 
-PR #1 (adding the `--tap-host` feature) had tests fail in CI because it was based
-on a stale `main` branch. The branch was forked from `bc7d344` while `main` had
-advanced to `bd7ec3f`. The `uv.lock` file was incompatible between the two versions,
-causing dependency resolution to fail and tests to error out.
+PR #1（新增 `--tap-host` 功能）在 CI 中测试失败，原因是它基于过期的 `main` 分支。
+该分支从 `bc7d344` 分叉，而 `main` 已推进到 `bd7ec3f`。两个版本的 `uv.lock`
+不兼容，导致依赖解析失败，测试报错。
 
-## Root Cause
+## 根因
 
-The feature branch was not rebased onto the latest `main` before opening the PR.
-The `uv.lock` file had diverged, and the stale version could not resolve the correct
-dependency set.
+在打开 PR 前，feature 分支没有 rebase 到最新 `main`。
+`uv.lock` 已产生分叉，过期版本无法解析正确依赖集。
 
-## Impact
+## 影响
 
-- CI tests failed on an otherwise correct PR
-- Required an extra rebase cycle to fix
-- Delayed merge by one review round
+- 原本正确的 PR 在 CI 中失败
+- 需要额外一次 rebase 循环修复
+- 合并延迟了一个 review 回合
 
-## Lesson Learned
+## 经验
 
-**Always rebase onto latest `main` before opening or merging a PR.**
+**在打开或合并 PR 前，始终先 rebase 到最新 `main`。**
 
-Checklist to prevent recurrence:
-1. Before opening a PR: `git fetch origin && git rebase origin/main`
-2. Verify `uv.lock` is up to date: `uv lock --check`
-3. Run the full test suite locally after rebase: `uv run pytest tests/ -x --timeout=60`
+防止复发的 checklist：
+1. 开 PR 前：`git fetch origin && git rebase origin/main`
+2. 验证 `uv.lock` 最新：`uv lock --check`
+3. rebase 后本地运行完整测试：`uv run pytest tests/ -x --timeout=60`
 
-## Related
+## 相关
 
-- PR: #1
-- Commits: bc7d344..bd7ec3f
+- PR：#1
+- Commits：bc7d344..bd7ec3f

--- a/docs/error-experience/entries/2026-02-26-codex-sandbox-git-blocked.md
+++ b/docs/error-experience/entries/2026-02-26-codex-sandbox-git-blocked.md
@@ -1,28 +1,28 @@
-# Codex Sandbox Cannot Run Git Commit
+# Codex Sandbox 无法执行 Git Commit
 
-**Date:** 2026-02-26
-**Severity:** Medium
-**Tags:** codex, sandbox, git, environment
+**日期：** 2026-02-26
+**严重级别：** 中
+**标签：** codex, sandbox, git, environment
 
-## Problem
+## 问题
 
-Codex `--full-auto` sandbox blocks write access to `.git/index.lock` and
-`.git/FETCH_HEAD`, preventing `git commit` and `git fetch` from completing.
+Codex `--full-auto` sandbox 会阻止对 `.git/index.lock` 和
+`.git/FETCH_HEAD` 的写访问，导致 `git commit` 与 `git fetch` 无法完成。
 
-## Impact
+## 影响
 
-- Codex can stage files with `git add` but cannot commit or fetch.
-- Any workflow that requires committing at the end must defer to external execution.
+- Codex 可以通过 `git add` 暂存文件，但无法 commit 或 fetch。
+- 任何要求最后提交的工作流都必须转到外部环境执行。
 
-## Workaround
+## 变通方案
 
-- Use Codex for code edits, refactors, test runs, and lint checks.
-- After Codex finishes, run `git add -A && git commit` outside the sandbox
-  (via OpenClaw exec or local shell).
-- Do not include `git commit` in Codex task prompts; it will fail silently or error out.
+- 用 Codex 完成代码编辑、重构、测试和 lint 检查。
+- Codex 完成后，在 sandbox 外执行 `git add -A && git commit`
+  （通过 OpenClaw exec 或本地 shell）。
+- 不要在 Codex 任务提示中要求 `git commit`；它会静默失败或直接报错。
 
-## Lesson Learned
+## 经验
 
-The Codex sandbox restricts `.git/` directory writes. Always plan for a post-Codex
-commit step when delegating tasks that produce file changes. Split the workflow:
-Codex edits → external git commit → push.
+Codex sandbox 会限制 `.git/` 目录写入。把会产生文件变更的任务交给 Codex 时，
+始终规划一个 Codex 后置 commit 步骤。将流程拆分为：
+Codex 编辑 → 外部 git commit → push。

--- a/docs/error-experience/entries/2026-02-26-codex-sandbox-tmux-blocked.md
+++ b/docs/error-experience/entries/2026-02-26-codex-sandbox-tmux-blocked.md
@@ -1,27 +1,26 @@
-# Codex Sandbox Blocked tmux Socket Creation
+# Codex Sandbox 阻止 tmux Socket 创建
 
-**Date:** 2026-02-26
-**Severity:** Medium
-**Tags:** codex, sandbox, tmux, environment
+**日期：** 2026-02-26
+**严重级别：** 中
+**标签：** codex, sandbox, tmux, environment
 
-## Problem
+## 问题
 
-Running tmux-based E2E flows inside Codex `--full-auto` failed because tmux could
-not create or access its socket path under `/private/tmp` (permission denied).
+在 Codex `--full-auto` 中运行基于 tmux 的 E2E 流程失败，因为 tmux 无法在
+`/private/tmp` 下创建或访问其 socket 路径（permission denied）。
 
-## Impact
+## 影响
 
-- Codex could update code and docs but could not execute tmux interactive tests directly.
-- End-to-end validation requiring tmux had to be completed outside the Codex sandbox.
+- Codex 可以更新代码和文档，但不能直接执行 tmux 交互测试。
+- 依赖 tmux 的端到端验证必须在 Codex sandbox 外完成。
 
-## Workaround
+## 变通方案
 
-- Use Codex for code edits, refactors, and static/testable logic.
-- Run tmux-dependent validation outside Codex (for example, via OpenClaw exec or local shell).
-- Feed results back into repo docs/tests after external verification.
+- 用 Codex 处理代码编辑、重构以及可静态/可测试逻辑。
+- 在 Codex 外执行依赖 tmux 的验证（例如 OpenClaw exec 或本地 shell）。
+- 外部验证后，再把结果回填到仓库文档/测试中。
 
-## Lesson Learned
+## 经验
 
-Tasks requiring system-level terminal multiplexers (`tmux`, `screen`) are not fully
-delegable to a restricted Codex sandbox. Split responsibilities explicitly between
-sandbox-safe work and external execution.
+需要系统级终端复用器（`tmux`、`screen`）的任务，无法完整委托给受限的 Codex sandbox。
+必须明确划分 sandbox 安全工作与外部执行职责。

--- a/docs/error-experience/entries/2026-02-26-hardcoded-version-string.md
+++ b/docs/error-experience/entries/2026-02-26-hardcoded-version-string.md
@@ -1,25 +1,23 @@
-# Hardcoded Version String in CLI
+# CLI 中硬编码版本字符串
 
-**Date:** 2026-02-26
-**Severity:** Medium
-**Tags:** versioning, cli, metadata, release
+**日期：** 2026-02-26
+**严重级别：** 中
+**标签：** versioning, cli, metadata, release
 
-## Problem
+## 问题
 
-`__version__` in `cli.py` was hardcoded as `"0.1.7"` and never updated on
-release. Users saw the wrong version with the `-v` flag even after upgrading.
+`cli.py` 中的 `__version__` 被硬编码为 `"0.1.7"`，发布时从未更新。
+用户即使升级后，用 `-v` 看到的仍是错误版本。
 
-## Root Cause
+## 根因
 
-The version string was a literal in source code instead of reading from package
-metadata.
+版本字符串是源码字面量，而不是从 package metadata 读取。
 
-## Fix
+## 修复
 
-Replaced the hardcoded value with `importlib.metadata.version("claude-tap")` so
-it always matches `pyproject.toml` and PyPI package metadata.
+将硬编码值替换为 `importlib.metadata.version("claude-tap")`，
+使其始终与 `pyproject.toml` 和 PyPI package metadata 一致。
 
-## Lesson Learned
+## 经验
 
-Never hardcode version strings. Always use `importlib.metadata` (or another
-single source of truth such as dynamic reading from `pyproject.toml`).
+不要硬编码版本字符串。始终使用 `importlib.metadata`（或其他单一真相源，例如从 `pyproject.toml` 动态读取）。

--- a/docs/error-experience/entries/2026-02-26-python313-ssl-aki-required.md
+++ b/docs/error-experience/entries/2026-02-26-python313-ssl-aki-required.md
@@ -1,42 +1,42 @@
-# Python 3.13 SSL Requires Authority Key Identifier in Certificates
+# Python 3.13 SSL 要求证书包含 Authority Key Identifier
 
-**Date:** 2026-02-26
-**Severity:** High (CI blocker — 4 consecutive failures)
-**Tags:** ssl, certificates, python313, ci, certs.py
+**日期：** 2026-02-26
+**严重级别：** 高（CI 阻塞 - 连续 4 次失败）
+**标签：** ssl, certificates, python313, ci, certs.py
 
-## Problem
+## 问题
 
-`test_forward_proxy_connect` failed on Python 3.13 with:
+`test_forward_proxy_connect` 在 Python 3.13 下失败，报错如下：
 
 ```
 SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED]
 certificate verify failed: Missing Authority Key Identifier (_ssl.c:1032)')
 ```
 
-CI passed on Python 3.11/3.12 but consistently failed on 3.13.
+CI 在 Python 3.11/3.12 通过，但在 3.13 持续失败。
 
-## Root Cause
+## 根因
 
-Python 3.13 tightened SSL certificate validation. It now **requires** the
-Authority Key Identifier (AKI) extension in certificates signed by a CA.
+Python 3.13 收紧了 SSL 证书校验。它现在**要求**由 CA 签发的证书包含
+Authority Key Identifier（AKI）扩展。
 
-Our `certs.py` generated:
-- CA cert: missing `SubjectKeyIdentifier` (SKI)
-- Host cert: missing `AuthorityKeyIdentifier` (AKI) and SKI
+我们的 `certs.py` 生成结果：
+- CA 证书：缺少 `SubjectKeyIdentifier`（SKI）
+- Host 证书：缺少 `AuthorityKeyIdentifier`（AKI）和 SKI
 
-These extensions are technically optional per X.509 but Python 3.13's SSL
-implementation treats missing AKI as a verification failure.
+这些扩展在 X.509 中技术上可选，但 Python 3.13 的 SSL 实现会将缺失 AKI
+视为校验失败。
 
-## Why It Wasn't Caught Locally
+## 为什么本地未捕获
 
-Local dev environment ran Python 3.11, which does not enforce AKI presence.
-The issue only surfaced in CI's Python 3.13 matrix.
+本地开发环境是 Python 3.11，不强制 AKI 存在。
+该问题只在 CI 的 Python 3.13 matrix 中暴露。
 
-## Fix
+## 修复
 
-Added proper X.509 extensions to both certificate types in `certs.py`:
+在 `certs.py` 中为两类证书都加入正确的 X.509 扩展：
 
-**CA certificate:**
+**CA 证书：**
 ```python
 .add_extension(
     x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
@@ -44,7 +44,7 @@ Added proper X.509 extensions to both certificate types in `certs.py`:
 )
 ```
 
-**Host certificate:**
+**Host 证书：**
 ```python
 .add_extension(
     x509.AuthorityKeyIdentifier.from_issuer_public_key(
@@ -58,12 +58,11 @@ Added proper X.509 extensions to both certificate types in `certs.py`:
 )
 ```
 
-## Lesson Learned
+## 经验
 
-1. **Always check CI across all Python versions before assuming tests pass.**
-   Local green on 3.11 doesn't mean green on 3.13.
-2. **Self-signed certificate generation must include SKI/AKI extensions.**
-   Even if older Python versions tolerate their absence, newer versions won't.
-3. **When CI fails on a specific Python version, check that version's changelog
-   for tightened security requirements** — SSL/TLS validation is a common area
-   for stricter enforcement.
+1. **在假定测试通过之前，务必检查 CI 的全部 Python 版本。**
+   本地 3.11 绿灯不代表 3.13 也绿灯。
+2. **自签证书生成必须包含 SKI/AKI 扩展。**
+   即使旧版 Python 容忍缺失，新版也可能不容忍。
+3. **当 CI 只在特定 Python 版本失败时，先看该版本 changelog 是否有更严格的安全要求**。
+   SSL/TLS 校验是常见收紧区域。

--- a/docs/error-experience/entries/2026-02-26-rg-not-portable.md
+++ b/docs/error-experience/entries/2026-02-26-rg-not-portable.md
@@ -1,24 +1,22 @@
-# `rg` (ripgrep) Not Available in All Environments
+# `rg`（ripgrep）并非所有环境都可用
 
-**Date:** 2026-02-26
-**Severity:** Low
-**Tags:** portability, shell, tooling
+**日期：** 2026-02-26
+**严重级别：** 低
+**标签：** portability, shell, tooling
 
-## Problem
+## 问题
 
-Shell script `run_real_e2e_tmux.sh` used `rg` (ripgrep) for JSONL assertions.
-On environments where ripgrep is not installed or not in `$PATH`, the script
-silently failed or gave misleading results.
+Shell 脚本 `run_real_e2e_tmux.sh` 使用 `rg`（ripgrep）做 JSONL 断言。
+在未安装 ripgrep 或不在 `$PATH` 的环境里，脚本会静默失败或给出误导结果。
 
-## Root Cause
+## 根因
 
-`rg` is a Rust-based tool that is not part of POSIX or macOS default installs.
-CI runners, Codex sandboxes, and freshly provisioned machines may lack it.
+`rg` 是 Rust 工具，不属于 POSIX，也不是 macOS 默认安装。
+CI runner、Codex sandbox 和新初始化机器都可能缺少它。
 
-## Fix
+## 修复
 
-Replaced all `rg` calls with `grep -F` (fixed-string match), which is POSIX-standard
-and universally available.
+将全部 `rg` 调用替换为 `grep -F`（固定字符串匹配），后者是 POSIX 标准且普遍可用。
 
 ```bash
 # Before (fragile)
@@ -28,8 +26,8 @@ rg '"tool_use"' "$JSONL_FILE"
 grep -F '"tool_use"' "$JSONL_FILE"
 ```
 
-## Lesson Learned
+## 经验
 
-**Prefer POSIX-standard utilities in shell scripts**: `grep`, `sed`, `awk`, `find`, `cut`.
-Reserve `rg`, `fd`, `jq`, etc. for interactive use or when explicitly declared as
-dependencies. Scripts must work on bare environments.
+**在 shell 脚本中优先使用 POSIX 标准工具**：`grep`、`sed`、`awk`、`find`、`cut`。
+`rg`、`fd`、`jq` 等工具应留给交互式使用，或明确声明为依赖。
+脚本必须能在裸环境运行。

--- a/docs/error-experience/entries/2026-02-26-sigttou-suspend-on-exit.md
+++ b/docs/error-experience/entries/2026-02-26-sigttou-suspend-on-exit.md
@@ -1,32 +1,30 @@
-# SIGTTOU Suspend on Exit After Child Process
+# 子进程退出后因 SIGTTOU 被挂起
 
-**Date:** 2026-02-26
-**Severity:** High
-**Tags:** signal, tty, process-group, tcsetpgrp, exit-path
+**日期：** 2026-02-26
+**严重级别：** 高
+**标签：** signal, tty, process-group, tcsetpgrp, exit-path
 
-## Problem
+## 问题
 
-After Claude Code exits, `claude-tap` tries to print a summary and generate
-HTML output but gets suspended with `suspended (tty output)` every time.
+Claude Code 退出后，`claude-tap` 尝试打印摘要并生成 HTML 输出，
+却每次都触发 `suspended (tty output)`。
 
-## Impact
+## 影响
 
-High. This was the #1 user-facing bug: users could never get HTML output
-because the process was suspended before the finalization path completed.
+高。这是用户感知最强的问题：进程在收尾路径完成前就被挂起，
+用户始终拿不到 HTML 输出。
 
-## Root Cause
+## 根因
 
-`claude-tap` gives terminal foreground control to the Claude Code child process
-via `tcsetpgrp`. When the child exits, `claude-tap` is still in a background
-process group. Any terminal write triggers `SIGTTOU`, which suspends the
-process, so the `finally` block (HTML generation and summary) never runs.
+`claude-tap` 通过 `tcsetpgrp` 把终端前台控制权交给 Claude Code 子进程。
+当子进程退出时，`claude-tap` 仍处于后台进程组。任何终端写操作都会触发 `SIGTTOU`，
+导致进程被挂起，因此 `finally` 块（HTML 生成与摘要）无法运行。
 
-## Fix
+## 修复
 
-Ignore `SIGTTOU` before calling `tcsetpgrp` to reclaim the foreground group,
-then restore the original signal handler afterward.
+在调用 `tcsetpgrp` 夺回前台进程组前先忽略 `SIGTTOU`，
+之后恢复原始 signal handler。
 
-## Lesson Learned
+## 经验
 
-When using process groups with `tcsetpgrp`, always handle `SIGTTOU` around the
-transition back to the parent foreground group.
+只要使用 `tcsetpgrp` 进行进程组切换，在切回父进程前台组时就必须处理 `SIGTTOU`。

--- a/docs/error-experience/entries/2026-02-27-pr-screenshot-cache-stale.md
+++ b/docs/error-experience/entries/2026-02-27-pr-screenshot-cache-stale.md
@@ -1,35 +1,35 @@
-# PR Screenshot Cache Staleness on GitHub Raw URLs
+# GitHub Raw URL 导致 PR 截图缓存陈旧
 
-**Date:** 2026-02-27
-**Tags:** github, pr, screenshot, cache, review
+**日期：** 2026-02-27
+**标签：** github, pr, screenshot, cache, review
 
-## Problem
+## 问题
 
-After pushing updated screenshots to a PR branch, the PR description still displayed old images, making it appear that changes were not applied.
+向 PR 分支 push 更新后的截图后，PR 描述仍显示旧图，看起来像变更未生效。
 
-## Root Cause
+## 根因
 
-PR descriptions referenced stable `raw.githubusercontent.com` image paths with the same filenames.
-GitHub/CDN caching can keep serving stale content for those URLs for a period of time.
+PR 描述引用了稳定不变文件名的 `raw.githubusercontent.com` 路径。
+GitHub/CDN 会在一段时间内继续缓存这些 URL 的旧内容。
 
-## Impact
+## 影响
 
-- Review confusion: reviewers believe PR evidence was not updated.
-- Extra communication overhead and repeated manual refresh attempts.
+- review 混乱：reviewer 误以为 PR 证据未更新。
+- 增加沟通成本与反复手动刷新。
 
-## Fix Applied
+## 已实施修复
 
-1. Generated new image files with versioned names (`*-v2.png`).
-2. Updated PR description image links to point to the new filenames.
-3. Confirmed PR references moved to the versioned URLs.
+1. 生成带版本后缀的新图片文件名（`*-v2.png`）。
+2. 更新 PR 描述中的图片链接，指向新文件名。
+3. 确认 PR 引用已切换到版本化 URL。
 
-## Preventive Rule
+## 预防规则
 
-When updating PR-embedded screenshots, prefer immutable image URLs by changing filenames
-(`before-v2.png`, `after-v3.png`) instead of reusing existing names.
+更新 PR 内嵌截图时，优先通过改文件名使用不可变图片 URL
+（如 `before-v2.png`、`after-v3.png`），不要复用旧文件名。
 
-## Verification Checklist
+## 验证 Checklist
 
-- New files appear in `Files changed`.
-- PR markdown links point to versioned filenames.
-- Reviewer can view updated images without hard-refresh dependency.
+- 新文件出现在 `Files changed`。
+- PR markdown 链接指向带版本后缀的文件名。
+- reviewer 无需强制刷新也能看到更新图片。

--- a/docs/error-experience/entries/2026-02-28-codex-reverse-websocket-capture-gap.md
+++ b/docs/error-experience/entries/2026-02-28-codex-reverse-websocket-capture-gap.md
@@ -1,37 +1,35 @@
-# Codex Reverse Mode Could Miss Responses Traffic
+# Codex Reverse Mode 可能遗漏 Responses 流量
 
-**Date:** 2026-02-28  
-**Severity:** High  
-**Tags:** codex, reverse-proxy, websocket, trace-capture
+**日期：** 2026-02-28  
+**严重级别：** 高  
+**标签：** codex, reverse-proxy, websocket, trace-capture
 
-## Problem
+## 问题
 
-In `--tap-client codex` reverse mode, some runs only captured `/v1/models` and showed
-zero token usage in the viewer. Follow-up conversation traffic was not consistently
-captured as `/v1/responses`.
+在 `--tap-client codex` 的 reverse mode 中，部分运行只捕获到 `/v1/models`，
+viewer 中 token usage 为 0。后续对话流量未能稳定捕获为 `/v1/responses`。
 
-## Root Cause
+## 根因
 
-Codex can attempt websocket-based Responses paths in interactive/session flows.
-When websocket behavior is enabled via user config or feature toggles, reverse-mode
-base URL routing can become inconsistent for trace capture.
+Codex 在交互/会话流中可能尝试基于 websocket 的 Responses 路径。
+当用户配置或特性开关启用 websocket 行为时，reverse-mode base URL 路由会出现
+trace 捕获不一致。
 
-## Fix
+## 修复
 
-- In reverse mode for Codex, auto-inject:
+- 在 Codex 的 reverse mode 下自动注入：
   - `--disable responses_websockets`
   - `--disable responses_websockets_v2`
-- Preserve user intent: if a feature is explicitly overridden via `--enable`,
-  `--disable`, or `-c/--config features.<name>=...`, do not force override it.
+- 保留用户意图：若用户已通过 `--enable`、`--disable` 或 `-c/--config features.<name>=...`
+  显式覆盖特性，不再强制覆盖。
 
-## Validation
+## 验证
 
-- Added E2E assertions that reverse-mode launch includes websocket-disable flags.
-- Added E2E assertions that explicit user feature override is respected.
-- Ran full gate checks (`ruff`, format check, `pytest tests/ -x --timeout=60`).
+- 增加 E2E 断言：reverse-mode 启动包含 websocket-disable flags。
+- 增加 E2E 断言：尊重用户显式 feature override。
+- 运行完整 gate 检查（`ruff`、format check、`pytest tests/ -x --timeout=60`）。
 
-## Lesson Learned
+## 经验
 
-For proxy-capture reliability, do not assume Codex transport is always HTTP POST.
-When reverse proxying, explicitly pin transport features to the capture path and
-make override behavior deterministic in tests.
+为了保证 proxy 捕获可靠性，不要假设 Codex 传输永远是 HTTP POST。
+在 reverse proxy 场景下，应显式将传输特性固定到可捕获路径，并在测试中让覆盖行为具备确定性。

--- a/docs/error-experience/entries/2026-03-03-codex-ws-timeout-fallback-evidence.md
+++ b/docs/error-experience/entries/2026-03-03-codex-ws-timeout-fallback-evidence.md
@@ -1,36 +1,36 @@
-# Codex WS Timeout With Verified HTTPS Fallback (PR #22)
+# Codex WS 超时且已验证 HTTPS 回退（PR #22）
 
-**Date:** 2026-03-03
-**Tags:** codex, websocket, reverse-proxy, validation, fallback
+**日期：** 2026-03-03
+**标签：** codex, websocket, reverse-proxy, validation, fallback
 
-## Context
+## 背景
 
-While validating PR #22 (`feat/ws-proxy`) with real Codex runs, we needed hard evidence for WebSocket transport behavior and fallback behavior in the current environment.
+在用真实 Codex 运行验证 PR #22（`feat/ws-proxy`）时，我们需要对 WebSocket 传输行为和当前环境中的回退行为提供硬证据。
 
-## What Happened
+## 发生了什么
 
-- A normal Codex run through `claude_tap --tap-client codex` succeeded via HTTP/SSE (`POST /v1/responses`).
-- Forced WS runs (`--enable responses_websockets` and `--enable responses_websockets_v2`) repeatedly failed to connect upstream:
+- 通过 `claude_tap --tap-client codex` 的常规 Codex 运行经由 HTTP/SSE（`POST /v1/responses`）成功。
+- 强制 WS 运行（`--enable responses_websockets` 与 `--enable responses_websockets_v2`）反复连接上游失败：
   - `502 Bad Gateway`
-  - timeout to `wss://chatgpt.com/backend-api/codex/responses`
-- After retries, Codex automatically fell back to HTTPS transport and completed the turn successfully.
+  - 连接 `wss://chatgpt.com/backend-api/codex/responses` 超时
+- 多次重试后，Codex 自动回退到 HTTPS 传输并成功完成该轮。
 
-## Root Cause (Observed)
+## 根因（观察）
 
-The observed failure is upstream WS connection timeout in this environment, not a local crash in the proxy process. The proxy records WS failure correctly, and the client fallback path recovers the run.
+观察到的问题是当前环境中的上游 WS 连接超时，而非 proxy 进程本地崩溃。proxy 正确记录了 WS 失败，client 的 fallback 路径恢复了运行。
 
-## Evidence
+## 证据
 
 - `/tmp/pr22-ws-unblock-evidence-20260303/codex-ws-v1-run.log`
 - `/tmp/pr22-ws-unblock-evidence-20260303/codex-ws-v2-run.log`
 - `/tmp/pr22-ws-unblock-evidence-20260303/codex-ws-v1-run/trace_20260303_180901.jsonl`
 - `/tmp/pr22-ws-unblock-evidence-20260303/codex-ws-v2-run/trace_20260303_180901.jsonl`
 
-## Lesson
+## 经验
 
-For transport-sensitive validation, separate three statements explicitly:
-1. implemented behavior (code + tests),
-2. observed behavior in this environment,
-3. not-yet-verified behavior due to network/runtime constraints.
+对传输敏感验证，需明确区分三类陈述：
+1. 已实现行为（代码 + 测试），
+2. 当前环境中的观察行为，
+3. 因网络/运行时约束尚未验证的行为。
 
-This prevents over-claiming while still allowing merge decisions on verified scope.
+这样能避免过度声明，同时仍可在已验证范围内推进合并决策。

--- a/docs/error-experience/entries/2026-03-03-pr-screenshot-quality-failures.md
+++ b/docs/error-experience/entries/2026-03-03-pr-screenshot-quality-failures.md
@@ -1,57 +1,57 @@
-# PR Screenshot Quality Failures (2026-03-03)
+# PR 截图质量失败案例（2026-03-03）
 
-## What Happened
+## 发生了什么
 
-PR #22 (WebSocket proxy fix) needed screenshot evidence. Three separate quality failures occurred before producing acceptable screenshots:
+PR #22（WebSocket proxy 修复）需要截图证据。在产出可接受截图前，先后出现了三次质量失败：
 
-### Failure 1: Mobile Viewport Layout
-- **Symptom**: Trace viewer rendered as mobile layout — cramped, single-column, unreadable
-- **Root cause**: OpenClaw built-in browser defaults to a narrow viewport (~750px), triggering responsive mobile breakpoints
-- **Impact**: Screenshot showed mobile UI that didn't match what users actually see
+### 失败 1：移动端 Viewport 布局
+- **症状**：Trace viewer 渲染为移动端布局，拥挤、单列、难以阅读
+- **根因**：OpenClaw 内置浏览器默认窄 viewport（约 750px），触发响应式移动端断点
+- **影响**：截图展示的是移动端 UI，和用户实际看到的不一致
 
-### Failure 2: Unicode Arrow Corruption
-- **Symptom**: Log file arrows `→` and `←` rendered as garbled characters `鉞@` in the screenshot
-- **Root cause**: The log file contained Unicode arrows. The browser or font rendering in the headless environment corrupted multi-byte characters. The raw `.log` file was served directly without charset handling.
-- **Impact**: Screenshot was unreadable for the key evidence (WS direction indicators)
+### 失败 2：Unicode 箭头乱码
+- **症状**：日志中的箭头 `→` 与 `←` 在截图里显示为乱码 `鉞@`
+- **根因**：日志文件包含 Unicode 箭头。headless 环境中的浏览器或字体渲染破坏了多字节字符；原始 `.log` 被直接提供且未处理 charset。
+- **影响**：关键证据（WS 方向标记）不可读
 
-### Failure 3: Wrong Content in Screenshot
-- **Symptom**: Trace viewer showed `/v1/models` request detail instead of the WebSocket `/v1/responses` request
-- **Root cause**: Didn't click into the correct trace entry before taking the screenshot. Assumed the default view would show the WS request.
-- **Impact**: Screenshot didn't prove what the PR claimed
+### 失败 3：截图内容错误
+- **症状**：Trace viewer 显示的是 `/v1/models` 请求详情，而非 WebSocket `/v1/responses` 请求
+- **根因**：截图前没有先点击到正确 trace entry，误以为默认视图就是 WS 请求
+- **影响**：截图无法证明 PR 声称的内容
 
-### Meta-Failure: No Pre-Commit Review
-- All three bad screenshots were committed and pushed to the PR without being reviewed first
-- User had to manually inspect and flag each issue
-- Multiple round-trips to fix what should have been caught before commit
+### 元失败：缺少提交前审查
+- 三张错误截图都在未先审查的情况下被 commit 并 push 到 PR
+- 用户不得不手动检查并逐个指出问题
+- 多轮往返才修复本应在 commit 前捕获的问题
 
-## How It Was Fixed
+## 如何修复
 
-1. **Viewport**: `browser act resize width=1440 height=900` before taking screenshots
-2. **Unicode**: Created a custom HTML card (`ws-log-clean.html`) using HTML entities (`&gt;` `&lt;` `->`) instead of raw Unicode arrows
-3. **Content**: Navigated to the correct trace entry (Turn 2 WEBSOCKET) and verified the content before capturing
-4. **Review**: Visually inspected each screenshot before committing
+1. **Viewport**：截图前执行 `browser act resize width=1440 height=900`
+2. **Unicode**：创建自定义 HTML 卡片（`ws-log-clean.html`），使用 HTML entities（`&gt;` `&lt;` `->`）替代原始 Unicode 箭头
+3. **内容**：先导航到正确 trace entry（Turn 2 WEBSOCKET），确认内容后再截图
+4. **审查**：commit 前逐张肉眼检查截图
 
-## Standards Derived
+## 形成的标准
 
-### Screenshot Pre-Commit Checklist
-1. **Viewport**: Set to desktop width (≥1280px) before capture
-2. **Content**: Verify the screenshot shows exactly what you claim it shows
-3. **Encoding**: Check for garbled/corrupted characters — especially Unicode symbols, CJK text, emoji
-4. **Layout**: Confirm desktop layout rendered (not mobile/responsive breakpoint)
-5. **Readability**: Key evidence text must be legible at 1x zoom
-6. **Review**: View the actual PNG file before `git add` — never blind-commit screenshots
+### 截图提交前 Checklist
+1. **Viewport**：截图前设为桌面宽度（≥1280px）
+2. **内容**：确认截图展示的内容与声明完全一致
+3. **编码**：检查是否有乱码/损坏字符，尤其是 Unicode 符号、CJK 文本、emoji
+4. **布局**：确认渲染为桌面布局（不是移动端响应断点）
+5. **可读性**：关键证据文本在 1x 缩放下可清晰阅读
+6. **审查**：`git add` 前查看实际 PNG 文件，禁止盲目提交
 
-### Automation Opportunities
-- `scripts/check_screenshots.sh`: Automated checks for image dimensions (reject <1000px wide as likely mobile), file size (reject <10KB as likely error pages), and basic sanity
-- PR body template could include a screenshot checklist section
-- Consider generating evidence screenshots programmatically with fixed viewport settings
+### 自动化机会
+- `scripts/check_screenshots.sh`：自动检查图像尺寸（拒绝宽度 <1000px，疑似移动端）、文件大小（拒绝 <10KB，疑似错误页）和基础合理性
+- PR 正文模板可以加入截图 checklist 章节
+- 可考虑通过固定 viewport 设置程序化生成证据截图
 
-## Prevention
+## 预防
 
-- Added screenshot quality gate to `docs/standards/e2e-and-evidence.md`
-- Created `scripts/check_screenshots.sh` for automated pre-commit validation
-- AGENTS.md should reference the screenshot standard for any PR with visual evidence
+- 已在 `docs/standards/e2e-and-evidence.md` 增加截图质量 gate
+- 已新增 `scripts/check_screenshots.sh` 用于 pre-commit 自动验证
+- AGENTS.md 应对任何包含视觉证据的 PR 引用该截图标准
 
-## Key Takeaway
+## 关键结论
 
-Screenshots are evidence. Evidence must be verified before submission. "I took a screenshot" is not the same as "I verified the screenshot proves what I claim."
+截图是证据。证据必须在提交前验证。“我截了图”不等于“我验证了这张图能证明我的结论”。

--- a/docs/good-experience/entries/2026-02-25-mock-e2e-pattern.md
+++ b/docs/good-experience/entries/2026-02-25-mock-e2e-pattern.md
@@ -1,52 +1,48 @@
-# Mock E2E Test Pattern: Fake Upstream + Fake Claude
+# Mock E2E 测试模式：Fake Upstream + Fake Claude
 
-**Date:** 2026-02-25
-**Tags:** testing, E2E, mock, best-practice
+**日期：** 2026-02-25
+**标签：** testing, E2E, mock, best-practice
 
-## Pattern Description
+## 模式描述
 
-The existing E2E test suite (`tests/test_e2e.py`) uses a fully mocked approach
-that tests the entire claude-tap pipeline without any external dependencies:
+现有 E2E 测试套件（`tests/test_e2e.py`）采用了全 mock 方案，
+可在无外部依赖的情况下测试整个 claude-tap pipeline：
 
-1. **Fake upstream server** — An aiohttp server running in a background thread
-   that mimics the Anthropic API, returning both non-streaming and streaming (SSE)
-   responses.
+1. **Fake upstream server** - 在后台线程运行 aiohttp server，
+   模拟 Anthropic API，同时返回 non-streaming 与 streaming（SSE）响应。
 
-2. **Fake Claude script** — A temporary Python script placed in PATH that acts
-   as the `claude` CLI. It makes HTTP requests to `ANTHROPIC_BASE_URL` (set by
-   claude-tap to point at the proxy) and prints the results.
+2. **Fake Claude script** - 在 PATH 中放置临时 Python 脚本作为 `claude` CLI。
+   它向 `ANTHROPIC_BASE_URL`（由 claude-tap 设置为 proxy 地址）发送 HTTP 请求并打印结果。
 
-3. **Real claude-tap** — The actual `claude_tap` module is run as a subprocess
-   with `--tap-target` pointing to the fake upstream.
+3. **真实 claude-tap** - 以子进程方式运行真实 `claude_tap` module，
+   并通过 `--tap-target` 指向 fake upstream。
 
-## Why It Works Well
+## 为什么效果好
 
-- **No external dependencies**: Tests run offline, no API keys needed
-- **Deterministic**: Same input always produces the same output
-- **Fast**: No network latency, no rate limits
-- **Complete coverage**: Tests the full pipeline — proxy startup, request forwarding,
-  SSE reassembly, JSONL recording, HTML viewer generation, API key redaction
-- **Robust edge cases**: Includes tests for upstream errors (500), malformed SSE,
-  and large payloads (100KB+)
+- **无外部依赖**：测试可离线运行，无需 API keys
+- **可确定性**：相同输入始终产生相同输出
+- **速度快**：无网络时延，无 rate limit
+- **覆盖完整**：测试全链路，包括 proxy 启动、请求转发、SSE 重组、JSONL 记录、HTML viewer 生成、API key 脱敏
+- **边界情况稳健**：覆盖上游错误（500）、畸形 SSE、大 payload（100KB+）
 
-## Key Implementation Details
+## 关键实现细节
 
-- `run_fake_upstream_in_thread()` uses `threading.Event` for synchronization
-- Fake Claude script is created with `_create_fake_claude()` and made executable
-- Temporary bin directory is prepended to `PATH` so claude-tap finds the fake `claude`
-- Port hardcoding (19199, 19200, etc.) keeps tests isolated
-- Trace files are written to `tempfile.mkdtemp()` and cleaned up after assertions
+- `run_fake_upstream_in_thread()` 使用 `threading.Event` 做同步
+- Fake Claude 脚本由 `_create_fake_claude()` 创建并设为可执行
+- 临时 bin 目录会 prepend 到 `PATH`，让 claude-tap 找到 fake `claude`
+- 端口硬编码（19199、19200 等）保持测试隔离
+- Trace 文件写入 `tempfile.mkdtemp()`，断言后清理
 
-## When to Use This Pattern
+## 何时使用此模式
 
-Use this pattern when:
-- Testing proxy behavior (forwarding, recording, SSE handling)
-- Testing HTML viewer generation
-- Testing header redaction and security features
-- Running in CI where no Claude API access is available
+适用于：
+- 测试 proxy 行为（转发、记录、SSE 处理）
+- 测试 HTML viewer 生成
+- 测试 header 脱敏与安全能力
+- 在无 Claude API 访问的 CI 中运行
 
-## Complementary Pattern
+## 互补模式
 
-For testing real Claude integration (actual API responses, tool use, multi-turn
-conversations), see the real E2E tests in `tests/e2e/`. Those require a working
-`claude` CLI installation and are skipped by default in CI.
+若要测试真实 Claude 集成（实际 API 响应、tool use、多轮对话），
+请参考 `tests/e2e/` 下的 real E2E 测试。它们需要可用的 `claude` CLI 安装，
+且在 CI 中默认跳过。

--- a/docs/good-experience/entries/2026-02-25-proxy-e2e-ci-hardening.md
+++ b/docs/good-experience/entries/2026-02-25-proxy-e2e-ci-hardening.md
@@ -1,43 +1,43 @@
-# Proxy-Aware E2E and CI Hardening
+# 面向 Proxy 的 E2E 与 CI 强化
 
-**Date:** 2026-02-25  
-**Tags:** e2e, proxy, oauth, ci, reliability
+**日期：** 2026-02-25  
+**标签：** e2e, proxy, oauth, ci, reliability
 
-## Context
+## 背景
 
-Real E2E coverage was blocked by environment-dependent behavior:
+真实 E2E 覆盖曾被环境相关行为阻塞：
 
-- OAuth flows failed with `403 Request not allowed` in forward-proxy runs.
-- CI failed on Python 3.13 due to stricter TLS certificate validation in a forward proxy test.
-- Test expectations assumed `/v1/messages` was always the first API call, which is not true for OAuth preflight.
+- forward-proxy 运行中的 OAuth 流程出现 `403 Request not allowed`。
+- CI 在 Python 3.13 下因 forward proxy 测试中的 TLS 证书校验更严格而失败。
+- 测试预期误以为首个 API 调用总是 `/v1/messages`，但 OAuth 预检并非如此。
 
-## What Worked
+## 有效做法
 
-1. **Respect system proxy env in upstream forwarding**
-   - Set `trust_env=True` in the aiohttp session used by `claude-tap` upstream forwarding.
-   - This allowed traffic to follow local proxy/VPN tooling (e.g., Clash) instead of bypassing it.
+1. **上游转发尊重系统 proxy env**
+   - 在 claude-tap 上游转发使用的 aiohttp session 中设置 `trust_env=True`。
+   - 使流量能遵循本地 proxy/VPN 工具（如 Clash），而不是绕过它。
 
-2. **Make forward/OAuth assertions robust**
-   - Do not assume the first traced request is `/v1/messages`.
-   - Search records for at least one `/v1/messages` call and validate response content there.
+2. **提升 forward/OAuth 断言鲁棒性**
+   - 不假设首条 trace 请求是 `/v1/messages`。
+   - 在记录中搜索至少一条 `/v1/messages` 调用，并在该处验证响应内容。
 
-3. **Harden test certificates for Python 3.13**
-   - Add both `SubjectKeyIdentifier` and `AuthorityKeyIdentifier` extensions in self-signed test certs.
-   - This resolved `CERTIFICATE_VERIFY_FAILED: Missing Authority Key Identifier` in CI.
+3. **为 Python 3.13 强化测试证书**
+   - 在自签测试证书中同时添加 `SubjectKeyIdentifier` 与 `AuthorityKeyIdentifier` 扩展。
+   - 解决 CI 中 `CERTIFICATE_VERIFY_FAILED: Missing Authority Key Identifier`。
 
-4. **Fix trace stats null-safety**
-   - Guard against `request.body is None` when collecting model usage metrics.
+4. **修复 trace 统计的空值安全**
+   - 在收集 model usage 指标时防护 `request.body is None`。
 
-## Why This Matters
+## 为什么重要
 
-- Real E2E can pass in proxy-heavy developer environments without hidden network-path mismatches.
-- CI becomes stable across Python versions.
-- Tests validate behavior rather than incidental request ordering.
+- 真实 E2E 可在 proxy 重环境的开发机中通过，避免隐藏的网络路径不一致。
+- CI 在不同 Python 版本间更稳定。
+- 测试验证的是行为本身，而不是偶然的请求顺序。
 
-## Operational Notes
+## 运行说明
 
-- Real E2E remains opt-in via `--run-real-e2e`.
-- Browser integration tests require Playwright installation and browser binaries.
-- When debugging proxy issues, verify both legs:
+- 真实 E2E 仍通过 `--run-real-e2e` opt-in。
+- Browser integration 测试需要安装 Playwright 与浏览器二进制。
+- 调试 proxy 问题时，两个链路都要验证：
   - Claude CLI -> claude-tap
-  - claude-tap -> upstream (must honor proxy env when required)
+  - claude-tap -> upstream（必要时必须遵守 proxy env）

--- a/docs/good-experience/entries/2026-02-26-tmux-e2e-success.md
+++ b/docs/good-experience/entries/2026-02-26-tmux-e2e-success.md
@@ -1,41 +1,40 @@
-# tmux Real E2E Success Pattern
+# tmux 真实 E2E 成功模式
 
-**Date:** 2026-02-26
-**Tags:** e2e, tmux, testing, verification
+**日期：** 2026-02-26
+**标签：** e2e, tmux, testing, verification
 
-## Problem
+## 问题
 
-tmux `send-keys` was not reliably submitting prompts to Claude Code TUI during real
-interactive E2E runs.
+tmux `send-keys` 在真实交互式 E2E 运行中，无法稳定向 Claude Code TUI 提交 prompt。
 
-## Root Cause
+## 根因
 
-- Some flows assumed `rg` was available for assertions, but it was missing in parts of the environment.
-- Submit behavior in Claude Code TUI under tmux was mis-modeled; the correct submit key was just `Enter`.
+- 部分流程假设 `rg` 可用于断言，但在一些环境中并不存在。
+- 对 Claude Code TUI 在 tmux 下的提交行为建模错误；正确提交键是 `Enter`。
 
-## Solution
+## 解决方案
 
-- Replaced fragile `rg`-based checks with portable `grep -F` checks.
-- Standardized submit behavior to `Enter` by default.
-- Added retry-on-miss submission logic to reduce transient input timing failures.
+- 将脆弱的 `rg` 断言替换为可移植的 `grep -F`。
+- 将默认提交行为统一为 `Enter`。
+- 加入“未命中重试提交”逻辑，降低瞬时输入时序失败。
 
-## Verification
+## 验证
 
-Validated via JSONL assertions:
+通过 JSONL 断言验证：
 
-1. Both prompts appear in trace data.
-2. `/v1/messages` calls are at least 2.
-3. At least one response content block is `tool_use`.
-4. HTML viewer artifact is generated.
+1. 两个 prompt 都出现在 trace 数据中。
+2. `/v1/messages` 调用至少为 2 次。
+3. 至少一个响应内容块为 `tool_use`。
+4. 生成了 HTML viewer 产物。
 
-## Result
+## 结果
 
-- `7/7` pytest real E2E cases passed.
-- tmux interactive E2E passed with confirmed `tool_use` capture.
-- asciinema recording was produced.
-- Browser screenshots of the generated HTML viewer were captured.
+- pytest real E2E 用例 `7/7` 通过。
+- tmux 交互式 E2E 通过，且确认捕获到 `tool_use`。
+- 生成了 asciinema 录制。
+- 已截取生成的 HTML viewer browser 截图。
 
-## Lesson Learned
+## 经验
 
-For real Claude TUI automation under tmux, portability and input semantics matter more
-than clever tooling: prefer `grep -F`, use `Enter`, and verify through trace artifacts.
+在 tmux 下做真实 Claude TUI 自动化时，可移植性与输入语义比“巧工具”更重要：
+优先 `grep -F`，使用 `Enter`，并通过 trace 产物验证。

--- a/docs/good-experience/entries/2026-02-27-viewer-sticky-validation-flow.md
+++ b/docs/good-experience/entries/2026-02-27-viewer-sticky-validation-flow.md
@@ -1,25 +1,25 @@
-# UI Fix Delivery Pattern: Sticky Header + Evidence-First Validation
+# UI 修复交付模式：Sticky Header + 证据优先验证
 
-**Date:** 2026-02-27
-**Tags:** ui, viewer, testing, workflow, pr
+**日期：** 2026-02-27
+**标签：** ui, viewer, testing, workflow, pr
 
-## Context
+## 背景
 
-A small UI behavior fix (sticky action controls in the viewer detail panel) needed to be delivered with reliable evidence for review.
+一个小型 UI 行为修复（viewer detail panel 的操作控件 sticky）需要以可靠证据交付，便于 review。
 
-## What Worked
+## 有效做法
 
-1. Applied a minimal CSS-only fix first, without changing JS behavior.
-2. Ran fast quality gates early (`ruff` + `pytest`) to quickly detect regressions.
-3. Produced visual evidence (before/after scrolling state) for PR review.
-4. Added explicit process requirements in `AGENTS.md` so future UI changes consistently include E2E validation and screenshots.
+1. 先应用最小化、仅 CSS 的修复，不改动 JS 行为。
+2. 提前运行快速质量 gate（`ruff` + `pytest`）以快速发现回归。
+3. 产出可视化证据（滚动前/后状态）供 PR review。
+4. 在 `AGENTS.md` 添加明确流程要求，确保未来 UI 变更始终附带 E2E 验证与截图。
 
-## Why This Pattern Is Good
+## 为什么这个模式好
 
-- Low risk: tiny change surface.
-- High review clarity: behavior proof is visible in screenshots.
-- Reusable process: same flow can be applied to future UI changes.
+- 低风险：改动面很小。
+- review 清晰度高：截图可直接证明行为。
+- 流程可复用：同样流程可应用于后续 UI 变更。
 
-## Lesson Learned
+## 经验
 
-For UI behavior fixes, evidence is part of the deliverable. A good PR is not only "code + tests" but also "visual proof + explicit validation steps".
+对 UI 行为修复，证据是交付物的一部分。好的 PR 不只是“代码 + 测试”，还包括“可视化证明 + 明确验证步骤”。

--- a/docs/guides/engineering-practices.md
+++ b/docs/guides/engineering-practices.md
@@ -1,34 +1,34 @@
-# Engineering Practices Guide
+# 工程实践指南
 
-This document codifies the engineering standards for the claude-tap project.
+本文档对 claude-tap 项目的工程标准进行规范化。
 
-## Python Code Style
+## Python 代码风格
 
-- **Linter/formatter:** [ruff](https://docs.astral.sh/ruff/)
-- **Line length:** 120 characters
-- **Target version:** Python 3.11+
-- **Lint rules:** `E` (errors), `F` (pyflakes), `W` (warnings), `I` (import sorting)
-- **Ignored rules:** `E501` (line length — enforced by formatter instead)
+- **Linter/formatter：** [ruff](https://docs.astral.sh/ruff/)
+- **行长限制：** 120 字符
+- **目标版本：** Python 3.11+
+- **Lint 规则：** `E`（errors）、`F`（pyflakes）、`W`（warnings）、`I`（import sorting）
+- **忽略规则：** `E501`（行长，由 formatter 而非 lint 强制）
 
-Run locally:
+本地运行：
 ```bash
 uv run ruff check .          # Lint
 uv run ruff format --check . # Check formatting
 uv run ruff format .         # Auto-fix formatting
 ```
 
-## Testing Strategy
+## 测试策略
 
-### Test Layers
+### 测试分层
 
-| Layer | Location | What It Tests | Runs In CI | External Deps |
-|-------|----------|---------------|------------|---------------|
-| **Unit** | `tests/test_diff_matching.py` | Pure logic (diff matching, parsing) | Yes | None |
-| **Mock E2E** | `tests/test_e2e.py` | Full pipeline with fake upstream + fake Claude | Yes | None |
-| **Browser integration** | `tests/test_nav_browser.py` | HTML viewer JavaScript logic | Yes (with Playwright) | Playwright |
-| **Real E2E** | `tests/e2e/` | Actual Claude CLI integration | No (opt-in) | Claude CLI, API key |
+| Layer | Location | 测试内容 | 在 CI 中运行 | 外部依赖 |
+|-------|----------|----------|--------------|----------|
+| **Unit** | `tests/test_diff_matching.py` | 纯逻辑（diff matching、parsing） | 是 | 无 |
+| **Mock E2E** | `tests/test_e2e.py` | fake upstream + fake Claude 的完整 pipeline | 是 | 无 |
+| **Browser integration** | `tests/test_nav_browser.py` | HTML viewer JavaScript 逻辑 | 是（使用 Playwright） | Playwright |
+| **Real E2E** | `tests/e2e/` | 真实 Claude CLI 集成 | 否（opt-in） | Claude CLI、API key |
 
-### Running Tests
+### 运行测试
 
 ```bash
 # Full CI suite (unit + mock E2E)
@@ -44,23 +44,23 @@ uv run pytest tests/e2e/ --run-real-e2e --timeout=300
 uv run pytest tests/ --run-real-e2e --timeout=300
 ```
 
-### Writing New Tests
+### 编写新测试
 
-- Use `pytest` fixtures for setup/teardown (see `conftest.py`)
-- Use `tempfile.mkdtemp()` for temporary directories — always clean up
-- For async tests, use `pytest-asyncio` (configured with `asyncio_mode = "auto"`)
-- Mark slow tests with `@pytest.mark.slow`
-- Mark integration tests with `@pytest.mark.integration`
+- 使用 `pytest` fixtures 做 setup/teardown（见 `conftest.py`）
+- 用 `tempfile.mkdtemp()` 创建临时目录，并始终清理
+- 对 async 测试，使用 `pytest-asyncio`（配置为 `asyncio_mode = "auto"`）
+- 慢测试标记为 `@pytest.mark.slow`
+- integration 测试标记为 `@pytest.mark.integration`
 
-## Commit Conventions
+## Commit 约定
 
-- Write commit messages in English
-- Use imperative mood: "add feature" not "added feature"
-- Prefix with type: `feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`
-- Keep subject line under 72 characters
-- Add body for non-trivial changes explaining "why"
+- commit message 使用英文
+- 使用祈使语气：“add feature” 而非 “added feature”
+- 使用类型前缀：`feat:`、`fix:`、`refactor:`、`test:`、`docs:`、`chore:`
+- subject 行保持在 72 字符以内
+- 对非简单变更，在 body 解释“为什么”
 
-Examples:
+示例：
 ```
 feat: add --tap-host flag for custom bind address
 fix: handle malformed SSE events without crashing
@@ -70,20 +70,20 @@ docs: update engineering practices guide
 
 ## Pre-Work Checklist
 
-Before making any code change:
+进行任何代码变更之前：
 
-1. **Check repo state:**
+1. **检查仓库状态：**
    ```bash
    git diff --stat
    git log --oneline -10
    ```
-2. **Ensure clean working tree** or stash changes
-3. **Pull latest main:** `git fetch origin && git rebase origin/main`
-4. **Verify tests pass:** `uv run pytest tests/ -x --timeout=60`
+2. **确保工作树干净**，或先 stash 变更
+3. **拉取最新 main：** `git fetch origin && git rebase origin/main`
+4. **确认测试通过：** `uv run pytest tests/ -x --timeout=60`
 
-## Worktree Workflow for Features
+## Feature 的 Worktree 工作流
 
-Use git worktrees for isolated feature development:
+使用 git worktree 进行隔离的 feature 开发：
 
 ```bash
 # Create worktree for new feature
@@ -102,29 +102,29 @@ git worktree remove /tmp/claude-tap-my-feature
 git branch -d feat/my-feature
 ```
 
-Benefits:
-- Main worktree stays clean
-- Can switch between features without stashing
-- Natural isolation prevents cross-contamination
+收益：
+- 主 worktree 保持干净
+- 无需 stash 即可在多个 feature 间切换
+- 自然隔离可防止相互污染
 
-## Code Review Process
+## Code Review 流程
 
-Before committing:
+commit 前：
 
-1. **Lint:** `uv run ruff check .`
-2. **Format:** `uv run ruff format --check .`
-3. **Test:** `uv run pytest tests/ -x --timeout=60`
-4. **Review diff:** `git diff` — read every changed line
-5. **Verify scope:** Only changed files relevant to the task?
+1. **Lint：** `uv run ruff check .`
+2. **Format：** `uv run ruff format --check .`
+3. **Test：** `uv run pytest tests/ -x --timeout=60`
+4. **Review diff：** `git diff`，逐行阅读每个变更
+5. **验证范围：** 仅修改了与任务相关的文件吗？
 
-Before merging a PR:
+合并 PR 前：
 
-1. All CI checks pass
-2. No unresolved review comments
-3. Branch is rebased on latest `main`
-4. `uv.lock` is consistent
+1. 所有 CI 检查通过
+2. 无未解决 review 评论
+3. 分支已 rebase 到最新 `main`
+4. `uv.lock` 保持一致
 
-## Language
+## 语言
 
-All code, comments, commit messages, docs, and skill files must be in English.
-The only exceptions are `README_zh.md` and other explicitly Chinese README files.
+所有代码、注释、commit message、文档和 skill 文件必须使用英文。
+唯一例外是 `README_zh.md` 以及其他明确为中文的 README 文件。

--- a/docs/guides/new-client-integration-playbook.md
+++ b/docs/guides/new-client-integration-playbook.md
@@ -1,28 +1,23 @@
-# Playbook: Adding a New LLM Client to claude-tap
+# Playbook：为 claude-tap 添加新的 LLM Client
 
-Distilled from the Codex integration (PR #12, 2026-02-28). Use this as a repeatable
-framework for adding support for any new LLM client (e.g., Gemini CLI, Grok CLI, etc.).
+提炼自 Codex 集成（PR #12，2026-02-28）。将其作为可复用框架，用于为任意新的 LLM client（如 Gemini CLI、Grok CLI 等）添加支持。
 
 ---
 
-## Phase 1: Reconnaissance — Understand the Client's Wire Protocol
+## 第 1 阶段：侦察 - 理解 Client 的 Wire Protocol
 
-Before writing code, answer these questions:
+在写代码前，先回答以下问题：
 
-1. **What API endpoint does the client call?** (e.g., `api.openai.com/v1/responses`,
-   `api.anthropic.com/v1/messages`)
-2. **Does it have alternative endpoints?** (e.g., Codex uses `chatgpt.com/backend-api/codex`
-   for ChatGPT Plus users, NOT `api.openai.com`)
-3. **What transport does it use?** HTTP POST? WebSocket? gRPC?
-   - **Lesson from Codex**: Codex v0.106.0 silently switched from HTTP to WebSocket
-     for `/v1/responses`. The HTTP proxy saw nothing. Always verify the actual wire
-     transport, not what the docs say.
-4. **What env var controls the base URL?** (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, etc.)
-5. **Does the child process actually inherit that env var?** (Codex has a Rust subprocess
-   that may or may not respect the Node.js parent's env)
-6. **What encoding/compression does it use?** (Codex sends zstd-compressed bodies)
+1. **Client 调用的是哪个 API endpoint？**（例如 `api.openai.com/v1/responses`、
+   `api.anthropic.com/v1/messages`）
+2. **它是否有备用 endpoint？**（例如 Codex 对 ChatGPT Plus 用户使用 `chatgpt.com/backend-api/codex`，而不是 `api.openai.com`）
+3. **它使用什么传输方式？** HTTP POST？WebSocket？gRPC？
+   - **Codex 经验**：Codex v0.106.0 在无提示情况下把 `/v1/responses` 从 HTTP 切到 WebSocket。HTTP proxy 看不到任何内容。务必验证实际 wire transport，而不是只看文档。
+4. **哪个 env var 控制 base URL？**（`OPENAI_BASE_URL`、`ANTHROPIC_BASE_URL` 等）
+5. **子进程是否真的继承了该 env var？**（Codex 有 Rust 子进程，可能会或可能不会遵循 Node.js 父进程环境）
+6. **它使用何种编码/压缩？**（Codex 会发送 zstd 压缩体）
 
-### How to investigate
+### 如何调查
 
 ```bash
 # Watch actual network traffic
@@ -35,23 +30,22 @@ ps -p <pid> -E | tr ' ' '\n' | grep BASE_URL
 mitmproxy --mode reverse:https://api.example.com --listen-port 8080
 ```
 
-**Key principle**: Don't trust documentation. Observe actual behavior.
+**关键原则**：不要盲信文档。观察真实行为。
 
 ---
 
-## Phase 2: Proxy Wiring — Make Every Request Visible
+## 第 2 阶段：Proxy Wiring - 让每个请求都可见
 
 ### Checklist
 
-- [ ] Set the correct env var to redirect traffic to claude-tap's local proxy
-- [ ] Handle path mapping (client sends `/v1/responses`, upstream expects `/responses`)
-- [ ] Handle request body encoding (zstd, gzip, etc.)
-- [ ] Handle response streaming (SSE events, chunked transfer)
-- [ ] **Pin transport to HTTP if using reverse proxy** — disable WebSocket/gRPC features
-      that bypass the HTTP proxy
-- [ ] Verify with actual traffic (not just unit tests)
+- [ ] 设置正确的 env var，将流量重定向到 claude-tap 本地 proxy
+- [ ] 处理路径映射（client 发送 `/v1/responses`，upstream 期望 `/responses`）
+- [ ] 处理请求体编码（zstd、gzip 等）
+- [ ] 处理响应流（SSE events、chunked transfer）
+- [ ] **若使用 reverse proxy，将传输固定为 HTTP** - 禁用会绕过 HTTP proxy 的 WebSocket/gRPC 特性
+- [ ] 用真实流量验证（不仅是 unit tests）
 
-### Validation checkpoint
+### 验证检查点
 
 ```bash
 # Run the client through claude-tap
@@ -68,14 +62,13 @@ with open('.traces/trace_<latest>.jsonl') as f:
 "
 ```
 
-**If trace only shows 1 line (models/health check): the real API calls are bypassing
-your proxy.** Stop and investigate transport.
+**如果 trace 只有 1 行（models/health check），说明真实 API 调用绕过了你的 proxy。** 立即停止并排查传输路径。
 
 ---
 
-## Phase 3: Viewer Compatibility — Every API Format Is Different
+## 第 3 阶段：Viewer 兼容性 - 每种 API 格式都不同
 
-Each LLM provider has a different response format. Map these fields:
+每个 LLM provider 的响应格式都不同。需要映射这些字段：
 
 | Concept | Claude (Chat Completions) | OpenAI (Responses API) | Your Client |
 |---------|--------------------------|----------------------|-------------|
@@ -86,77 +79,77 @@ Each LLM provider has a different response format. Map these fields:
 | Response output | `response.body.content` | SSE `response.output_text.delta` | ? |
 | Tools | `body.tools[]` | `body.tools[]` | ? |
 
-### Viewer fix pattern
+### Viewer 修复模式
 
-1. Find every place the viewer reads Claude-specific fields
-2. Add a normalize function that maps the new format to a common structure
-3. Keep backward compatibility — old traces must still render correctly
+1. 找出 viewer 读取 Claude 特定字段的所有位置
+2. 新增 normalize 函数，把新格式映射到通用结构
+3. 保持向后兼容，旧 trace 仍要能正确渲染
 
-### Validation checkpoint
+### 验证检查点
 
-Open the HTML viewer with a real trace and verify:
-- [ ] System prompt displayed
-- [ ] Messages rendered with correct roles
-- [ ] Token counts non-zero
-- [ ] Diff between turns works
-- [ ] Response output shown
-
----
-
-## Phase 4: Recording — Evidence Is Part of the Deliverable
-
-Every new client integration needs:
-
-1. **Terminal recording**: Real E2E session showing the client running through claude-tap
-   - Tool: `asciinema rec` → `agg` (GIF) → `ffmpeg` (MP4)
-   - Must show: startup banner, at least 2-3 turns, tool calls if applicable
-
-2. **Viewer recording**: Playwright-automated walkthrough of the HTML viewer
-   - Tool: Playwright `record_video_dir` → `.webm` → `ffmpeg` (MP4)
-   - Must show: system prompt, messages, tokens, diff
-
-3. **Screenshots**: Static evidence for PR review
-   - At least: overview, messages, diff, token stats
-
-**Use real trace data, not mocks.** Reviewers can tell the difference.
-
-### PR screenshots gotcha
-
-Use absolute URLs in PR descriptions (`raw.githubusercontent.com/...`), not relative
-paths. GitHub PR bodies don't resolve relative image paths.
+用真实 trace 打开 HTML viewer 并验证：
+- [ ] System prompt 已显示
+- [ ] Messages 以正确 role 渲染
+- [ ] Token 计数非零
+- [ ] Turn 间 diff 可用
+- [ ] Response output 已显示
 
 ---
 
-## Phase 5: Defensive Design — What Will Break Next?
+## 第 4 阶段：录制 - 证据是交付物的一部分
 
-After the integration works, anticipate future breakage:
+每次新增 client 集成都需要：
 
-- **Client updates transport**: Pin transport explicitly, don't assume HTTP forever.
-  Document the workaround AND file a TODO for native support.
-- **Client changes API format**: Keep normalize functions isolated so they're easy to update.
-- **Client adds auth complexity**: Document required scopes/permissions in the plan doc.
+1. **终端录制**：展示 client 通过 claude-tap 运行的真实 E2E 会话
+   - 工具：`asciinema rec` → `agg`（GIF）→ `ffmpeg`（MP4）
+   - 必须展示：启动 banner、至少 2-3 轮对话、如适用的 tool calls
 
-### Always leave behind
+2. **Viewer 录制**：通过 Playwright 自动化演示 HTML viewer
+   - 工具：Playwright `record_video_dir` → `.webm` → `ffmpeg`（MP4）
+   - 必须展示：system prompt、messages、tokens、diff
 
-- [ ] Error experience doc if you hit non-obvious issues
-- [ ] TODO/plan doc for known limitations (e.g., WebSocket native support)
-- [ ] Tests that catch the specific failure mode you discovered
+3. **截图**：用于 PR review 的静态证据
+   - 至少包括：overview、messages、diff、token stats
 
----
+**使用真实 trace 数据，不要用 mock。** reviewer 一眼就能看出来。
 
-## Anti-Patterns (from Codex integration)
+### PR 截图陷阱
 
-| Anti-pattern | What happened | Lesson |
-|-------------|---------------|--------|
-| Trusting the obvious API endpoint | Assumed `api.openai.com`, actual was `chatgpt.com/backend-api/codex` | Always trace actual network calls |
-| Assuming HTTP transport | Codex uses WebSocket by default, proxy saw nothing | Verify wire transport, pin if needed |
-| Recording demos before fixing data | First recordings showed 0 tokens (403 errors in trace) | Fix data pipeline first, record last |
-| Using old trace data for screenshots | Screenshots showed errors from pre-fix traces | Always re-record after fixes |
-| Relative image paths in PR body | All images broken on GitHub | Use `raw.githubusercontent.com` absolute URLs |
+PR 描述中使用绝对 URL（`raw.githubusercontent.com/...`），不要用相对路径。
+GitHub PR 正文不会解析相对图片路径。
 
 ---
 
-## Template: New Client Checklist
+## 第 5 阶段：防御式设计 - 下一次会坏在哪里？
+
+集成跑通后，提前预判未来的破坏点：
+
+- **Client 更新传输方式**：显式固定传输，不要假设永远是 HTTP。
+  记录 workaround，并为原生支持创建 TODO。
+- **Client 修改 API 格式**：将 normalize 函数隔离，便于后续更新。
+- **Client 新增 auth 复杂性**：在 plan 文档记录所需 scopes/permissions。
+
+### 始终留下这些资产
+
+- [ ] 遇到非显而易见问题时，写 error experience 文档
+- [ ] 已知限制写 TODO/plan 文档（例如 WebSocket 原生支持）
+- [ ] 补能覆盖你发现的特定失败模式的测试
+
+---
+
+## 反模式（来自 Codex 集成）
+
+| Anti-pattern | 发生了什么 | 经验 |
+|-------------|-----------|------|
+| 相信“看起来明显”的 API endpoint | 以为是 `api.openai.com`，实际是 `chatgpt.com/backend-api/codex` | 必须追踪真实网络调用 |
+| 假设传输一定是 HTTP | Codex 默认使用 WebSocket，proxy 什么都看不到 | 验证 wire transport，必要时固定 |
+| 在数据修复前录制演示 | 首版录制中 token 为 0（trace 中有 403 错误） | 先修数据链路，最后再录制 |
+| 截图使用旧 trace 数据 | 截图仍显示修复前 trace 的错误 | 修复后必须重新录制 |
+| PR 正文使用相对图片路径 | GitHub 上所有图片都坏掉 | 使用 `raw.githubusercontent.com` 绝对 URL |
+
+---
+
+## 模板：新 Client Checklist
 
 ```markdown
 ## Adding support for: <CLIENT_NAME>

--- a/docs/guides/viewer-ux-rationale.md
+++ b/docs/guides/viewer-ux-rationale.md
@@ -1,42 +1,42 @@
-# Viewer UX Rationale
+# Viewer UX 设计依据
 
-This guide captures stable design decisions that were previously tracked in one-off implementation specs.
+本指南记录了稳定的设计决策，这些决策此前分散在一次性的实现规格中。
 
-## Navigation Order
+## 导航顺序
 
-Keyboard and touch navigation must follow the same visual order shown in the sidebar.
+键盘与触控导航必须遵循侧边栏展示的同一视觉顺序。
 
-- Sidebar grouping and sorting define the user's expected navigation order.
-- `j/k` and arrow-key navigation should move through visible items in DOM order.
-- Mobile previous/next controls should use the same order as desktop keyboard navigation.
+- 侧边栏的分组与排序定义了用户预期的导航顺序。
+- `j/k` 与方向键导航应按 DOM 顺序在可见项间移动。
+- 移动端上一条/下一条控件应与桌面键盘导航保持相同顺序。
 
-## Mobile-First Constraints
+## Mobile-First 约束
 
-The viewer must remain usable on narrow screens without horizontal overflow.
+viewer 在窄屏下必须保持可用，且不能出现水平溢出。
 
-- Mobile layout should prioritize one primary pane at a time.
-- Detail view actions need touch-friendly controls and clear boundaries.
-- Diff and content-heavy views should switch to stacked layouts on mobile.
+- 移动端布局应优先一次只显示一个主 pane。
+- detail view 的操作区需要触控友好的控件和清晰边界。
+- diff 与内容密集视图在移动端应切换为堆叠布局。
 
-## Diff Matching Semantics
+## Diff 匹配语义
 
-Diff quality depends on comparing related turns.
+diff 质量取决于是否比较了相关 turn。
 
-- Prefer history-aware matching (shared message prefix or equivalent thread signal).
-- If fallback matching is approximate, show an explicit warning in the UI.
-- Allow manual target selection so users can override automatic matching.
+- 优先使用带历史感知的匹配（共享消息前缀或等价线程信号）。
+- 如果 fallback 匹配是近似的，应在 UI 中明确给出警告。
+- 允许手动选择目标，使用户可以覆盖自动匹配结果。
 
-## Internationalization
+## 国际化
 
-New user-visible UI text must be localized consistently.
+新增面向用户的 UI 文案必须保持一致的本地化策略。
 
-- Route all strings through the translation layer.
-- Keep language packs complete when adding new keys.
+- 所有字符串都要经过翻译层。
+- 增加新 key 时保持 language pack 完整。
 
-## Testing and Scope Discipline
+## 测试与范围纪律
 
-Viewer UX work should remain focused and verifiable.
+viewer UX 相关工作应保持聚焦且可验证。
 
-- Prefer constrained changes in `claude_tap/viewer.html` when possible.
-- Keep desktop behavior stable while improving mobile UX.
-- Validate behavior through tests and manual trace-viewer verification.
+- 可行时优先在 `claude_tap/viewer.html` 中做受限改动。
+- 在改进移动端 UX 的同时保持桌面行为稳定。
+- 通过测试与手动 trace-viewer 验证来确认行为。

--- a/docs/plans/2026-02-27-codex-support-handoff.md
+++ b/docs/plans/2026-02-27-codex-support-handoff.md
@@ -2,197 +2,197 @@
 status: completed
 ---
 
-# Codex Support Handoff (Detailed)
+# Codex 支持交接（详细）
 
-Date: 2026-02-27
-Branch: `feat/codex-client-support`
-Repository: `liaohch3/claude-tap`
+日期：2026-02-27
+分支：`feat/codex-client-support`
+仓库：`liaohch3/claude-tap`
 
-## 1. Goal, Scope, and Current Status
+## 1. 目标、范围与当前状态
 
-### Original Goal
+### 原始目标
 
-Add support for Codex in addition to Claude, while preserving existing Claude behavior.
+在保留现有 Claude 行为的同时，新增对 Codex 的支持。
 
-### Acceptance Constraint From User
+### 来自用户的验收约束
 
-Real Codex validation must be successful end-to-end. Any `403` is considered a hard failure.
+真实 Codex 验证必须端到端成功。任何 `403` 都视为硬失败。
 
-### Current Status
+### 当前状态
 
-- Core implementation for `--tap-client codex` is completed.
-- Mock/unit/integration tests are passing locally.
-- Real Codex run is still blocked by account/API permissions (`Missing scopes: api.model.read`) and upstream behavior in this environment.
-- Work is committed on branch `feat/codex-client-support`.
+- `--tap-client codex` 的核心实现已完成。
+- mock/unit/integration 测试在本地通过。
+- 真实 Codex 运行仍受账号/API 权限（`Missing scopes: api.model.read`）和当前环境中的上游行为阻塞。
+- 工作已提交到分支 `feat/codex-client-support`。
 
-## 2. What Was Done (and Why)
+## 2. 已完成内容（以及原因）
 
-### A. CLI and Runtime Behavior
+### A. CLI 与运行时行为
 
-#### File: `claude_tap/cli.py`
+#### 文件：`claude_tap/cli.py`
 
-Changes made:
+已做变更：
 
-- Added client selection support:
-  - New flag `--tap-client` with values `claude|codex`, default `claude`.
-- Extended launch path so we can run either `claude` or `codex`.
-- Reverse proxy env injection is now client-specific:
-  - Claude: `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`
-  - Codex: `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`
-- `--tap-target` default is now derived from client when omitted:
+- 增加 client 选择支持：
+  - 新增参数 `--tap-client`，取值 `claude|codex`，默认 `claude`。
+- 扩展启动路径，使其可运行 `claude` 或 `codex`。
+- 反向 proxy 环境注入改为按 client 区分：
+  - Claude：`ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`
+  - Codex：`OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`
+- 省略 `--tap-target` 时，默认值按 client 推导：
   - Claude -> `https://api.anthropic.com`
   - Codex -> `https://api.openai.com`
-- Updated user-facing startup/shutdown messages to reflect selected client.
-- Preserved existing Claude forward-mode behavior, including `--settings` injection path only for Claude.
+- 更新面向用户的启动/停止消息，使其反映所选 client。
+- 保留现有 Claude forward-mode 行为，包括仅对 Claude 的 `--settings` 注入路径。
 
-Reason:
+原因：
 
-- Existing implementation was Claude-only and hardcoded around Anthropic variables.
-- Codex requires OpenAI-style base URL behavior in reverse mode.
-- Keeping default `claude` preserves backward compatibility.
+- 现有实现仅支持 Claude，且围绕 Anthropic 变量硬编码。
+- Codex 在 reverse mode 下需要 OpenAI 风格的 base URL 行为。
+- 默认保持 `claude` 可确保向后兼容。
 
-### B. Trace Model Enhancement for Viewer
+### B. 面向 Viewer 的 Trace 模型增强
 
-#### File: `claude_tap/proxy.py`
+#### 文件：`claude_tap/proxy.py`
 
-Changes made:
+已做变更：
 
-- Added `upstream_base_url` into each trace record via `_build_record(...)`.
-- Threaded `upstream_base_url` through streaming and non-streaming handlers.
-- Simplified upstream encoding behavior by forcing `Accept-Encoding: identity` to avoid zstd-related client incompatibilities in this environment.
+- 通过 `_build_record(...)` 在每条 trace record 中新增 `upstream_base_url`。
+- 在 streaming 与 non-streaming handler 中贯穿传递 `upstream_base_url`。
+- 通过强制 `Accept-Encoding: identity` 简化上游编码行为，避免当前环境中的 zstd 兼容问题。
 
-Reason:
+原因：
 
-- Viewer copy-curl was hardcoded to Anthropic domain; needed source-specific upstream reconstruction.
-- Codex and some responses exhibited zstd decode failures in environment; identity encoding reduces this proxy-side compatibility risk.
+- viewer copy-curl 原先硬编码 Anthropic 域名；需要按来源重建上游地址。
+- Codex 与部分响应在该环境中出现 zstd 解码失败；使用 identity 编码可降低 proxy 侧兼容风险。
 
-### C. Forward Proxy Consistency
+### C. Forward Proxy 一致性
 
-#### File: `claude_tap/forward_proxy.py`
+#### 文件：`claude_tap/forward_proxy.py`
 
-Changes made:
+已做变更：
 
-- Also force `Accept-Encoding: identity` when forwarding upstream requests.
+- 在转发上游请求时同样强制 `Accept-Encoding: identity`。
 
-Reason:
+原因：
 
-- Keep behavior consistent with reverse proxy path and reduce compression-related failures.
+- 与 reverse proxy 路径保持一致，减少压缩相关失败。
 
-### D. Viewer Behavior
+### D. Viewer 行为
 
-#### File: `claude_tap/viewer.html`
+#### 文件：`claude_tap/viewer.html`
 
-Changes made:
+已做变更：
 
-- `copyCurl(...)` now uses `entry.upstream_base_url` when available.
-- Falls back to `https://api.anthropic.com` for legacy traces.
+- `copyCurl(...)` 在可用时使用 `entry.upstream_base_url`。
+- 对旧 trace 回退到 `https://api.anthropic.com`。
 
-Reason:
+原因：
 
-- Makes generated curl command accurate for Codex/OpenAI traces.
-- Maintains backward compatibility for existing old trace files.
+- 使生成的 curl 命令对 Codex/OpenAI trace 也准确。
+- 保持对现有旧 trace 文件的向后兼容。
 
-### E. Test Coverage Updates
+### E. 测试覆盖更新
 
-#### File: `tests/test_e2e.py`
+#### 文件：`tests/test_e2e.py`
 
-Changes made:
+已做变更：
 
-- Extended `_run_claude_tap(...)` helper with `tap_client` argument.
-- `test_parse_args` now validates Codex defaults:
+- 为 `_run_claude_tap(...)` helper 增加 `tap_client` 参数。
+- `test_parse_args` 现在验证 Codex 默认值：
   - `--tap-client codex`
-  - default target -> `https://api.openai.com`
-- Added `test_codex_client_reverse_proxy` with fake `codex` executable:
-  - fake codex uses `OPENAI_BASE_URL`
-  - fake upstream expects `/v1/messages`
-  - asserts trace contains expected path/model
-  - asserts `upstream_base_url` is recorded
-  - asserts startup output includes `OPENAI_BASE_URL=...`
+  - 默认 target -> `https://api.openai.com`
+- 新增 `test_codex_client_reverse_proxy`，使用 fake `codex` 可执行文件：
+  - fake codex 使用 `OPENAI_BASE_URL`
+  - fake upstream 期望路径 `/v1/messages`
+  - 断言 trace 包含预期 path/model
+  - 断言已记录 `upstream_base_url`
+  - 断言启动输出包含 `OPENAI_BASE_URL=...`
 
-Reason:
+原因：
 
-- Validate new client behavior without depending on real external credentials.
-- Ensure no regressions in argument parsing and runtime wiring.
+- 在不依赖真实外部凭据的前提下验证新 client 行为。
+- 确保参数解析与运行时连接路径不回归。
 
-### F. Planning Docs
+### F. 计划文档
 
-#### File: `docs/plans/2026-02-27-codex-support-plan.md`
+#### 文件：`docs/plans/2026-02-27-codex-support-plan.md`
 
-Changes made:
+已做变更：
 
-- Added a scoped implementation plan and explicit acceptance/risk notes.
+- 新增聚焦范围的实现计划与明确的验收/风险说明。
 
-Reason:
+原因：
 
-- Follow repository guidance for plan documentation and clear handoff context.
+- 遵循仓库关于计划文档与清晰交接上下文的规范。
 
-## 3. What Was Not Done (or Not Fully Done)
+## 3. 尚未完成（或未完全完成）内容
 
-### A. Real Codex E2E Success
+### A. 真实 Codex E2E 成功
 
-Not achieved yet due environment/account limitations.
+由于环境/账号限制，尚未达成。
 
-Observed blocker:
+观察到的阻塞：
 
-- Codex model refresh request failed:
+- Codex 模型刷新请求失败：
   - `GET /v1/models?client_version=...`
   - `403 Forbidden`
-  - message includes `Missing scopes: api.model.read`
+  - 消息包含 `Missing scopes: api.model.read`
 
-Implication:
+影响：
 
-- Per user requirement, this means real validation is not complete.
+- 按用户要求，这意味着真实验证尚未完成。
 
-### B. Dedicated `tests/e2e/` Real Codex Suite
+### B. 专用 `tests/e2e/` 真实 Codex 测试套件
 
-Not added yet.
+尚未添加。
 
-Reason:
+原因：
 
-- Given hard requirement that real run must succeed, adding real tests now would produce consistent failures in this environment until permissions are fixed.
+- 由于硬性要求是真实运行必须成功，在权限未修复前新增真实测试将稳定失败。
 
-### C. README / README_zh User-Facing Docs
+### C. README / README_zh 面向用户文档
 
-Not updated in this round.
+本轮未更新。
 
-Reason:
+原因：
 
-- Priority was code path and correctness first.
-- Follow-up should document new `--tap-client` behavior and examples.
+- 优先级先放在代码路径与正确性。
+- 后续应补充 `--tap-client` 新行为与示例。
 
-## 4. Exact Test Execution and Results
+## 4. 精确测试执行与结果
 
-The following were run locally and passed:
+以下命令已在本地运行并通过：
 
 - `uv run ruff check .`
 - `uv run ruff format --check .`
 - `uv run pytest tests/ -x --timeout=60`
-  - Result: `48 passed, 18 skipped`
+  - 结果：`48 passed, 18 skipped`
 
-Additional targeted tests run:
+额外执行的定向测试：
 
 - `uv run pytest tests/test_e2e.py -k "test_parse_args or test_codex_client_reverse_proxy" -x --timeout=120`
-  - Passed
+  - 通过
 - `uv run pytest tests/test_e2e.py -k "test_e2e or test_forward_proxy_connect or test_codex_client_reverse_proxy" -x --timeout=120`
-  - Passed
+  - 通过
 
-Real Codex smoke run attempted and failed (as expected in this env):
+尝试真实 Codex smoke 运行并失败（该环境预期如此）：
 
-- Command pattern:
+- 命令模式：
   - `uv run python -m claude_tap --tap-client codex --tap-target https://api.openai.com --tap-no-update-check --tap-no-open -- exec "Reply with exactly: CODEX_REAL_OK" --skip-git-repo-check --json`
-- Failure indicators:
-  - `403 Forbidden` with missing `api.model.read`
-  - Codex exits non-zero
+- 失败指标：
+  - `403 Forbidden`，缺少 `api.model.read`
+  - Codex 非零退出
 
-## 5. Working Tree Hygiene / Commit Scope
+## 5. 工作树卫生 / Commit 范围
 
-Important context:
+重要上下文：
 
-- There was a pre-existing `uv.lock` modification before this work.
-- `log/` contains runtime artifacts and is untracked.
-- These were intentionally excluded from commit scope.
+- 本次工作前已存在 `uv.lock` 修改。
+- `log/` 含运行产物，处于未跟踪状态。
+- 以上已被有意排除在 commit 范围外。
 
-Files intended for this task commit:
+本任务 commit 计划包含的文件：
 
 - `claude_tap/cli.py`
 - `claude_tap/proxy.py`
@@ -200,44 +200,44 @@ Files intended for this task commit:
 - `claude_tap/viewer.html`
 - `tests/test_e2e.py`
 - `docs/plans/2026-02-27-codex-support-plan.md`
-- `docs/plans/2026-02-27-codex-support-handoff.md` (this file)
+- `docs/plans/2026-02-27-codex-support-handoff.md`（本文件）
 
-## 6. Recommended Next Actions for the Next Codex Process
+## 6. 给下一轮 Codex 流程的建议动作
 
-### 1) Resolve Real Credential/Scope Blocker First
+### 1) 先解决真实凭据/Scope 阻塞
 
-- Ensure API key/project/org has `api.model.read` (and required response scopes).
-- Re-run real Codex smoke command to confirm non-403.
+- 确保 API key/project/org 拥有 `api.model.read`（以及所需响应 scope）。
+- 重新运行真实 Codex smoke 命令，确认不再返回 403。
 
-### 2) Add Real Codex E2E Coverage
+### 2) 添加真实 Codex E2E 覆盖
 
-Suggested additions:
+建议新增：
 
-- New test module under `tests/e2e/` for Codex real runs.
-- Cover at least:
-  - single turn success
-  - multi-turn continuity
-  - trace generation and path assertions
-- Keep `403/401` as hard fail per user rule.
+- 在 `tests/e2e/` 下新增 Codex 真实运行模块。
+- 至少覆盖：
+  - 单轮成功
+  - 多轮连续性
+  - trace 生成与路径断言
+- 按用户规则，`403/401` 保持硬失败。
 
-### 3) Update User Docs
+### 3) 更新用户文档
 
-- Update `README.md` and optionally `README_zh.md` with:
+- 更新 `README.md`，必要时更新 `README_zh.md`，补充：
   - `--tap-client codex`
-  - reverse mode example for Codex
-  - known prerequisite: proper OpenAI scopes
+  - Codex reverse mode 示例
+  - 已知前置条件：正确的 OpenAI scopes
 
-### 4) Optional: Investigate zstd error path deeper
+### 4) 可选：深入排查 zstd 错误路径
 
-- Even after identity preference from proxy to upstream, Codex may still log zstd decode issues in failure scenarios.
-- Verify whether this is tied to non-proxied traffic, fallback channels, or specific Codex internal endpoints.
+- 即使 proxy 到 upstream 已偏好 identity，Codex 在失败场景仍可能记录 zstd 解码问题。
+- 需要确认是否与非代理流量、fallback 通道或 Codex 特定内部 endpoint 有关。
 
-## 7. Quick Technical Summary for Next Agent Prompt
+## 7. 下一位 Agent Prompt 的快速技术摘要
 
-If you need an abbreviated bootstrap prompt for another Codex process:
+如果你需要给另一个 Codex 流程一个简短启动提示：
 
-- Branch: `feat/codex-client-support`
-- Core feature done: `--tap-client codex` + OpenAI reverse mode env wiring.
-- Tests pass locally (`48 passed, 18 skipped`) for `tests/`.
-- Real Codex still blocked by `403 missing scopes: api.model.read`.
-- Continue by fixing credentials/scopes and adding real Codex E2E tests + README updates.
+- 分支：`feat/codex-client-support`
+- 核心功能已完成：`--tap-client codex` + OpenAI reverse mode 环境注入。
+- `tests/` 本地通过（`48 passed, 18 skipped`）。
+- 真实 Codex 仍被 `403 missing scopes: api.model.read` 阻塞。
+- 后续先修凭据/scopes，再补真实 Codex E2E 测试与 README 更新。

--- a/docs/plans/2026-02-27-codex-support-plan.md
+++ b/docs/plans/2026-02-27-codex-support-plan.md
@@ -2,57 +2,57 @@
 status: completed
 ---
 
-# Codex Support Plan
+# Codex 支持计划
 
-Date: 2026-02-27
+日期：2026-02-27
 
-## Goal
+## 目标
 
-Add first-class Codex support to `claude-tap` while keeping Claude behavior fully backward compatible.
+为 `claude-tap` 增加一等公民级的 Codex 支持，同时保持 Claude 行为完全向后兼容。
 
-## Scope
+## 范围
 
-- Add client selection: `--tap-client {claude,codex}`.
-- Keep default client as `claude`.
-- For `codex` in reverse proxy mode, inject `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`.
-- Keep existing Claude behavior: `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`.
-- Set default upstream target by client when `--tap-target` is omitted:
+- 增加 client 选择：`--tap-client {claude,codex}`。
+- 默认 client 保持为 `claude`。
+- 对 reverse proxy mode 的 `codex` 注入 `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`。
+- 保持现有 Claude 行为：`ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`。
+- 当省略 `--tap-target` 时，按 client 设置默认 upstream target：
   - `claude` -> `https://api.anthropic.com`
   - `codex` -> `https://api.openai.com`
-- Preserve existing forward proxy behavior.
-- Add trace metadata `upstream_base_url` to improve viewer cURL reconstruction.
+- 保留现有 forward proxy 行为。
+- 增加 trace metadata `upstream_base_url`，提升 viewer cURL 重建能力。
 
-## Non-Goals
+## 非目标
 
-- Rename package/project branding (`claude-tap`) in this change.
-- Add broad provider abstractions beyond Claude/Codex.
-- Guarantee Codex ChatGPT login flow under forward proxy mode.
+- 在本次变更中重命名 package/project 品牌（`claude-tap`）。
+- 在 Claude/Codex 之外增加广泛 provider 抽象。
+- 保证 Codex ChatGPT 登录流在 forward proxy mode 下可用。
 
-## Test Strategy
+## 测试策略
 
-- Unit / mock E2E regression:
+- Unit / mock E2E 回归：
   - `uv run pytest tests/test_e2e.py -x --timeout=120`
-- New Codex mock E2E:
+- 新增 Codex mock E2E：
   - fake `codex` binary + fake upstream API
-  - assert reverse-mode request path and `upstream_base_url` trace field
-- Repo gate checks:
+  - 断言 reverse-mode 请求路径与 `upstream_base_url` trace 字段
+- 仓库 gate 检查：
   - `uv run ruff check .`
   - `uv run ruff format --check .`
   - `uv run pytest tests/ -x --timeout=60`
 
-## Success Criteria
+## 成功标准
 
-- Claude default workflow unchanged.
-- `--tap-client codex` launches `codex` and writes valid trace output.
-- Viewer copy-cURL uses `upstream_base_url` if present.
-- No regressions in existing test suite.
+- Claude 默认工作流不变。
+- `--tap-client codex` 可启动 `codex` 并写出有效 trace 输出。
+- viewer copy-cURL 在存在时使用 `upstream_base_url`。
+- 现有测试套件无回归。
 
-## Real E2E Acceptance Rule
+## 真实 E2E 验收规则
 
-For Codex real E2E validation, HTTP `403/401` is treated as a hard failure.
-A run is considered successful only when the end-to-end request completes with successful upstream responses.
+对 Codex 真实 E2E 验证，HTTP `403/401` 视为硬失败。
+仅当端到端请求以上游成功响应完成时，才视为运行成功。
 
-## Risks
+## 风险
 
-- Codex account scopes may block model-list or response APIs (`403`) even if proxy wiring is correct.
-- Codex ChatGPT-web route traffic may not be fully covered by current forward mode assumptions.
+- 即便 proxy 连接正确，Codex 账号 scopes 也可能阻塞 model-list 或 response API（`403`）。
+- Codex ChatGPT-web 路由流量可能无法被当前 forward mode 假设完整覆盖。

--- a/docs/plans/2026-02-27-viewer-sticky-e2e-workflow.md
+++ b/docs/plans/2026-02-27-viewer-sticky-e2e-workflow.md
@@ -2,50 +2,50 @@
 status: completed
 ---
 
-# Viewer Sticky Action Bar + Validation Workflow Plan
+# Viewer Sticky Action Bar + 验证工作流计划
 
-## Problem
+## 问题
 
-The action button row in `claude_tap/viewer.html` disappeared when users scrolled down in the detail pane.
-This reduced operational efficiency for repeated actions (`Request JSON`, `cURL`, `Diff with Prev`).
+`claude_tap/viewer.html` 中 detail pane 的操作按钮行在用户向下滚动时会消失。
+这会降低重复操作（`Request JSON`、`cURL`、`Diff with Prev`）的效率。
 
-## Scope
+## 范围
 
-- Keep action bar visible while scrolling detail content.
-- Update repository workflow guidance so future PRs include:
-  - real E2E validation expectations
-  - UI screenshot requirements for UI-affecting changes
-- Produce review evidence (test outputs + screenshots).
+- 在滚动 detail 内容时保持 action bar 可见。
+- 更新仓库工作流指引，确保未来 PR 包含：
+  - 真实 E2E 验证期望
+  - 对影响 UI 变更的截图要求
+- 产出 review 证据（测试输出 + 截图）。
 
-## Execution Order
+## 执行顺序
 
-1. Define target behavior and scope.
-2. Implement minimal UI change.
-3. Run focused tests for impacted behavior.
-4. Run E2E/browser validation and collect screenshots.
-5. Run full project quality gates.
-6. Prepare PR with evidence.
-7. Record lessons learned.
+1. 定义目标行为与范围。
+2. 实施最小化 UI 变更。
+3. 运行受影响行为的定向测试。
+4. 运行 E2E/browser 验证并收集截图。
+5. 运行完整项目质量 gate。
+6. 准备包含证据的 PR。
+7. 记录经验教训。
 
-## Change Summary
+## 变更摘要
 
 - `claude_tap/viewer.html`
-  - make `.action-bar` sticky in the detail scroll container.
+  - 让 `.action-bar` 在 detail 滚动容器中保持 sticky。
 - `AGENTS.md`
-  - add `E2E Validation Requirements` section.
-  - add `PR Requirements for UI Changes` section.
+  - 新增 `E2E Validation Requirements` 章节。
+  - 新增 `PR Requirements for UI Changes` 章节。
 
-## Validation
+## 验证
 
-- Unit/integration tests: `uv run pytest tests/ -x --timeout=60`
-- Lint/format checks:
+- Unit/integration 测试：`uv run pytest tests/ -x --timeout=60`
+- Lint/format 检查：
   - `uv run ruff check .`
   - `uv run ruff format --check .`
-- UI evidence:
-  - top-state screenshot
-  - scrolled-state screenshot confirming sticky action bar remains visible
+- UI 证据：
+  - 顶部状态截图
+  - 滚动状态截图，确认 sticky action bar 仍可见
 
-## Out of Scope
+## 范围外
 
-- Feature redesign in viewer layout.
-- Non-related dependency updates.
+- Viewer 布局的功能重设计。
+- 非相关依赖更新。

--- a/docs/plans/2026-02-28-codex-websocket-support.md
+++ b/docs/plans/2026-02-28-codex-websocket-support.md
@@ -2,58 +2,58 @@
 status: active
 ---
 
-# TODO: Support Codex WebSocket transport for /v1/responses
+# TODO：支持 /v1/responses 的 Codex WebSocket 传输
 
-**Date:** 2026-02-28
-**Priority:** Medium
-**Status:** Planned
+**日期：** 2026-02-28
+**优先级：** 中
+**状态：** 计划中
 
-## Context
+## 背景
 
-Codex CLI v0.106.0+ defaults to WebSocket transport for `/v1/responses` API calls
-(`responses_websockets` and `responses_websockets_v2` features). Currently claude-tap
-works around this by auto-injecting `--disable responses_websockets` to force HTTP,
-which allows the existing HTTP reverse proxy to capture all requests.
+Codex CLI v0.106.0+ 默认对 `/v1/responses` API 调用使用 WebSocket 传输
+（`responses_websockets` 和 `responses_websockets_v2` 特性）。当前 claude-tap
+通过自动注入 `--disable responses_websockets` 的方式绕过该行为并强制使用 HTTP，
+从而使现有 HTTP reverse proxy 能捕获全部请求。
 
-This is a functional workaround but not ideal — WebSocket transport is likely faster
-and will become the default/only path in future Codex versions.
+这个方案可用，但不理想。WebSocket 传输可能更快，且未来 Codex 版本很可能会
+成为默认/唯一路径。
 
-## Goal
+## 目标
 
-Natively support WebSocket interception in claude-tap's reverse proxy mode, so Codex
-can use its default WebSocket transport while claude-tap still captures all API calls.
+在 claude-tap 的 reverse proxy mode 中原生支持 WebSocket 拦截，使 Codex
+可使用默认 WebSocket 传输，同时 claude-tap 仍能捕获全部 API 调用。
 
-## Approach Options
+## 方案选项
 
-### Option A: WebSocket MITM proxy
-- Intercept WebSocket upgrade requests to `/v1/responses`
-- Proxy the WebSocket connection, recording all frames
-- Reassemble frames into the same trace format (request body + SSE-equivalent events)
-- Pros: Transparent to Codex, no CLI flag injection needed
-- Cons: More complex, need to handle WS frame reassembly
+### 方案 A：WebSocket MITM proxy
+- 拦截到 `/v1/responses` 的 WebSocket upgrade 请求
+- 代理 WebSocket 连接并记录全部 frame
+- 将 frame 重组为相同 trace 格式（请求体 + SSE 等价事件）
+- 优点：对 Codex 透明，无需注入 CLI flag
+- 缺点：实现更复杂，需要处理 WS frame 重组
 
-### Option B: Forward proxy with CONNECT tunneling
-- Use forward proxy mode (HTTP_PROXY/HTTPS_PROXY) with TLS interception
-- Intercept both HTTP and WebSocket traffic at the TLS layer
-- Pros: Works for all transport types
-- Cons: Requires TLS cert injection, more moving parts
+### 方案 B：带 CONNECT 隧道的 forward proxy
+- 使用 forward proxy mode（HTTP_PROXY/HTTPS_PROXY）并做 TLS 拦截
+- 在 TLS 层同时拦截 HTTP 与 WebSocket 流量
+- 优点：适用于所有传输类型
+- 缺点：需要注入 TLS 证书，系统组成更复杂
 
-### Option C: Hybrid — detect and adapt
-- Detect if Codex is using WebSocket (check for Upgrade headers)
-- If WebSocket: proxy the WS connection and record frames
-- If HTTP: use existing streaming proxy path
-- Pros: Backward compatible, works with any Codex version
-- Cons: Two code paths to maintain
+### 方案 C：混合方案（检测并自适应）
+- 检测 Codex 是否使用 WebSocket（检查 Upgrade headers）
+- 若是 WebSocket：代理 WS 连接并记录 frame
+- 若是 HTTP：使用现有 streaming proxy 路径
+- 优点：向后兼容，可覆盖任意 Codex 版本
+- 缺点：需要维护两条代码路径
 
-## Implementation Notes
+## 实现说明
 
-- WebSocket frames for Responses API likely follow the same SSE-like event structure
-- Need to investigate the exact WebSocket message format Codex uses
-- `aiohttp` (already a dependency) supports WebSocket proxying
-- The `--disable` flag workaround should remain as a fallback option
+- Responses API 的 WebSocket frame 很可能遵循类似 SSE 的事件结构
+- 需要进一步确认 Codex 使用的具体 WebSocket 消息格式
+- `aiohttp`（已是依赖）支持 WebSocket proxying
+- `--disable` flag 绕过方案应保留为 fallback 选项
 
-## References
+## 参考
 
-- Fix commit: `a0e00e2` (disable websocket transport in reverse mode)
-- Error experience: `docs/error-experience/entries/2026-02-28-codex-reverse-websocket-capture-gap.md`
-- Codex CLI flags: `--enable/--disable responses_websockets[_v2]`
+- 修复 commit：`a0e00e2`（在 reverse mode 下禁用 websocket 传输）
+- 错误经验：`docs/error-experience/entries/2026-02-28-codex-reverse-websocket-capture-gap.md`
+- Codex CLI flags：`--enable/--disable responses_websockets[_v2]`

--- a/docs/standards/README.md
+++ b/docs/standards/README.md
@@ -4,17 +4,17 @@ last_reviewed: 2026-03-03
 source_of_truth: AGENTS.md
 ---
 
-# Standards Metadata
+# 标准元数据
 
-All files in `docs/standards/*.md` must include frontmatter with:
+`docs/standards/*.md` 下所有文件都必须包含 frontmatter，字段包括：
 
-- `owner`: team or maintainer responsible for updates.
-- `last_reviewed`: ISO date `YYYY-MM-DD` of the last policy review.
-- `source_of_truth`: canonical policy source reference.
+- `owner`：负责更新的团队或维护者。
+- `last_reviewed`：最近一次策略审查的 ISO 日期 `YYYY-MM-DD`。
+- `source_of_truth`：规范策略来源引用。
 
-# Maintenance Workflow
+# 维护工作流
 
-1. Update the affected standards file and refresh `last_reviewed`.
-2. Keep `AGENTS.md` as a concise index that links to the updated file.
-3. Run `python scripts/check_legibility.py` locally.
-4. If policy behavior changed, record rationale in PR description.
+1. 更新受影响的标准文件，并刷新 `last_reviewed`。
+2. 保持 `AGENTS.md` 为简洁索引，并链接到更新后的文件。
+3. 本地运行 `python scripts/check_legibility.py`。
+4. 若策略行为发生变化，在 PR 描述中记录理由。

--- a/docs/standards/coding-and-runtime.md
+++ b/docs/standards/coding-and-runtime.md
@@ -4,32 +4,32 @@ last_reviewed: 2026-03-03
 source_of_truth: AGENTS.md
 ---
 
-# Coding Standards
+# 编码标准
 
-## Do
+## 应做
 
-- Delete dead code.
-- Fix root cause of test failures.
-- Use existing patterns and keep scope limited to relevant files.
-- Trust type invariants and avoid redundant runtime checks for typed values.
-- Keep functions focused on one purpose.
-- Prefer POSIX shell tools in scripts.
-- Use `grep -F` for fixed-string matches in scripts.
-- Read package version from metadata, not hardcoded strings.
+- 删除无用代码。
+- 修复测试失败的根因。
+- 使用现有模式，并将范围限制在相关文件。
+- 信任类型不变量，避免对已类型化值进行冗余运行时检查。
+- 保持函数聚焦单一职责。
+- 在脚本中优先使用 POSIX shell 工具。
+- 在脚本中使用 `grep -F` 做固定字符串匹配。
+- 从 metadata 读取 package version，而不是硬编码字符串。
 
-## Do Not
+## 禁止
 
-- Leave commented-out code.
-- Add speculative abstractions.
-- Suppress linter warnings without justification.
-- Commit generated files.
-- Mix refactoring with feature work.
-- Add compatibility shims for unused code.
-- Depend on non-portable tools without checks (`rg`, `jq`, `fd` may be missing).
+- 保留注释掉的代码。
+- 添加猜测性的抽象。
+- 无理由抑制 linter 警告。
+- 提交生成文件。
+- 将 refactor 与 feature 工作混在一起。
+- 为未使用代码添加兼容性 shim。
+- 在未做检查时依赖不可移植工具（`rg`、`jq`、`fd` 可能不存在）。
 
-# Runtime Safety Rules
+# 运行时安全规则
 
-- If using `tcsetpgrp` foreground handoff, handle `SIGTTOU` when reclaiming parent foreground process group.
-- Treat highest CI Python version (currently 3.13) as the compatibility ceiling for runtime-sensitive behavior.
-- Certificate generation for TLS tests/runtime must include SKI/AKI extensions for Python 3.13 compatibility.
-- For certificate/proxy/security-sensitive changes, validate on Python 3.13 locally when available.
+- 如果使用 `tcsetpgrp` 的前台控制权切换，在将父进程组切回前台时要处理 `SIGTTOU`。
+- 将 CI 最高 Python 版本（当前为 3.13）视为运行时敏感行为的兼容性上限。
+- TLS 测试/运行时的证书生成必须包含 SKI/AKI 扩展，以兼容 Python 3.13。
+- 涉及证书/proxy/安全敏感变更时，在可用条件下本地以 Python 3.13 验证。

--- a/docs/standards/e2e-and-evidence.md
+++ b/docs/standards/e2e-and-evidence.md
@@ -4,58 +4,58 @@ last_reviewed: 2026-03-03
 source_of_truth: AGENTS.md
 ---
 
-# E2E Validation Requirements
+# E2E 验证要求
 
-If a change affects proxying, trace capture, CLI session flow, auth handling, or other end-to-end behavior, run real E2E validation before opening a PR.
+如果变更影响 proxying、trace 捕获、CLI session 流程、auth 处理或其他端到端行为，在开 PR 前必须运行真实 E2E 验证。
 
-Preferred commands:
+优先命令：
 
 ```bash
 uv run pytest tests/e2e/ --run-real-e2e --timeout=300
 uv run pytest tests/e2e/test_real_proxy.py::TestRealProxy::test_single_turn --run-real-e2e --timeout=180
 ```
 
-Manual alternatives:
+手动替代方案：
 
 ```bash
 scripts/run_real_e2e.sh
 scripts/run_real_e2e_tmux.sh
 ```
 
-If real E2E cannot run (for example, missing auth/token), document reason and residual risk in the PR body.
+如果无法运行真实 E2E（例如缺少 auth/token），在 PR 正文中记录原因与剩余风险。
 
-# E2E Conversation Rule
+# E2E 对话规则
 
-Each E2E run must include at least one complete multi-turn conversation.
-For conversation validation and screenshot evidence, use tmux interactive flow (`scripts/run_real_e2e_tmux.sh`).
-Do not use `claude -p` one-shot runs as proof of conversation completeness.
+每次 E2E 运行必须至少包含一次完整的多轮对话。
+对于对话验证和截图证据，请使用 tmux 交互流程（`scripts/run_real_e2e_tmux.sh`）。
+不要使用 `claude -p` 的单次运行作为对话完整性的证明。
 
-# UI Evidence Requirements
+# UI 证据要求
 
-For PRs changing UI layout, styles, interaction flow, or rendered content:
+对于会改变 UI 布局、样式、交互流程或渲染内容的 PR：
 
-- Include at least one screenshot per changed screen/state.
-- Include before/after screenshots when a visual diff matters.
-- Include mobile screenshots when mobile behavior is affected.
-- Use real trace artifacts from `.traces/trace_*.jsonl` or real run outputs.
-- For E2E-related UI changes, screenshots must come from a run that completed at least one full multi-turn conversation.
+- 每个变更的页面/状态至少提供一张截图。
+- 当视觉差异重要时，提供变更前后截图。
+- 当移动端行为受影响时，提供移动端截图。
+- 使用来自 `.traces/trace_*.jsonl` 或真实运行输出的真实 trace 产物。
+- 对于与 E2E 相关的 UI 变更，截图必须来自至少完成一次完整多轮对话的运行。
 
-# Screenshot Quality Gate
+# 截图质量门禁
 
-Every screenshot committed as PR evidence must pass these checks before `git add`:
+作为 PR 证据提交的每张截图，在 `git add` 之前都必须通过以下检查：
 
-## Mandatory Checks
-1. **Viewport width ≥ 1280px** — Headless browsers often default to narrow viewports. Always resize to desktop dimensions (1280x800 or 1440x900) before capture.
-2. **Content matches claim** — If the PR says "WS trace captured", the screenshot must visibly show the WS trace, not a different request or a loading screen.
-3. **No encoding corruption** — Unicode arrows (→←), CJK characters, and emoji must render correctly. If in doubt, use ASCII equivalents or HTML entities in generated evidence pages.
-4. **No error pages** — 404, ERR_EMPTY_RESPONSE, blank pages, or "page not found" are not evidence.
-5. **Minimum resolution** — Image width must be ≥ 1000px. Anything narrower is likely a mobile/tablet capture.
-6. **File size sanity** — Screenshots < 10KB are likely blank or error pages. Typical trace viewer screenshots are 100KB–500KB.
+## 强制检查
+1. **Viewport 宽度 ≥ 1280px** — Headless browser 常默认窄 viewport。截图前务必调整为桌面尺寸（1280x800 或 1440x900）。
+2. **内容与声明一致** — 如果 PR 写的是“已捕获 WS trace”，截图中必须清楚显示 WS trace，而不是其他请求或加载页。
+3. **无编码损坏** — Unicode 箭头（→←）、CJK 字符和 emoji 必须正确渲染。如有疑问，在生成证据页面时使用 ASCII 等价字符或 HTML entity。
+4. **无错误页面** — 404、ERR_EMPTY_RESPONSE、空白页或 “page not found” 不能作为证据。
+5. **最小分辨率** — 图像宽度必须 ≥ 1000px。更窄通常是移动端/平板截图。
+6. **文件大小合理** — 小于 10KB 的截图通常是空白页或错误页。典型 trace viewer 截图为 100KB–500KB。
 
-## Best Practices
-- For log/text evidence, render as styled HTML (dark card, monospace, syntax highlighting) rather than serving raw `.log` files — avoids font/encoding issues.
-- When taking trace viewer screenshots, navigate to the specific entry first, then capture.
-- Use `scripts/check_screenshots.sh` to automate pre-commit validation.
+## 最佳实践
+- 对日志/文本证据，优先渲染为有样式的 HTML（深色卡片、monospace、语法高亮），不要直接提供原始 `.log` 文件，以避免字体/编码问题。
+- 截取 trace viewer 时，先导航到指定 entry，再截图。
+- 使用 `scripts/check_screenshots.sh` 自动执行 pre-commit 验证。
 
-## Anti-Pattern: Blind Commit
-Never `git add` + `git commit` + `git push` screenshots without opening and reviewing them first. This wastes reviewer time and erodes trust in the evidence.
+## 反模式：盲目提交
+不要在未先打开并检查截图的情况下直接 `git add` + `git commit` + `git push`。这会浪费 reviewer 时间并削弱证据信任。

--- a/docs/standards/hard-rules.md
+++ b/docs/standards/hard-rules.md
@@ -4,15 +4,15 @@ last_reviewed: 2026-03-03
 source_of_truth: AGENTS.md
 ---
 
-# Hard Rules
+# 硬性规则
 
-These rules are mandatory. If you cannot comply, stop and explain why.
+以下规则是强制性的。若你无法遵守，请停止并说明原因。
 
-1. Gate checks before every commit: `ruff check`, `ruff format --check`, `pytest`. No deferred fixes.
-2. UI changes require screenshots in the PR body using `raw.githubusercontent.com` absolute URLs.
-3. One concern per commit. Do not mix refactoring with features or bug fixes.
-4. English only in code, comments, commit messages, docs, and skill files. Exception: `README_zh.md` and explicitly Chinese README files.
-5. Screenshots, demos, and test evidence must use real trace data from `.traces/`, never mocks or synthetic data.
-6. Pre-work checklist is required before coding; pre-PR checklist is required before opening or merging.
-7. After changes, you must `git add`, `git commit`, and `git push origin <branch>`.
-8. You must create the GitHub PR with `gh pr create`; work is not done until PR exists.
+1. 每次 commit 前执行 gate 检查：`ruff check`、`ruff format --check`、`pytest`。不得延期修复。
+2. UI 变更要求在 PR 正文中提供使用 `raw.githubusercontent.com` 绝对 URL 的截图。
+3. 每个 commit 只处理一个关注点。不要把 refactor 与 feature 或 bug fix 混在一起。
+4. 代码、注释、commit message、文档和 skill 文件仅使用英文。例外：`README_zh.md` 与明确为中文的 README 文件。
+5. 截图、演示和测试证据必须使用 `.traces/` 中的真实 trace 数据，禁止 mock 或合成数据。
+6. 编码前必须完成 pre-work checklist；开 PR 或合并前必须完成 pre-PR checklist。
+7. 变更后必须执行 `git add`、`git commit` 和 `git push origin <branch>`。
+8. 必须使用 `gh pr create` 创建 GitHub PR；PR 未创建前，工作不算完成。

--- a/docs/standards/validation-and-gates.md
+++ b/docs/standards/validation-and-gates.md
@@ -4,9 +4,9 @@ last_reviewed: 2026-03-03
 source_of_truth: AGENTS.md
 ---
 
-# Pre-commit CI Checks
+# Pre-commit CI 检查
 
-Before every commit, run:
+每次 commit 前运行：
 
 ```bash
 uv run ruff check .
@@ -14,11 +14,11 @@ uv run ruff format --check .
 uv run pytest tests/ -x --timeout=60
 ```
 
-All checks must pass. If formatting fails, run `uv run ruff format .` and re-check.
+所有检查都必须通过。若格式检查失败，运行 `uv run ruff format .` 后重新检查。
 
 # Pre-work Checklist
 
-Before any code change:
+在进行任何代码变更之前：
 
 ```bash
 git diff --stat
@@ -26,7 +26,7 @@ git log --oneline -10
 git fetch origin
 ```
 
-Before opening or merging a PR:
+在打开或合并 PR 之前：
 
 ```bash
 git rebase origin/main

--- a/docs/standards/workflow-and-review.md
+++ b/docs/standards/workflow-and-review.md
@@ -4,9 +4,9 @@ last_reviewed: 2026-03-03
 source_of_truth: AGENTS.md
 ---
 
-# Worktree Workflow
+# Worktree 工作流
 
-Use git worktrees for isolated feature development:
+使用 git worktree 进行隔离的 feature 开发：
 
 ```bash
 git worktree add -b feat/<name> /tmp/claude-tap-<name> main
@@ -20,29 +20,29 @@ git branch -d feat/<name>
 
 # Code Review Checklist
 
-Before each commit:
+每次 commit 前：
 
 1. `uv run ruff check .`
 2. `uv run ruff format --check .`
 3. `uv run pytest tests/ -x --timeout=60`
-4. `git diff` and review each changed line.
-5. Confirm only relevant files changed.
+4. `git diff` 并检查每一行变更。
+5. 确认只改动了相关文件。
 
-# Compounding Engineering
+# 复利式工程实践
 
-Record lessons learned:
+记录经验教训：
 
-- Error experience: `docs/error-experience/entries/YYYY-MM-DD-<slug>.md`
-- Good experience: `docs/good-experience/entries/YYYY-MM-DD-<slug>.md`
-- Summaries: `docs/error-experience/summary/entries/` and `docs/good-experience/summary/entries/`
-- Plans: `docs/plans/`
-- Guides: `docs/guides/`
+- 错误经验：`docs/error-experience/entries/YYYY-MM-DD-<slug>.md`
+- 正向经验：`docs/good-experience/entries/YYYY-MM-DD-<slug>.md`
+- 汇总：`docs/error-experience/summary/entries/` 与 `docs/good-experience/summary/entries/`
+- 计划：`docs/plans/`
+- 指南：`docs/guides/`
 
-Create an entry after significant bug, CI failure, or useful pattern discovery with root cause and lesson.
+在出现重大 bug、CI 失败或发现有价值模式后，创建一条条目并记录根因与经验。
 
-# Brain + Hands Protocol
+# Brain + Hands 协议
 
-- Claude Code (Opus): planning brain, architecture/API/pattern/review decisions.
-- Codex: execution hands, boilerplate/commands/mechanical edits.
+- Claude Code (Opus)：规划大脑，负责架构/API/模式/review 决策。
+- Codex：执行双手，负责样板代码/命令/机械性编辑。
 
-Do not delegate architecture decisions to execution tools.
+不要把架构决策委托给执行工具。


### PR DESCRIPTION
## Summary
- translate AGENTS.md and internal docs under docs/standards, docs/plans, docs/guides, docs/error-experience/entries, docs/good-experience/entries into Simplified Chinese
- keep code blocks, commands, paths, and filenames unchanged
- preserve markdown structure and frontmatter

## Notes
- requested file `docs/plans/2026-02-28-codex-support-continuation.md` does not exist in this repository
- `README.md` was intentionally left unchanged

## Validation
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/ -x --timeout=60

## Result
- all target markdown files in the specified directories are translated
