### PR TITLE
feat: 本地 PR 自动 review 机器人（webhook + Codex/Claude）

### DIFF
--- a/docs/guides/pr-review-bot.md
+++ b/docs/guides/pr-review-bot.md
@@ -1,0 +1,128 @@
+# 本地 PR 自动 Review 机器人使用指南
+
+本文档说明如何在本地运行 webhook 驱动的 PR review 机器人，并自动把审查结果回贴到 GitHub PR。
+
+## 1. 前置条件
+
+- Python 3.11+
+- `uv`
+- `git`
+- `gh`（已登录并具备仓库 review/comment 权限）
+- `tmux`
+- 至少一个 review agent CLI：
+  - `codex`（默认）
+  - `claude`
+
+可选：
+- `npx`（用于自动启动 `smee-client`）
+
+## 2. 安装与环境变量
+
+在仓库根目录执行：
+
+```bash
+uv sync --extra review-bot --dev
+```
+
+设置环境变量：
+
+```bash
+export PR_REVIEW_WEBHOOK_SECRET="your_webhook_secret"
+export PR_REVIEW_REPO_PATH="/absolute/path/to/this/repo"
+export PR_REVIEW_AGENT="codex"   # or claude
+export PR_REVIEW_TIMEOUT="600"
+export PR_REVIEW_PORT="3456"
+```
+
+可选变量：
+
+```bash
+export PR_REVIEW_IGNORE_USERS="github-actions[bot],dependabot[bot]"
+export PR_REVIEW_LOG_FILE="/tmp/pr-review-bot.log"
+export SMEE_URL="https://smee.io/your-channel"
+```
+
+## 3. 配置 GitHub Webhook
+
+在目标仓库中创建 webhook：
+
+- Payload URL:
+  - 直连本地时：`http://<your-host>:3456/webhook`
+  - 使用 smee 时：`https://smee.io/<your-channel>`
+- Content type: `application/json`
+- Secret: 与 `PR_REVIEW_WEBHOOK_SECRET` 一致
+- 事件：选择 `Pull requests`
+
+机器人只处理以下 action：
+- `opened`
+- `synchronize`
+
+## 4. 启动方式
+
+前台运行：
+
+```bash
+scripts/start_review_bot.sh
+```
+
+后台运行：
+
+```bash
+scripts/start_review_bot.sh --daemon
+```
+
+手动 dry-run（验证导入与配置）：
+
+```bash
+python3 scripts/pr_review_bot.py --dry-run
+```
+
+健康检查：
+
+```bash
+curl -s http://127.0.0.1:${PR_REVIEW_PORT:-3456}/health
+```
+
+## 5. 运行流程
+
+收到 PR webhook 后，机器人会：
+
+1. 验证 `X-Hub-Signature-256`。
+2. 过滤非 `pull_request` 事件或非 `opened/synchronize` action。
+3. 忽略 bot 自身账号触发的 PR（避免循环）。
+4. 同一 PR 新事件到达时取消旧任务，只保留最新任务。
+5. 执行：
+   - `git fetch origin pull/<number>/head:pr-<number>`
+   - `git diff <base>...pr-<number>`
+6. 根据 `prompts/pr-review-prompt.md` 生成 prompt。
+7. 在 tmux session 中调用 `codex` 或 `claude` 完成 review。
+8. 10 分钟超时控制，超时或失败会记录日志。
+9. 根据输出包含的决策词执行：
+   - `APPROVE` -> `gh pr review --approve`
+   - `REQUEST_CHANGES` -> `gh pr review --request-changes`
+   - 其他 -> `gh pr comment`
+
+## 6. 日志与排障
+
+默认日志文件：
+
+- `/tmp/pr-review-bot.log`
+- `/tmp/pr-review-bot-stdout.log`（daemon 模式）
+- `/tmp/pr-review-bot-smee.log`（启用 smee 时）
+
+常见问题：
+
+1. webhook 返回 401  
+   检查 `PR_REVIEW_WEBHOOK_SECRET` 与 GitHub Webhook Secret 是否一致。
+
+2. review 未回贴  
+   检查 `gh auth status`，确认 token 权限包含 PR review/comment。
+
+3. agent 命令失败  
+   确认 `codex` 或 `claude` CLI 可在终端直接执行。
+
+4. tmux 报错  
+   安装并验证 `tmux -V`。
+
+5. smee 无转发  
+   检查 `SMEE_URL` 是否正确，以及 `npx smee-client` 是否可运行。

--- a/docs/guides/pr-review-bot.md
+++ b/docs/guides/pr-review-bot.md
@@ -1,6 +1,6 @@
 # 本地 PR 自动 Review 机器人使用指南
 
-本文档说明如何在本地运行 webhook 驱动的 PR review 机器人，并自动把审查结果回贴到 GitHub PR。
+本文档说明如何在本地运行 webhook 驱动的 PR review 机器人，并自动把审查结果回帖到 GitHub PR。
 
 ## 1. 前置条件
 
@@ -30,6 +30,7 @@ uv sync --extra review-bot --dev
 export PR_REVIEW_WEBHOOK_SECRET="your_webhook_secret"
 export PR_REVIEW_REPO_PATH="/absolute/path/to/this/repo"
 export PR_REVIEW_AGENT="codex"   # or claude
+export PR_REVIEW_OUTPUT_LANGUAGE="zh"  # zh or en
 export PR_REVIEW_TIMEOUT="600"
 export PR_REVIEW_PORT="3456"
 ```
@@ -39,6 +40,7 @@ export PR_REVIEW_PORT="3456"
 ```bash
 export PR_REVIEW_IGNORE_USERS="github-actions[bot],dependabot[bot]"
 export PR_REVIEW_LOG_FILE="/tmp/pr-review-bot.log"
+export PR_REVIEW_ALLOW_INSECURE_WEBHOOKS="false"  # only for local debug
 export SMEE_URL="https://smee.io/your-channel"
 ```
 
@@ -92,8 +94,9 @@ curl -s http://127.0.0.1:${PR_REVIEW_PORT:-3456}/health
 3. 忽略 bot 自身账号触发的 PR（避免循环）。
 4. 同一 PR 新事件到达时取消旧任务，只保留最新任务。
 5. 执行：
-   - `git fetch origin pull/<number>/head:pr-<number>`
-   - `git diff <base>...pr-<number>`
+   - `git fetch origin +pull/<number>/head:pr-<number>`
+   - `git fetch origin <base>`
+   - `git diff origin/<base>...pr-<number>`
 6. 根据 `prompts/pr-review-prompt.md` 生成 prompt。
 7. 在 tmux session 中调用 `codex` 或 `claude` 完成 review。
 8. 10 分钟超时控制，超时或失败会记录日志。
@@ -115,7 +118,7 @@ curl -s http://127.0.0.1:${PR_REVIEW_PORT:-3456}/health
 1. webhook 返回 401  
    检查 `PR_REVIEW_WEBHOOK_SECRET` 与 GitHub Webhook Secret 是否一致。
 
-2. review 未回贴  
+2. review 未回帖  
    检查 `gh auth status`，确认 token 权限包含 PR review/comment。
 
 3. agent 命令失败  

--- a/docs/guides/pr-review-bot.md
+++ b/docs/guides/pr-review-bot.md
@@ -1,131 +1,131 @@
-# 本地 PR 自动 Review 机器人使用指南
+# Local PR Auto-Review Bot Guide
 
-本文档说明如何在本地运行 webhook 驱动的 PR review 机器人，并自动把审查结果回帖到 GitHub PR。
+This guide explains how to run the webhook-driven PR review bot locally and automatically post review results back to a GitHub PR.
 
-## 1. 前置条件
+## 1. Prerequisites
 
 - Python 3.11+
 - `uv`
 - `git`
-- `gh`（已登录并具备仓库 review/comment 权限）
+- `gh` (authenticated with review/comment permissions for the target repository)
 - `tmux`
-- 至少一个 review agent CLI：
-  - `codex`（默认）
+- At least one review agent CLI:
+  - `codex` (default)
   - `claude`
 
-可选：
-- `npx`（用于自动启动 `smee-client`）
+Optional:
+- `npx` (for starting `smee-client` automatically)
 
-## 2. 安装与环境变量
+## 2. Install And Configure
 
-在仓库根目录执行：
+Run from the repository root:
 
 ```bash
 uv sync --extra review-bot --dev
 ```
 
-设置环境变量：
+Set environment variables:
 
 ```bash
 export PR_REVIEW_WEBHOOK_SECRET="your_webhook_secret"
 export PR_REVIEW_REPO_PATH="/absolute/path/to/this/repo"
 export PR_REVIEW_AGENT="codex"   # or claude
-export PR_REVIEW_OUTPUT_LANGUAGE="zh"  # zh or en
+export PR_REVIEW_OUTPUT_LANGUAGE="en"  # zh or en
 export PR_REVIEW_TIMEOUT="600"
 export PR_REVIEW_PORT="3456"
 ```
 
-可选变量：
+Optional variables:
 
 ```bash
 export PR_REVIEW_IGNORE_USERS="github-actions[bot],dependabot[bot]"
 export PR_REVIEW_LOG_FILE="/tmp/pr-review-bot.log"
-export PR_REVIEW_ALLOW_INSECURE_WEBHOOKS="false"  # only for local debug
+export PR_REVIEW_ALLOW_INSECURE_WEBHOOKS="false"  # local debug only
 export SMEE_URL="https://smee.io/your-channel"
 ```
 
-## 3. 配置 GitHub Webhook
+## 3. Configure GitHub Webhook
 
-在目标仓库中创建 webhook：
+Create a webhook in the target GitHub repository:
 
 - Payload URL:
-  - 直连本地时：`http://<your-host>:3456/webhook`
-  - 使用 smee 时：`https://smee.io/<your-channel>`
+  - Direct local endpoint: `http://<your-host>:3456/webhook`
+  - With smee relay: `https://smee.io/<your-channel>`
 - Content type: `application/json`
-- Secret: 与 `PR_REVIEW_WEBHOOK_SECRET` 一致
-- 事件：选择 `Pull requests`
+- Secret: same value as `PR_REVIEW_WEBHOOK_SECRET`
+- Events: `Pull requests`
 
-机器人只处理以下 action：
+The bot only processes these actions:
 - `opened`
 - `synchronize`
 
-## 4. 启动方式
+## 4. Start The Bot
 
-前台运行：
+Foreground:
 
 ```bash
 scripts/start_review_bot.sh
 ```
 
-后台运行：
+Background:
 
 ```bash
 scripts/start_review_bot.sh --daemon
 ```
 
-手动 dry-run（验证导入与配置）：
+Manual dry-run (validate imports and configuration):
 
 ```bash
 python3 scripts/pr_review_bot.py --dry-run
 ```
 
-健康检查：
+Health check:
 
 ```bash
 curl -s http://127.0.0.1:${PR_REVIEW_PORT:-3456}/health
 ```
 
-## 5. 运行流程
+## 5. Runtime Flow
 
-收到 PR webhook 后，机器人会：
+After receiving a PR webhook, the bot:
 
-1. 验证 `X-Hub-Signature-256`。
-2. 过滤非 `pull_request` 事件或非 `opened/synchronize` action。
-3. 忽略 bot 自身账号触发的 PR（避免循环）。
-4. 同一 PR 新事件到达时取消旧任务，只保留最新任务。
-5. 执行：
+1. Verifies `X-Hub-Signature-256` (or wrapped signature for smee payloads).
+2. Filters out non-`pull_request` events and actions other than `opened`/`synchronize`.
+3. Ignores configured bot/service accounts to avoid loops.
+4. Cancels any previous in-flight review for the same PR.
+5. Runs:
    - `git fetch origin +pull/<number>/head:pr-<number>`
    - `git fetch origin <base>`
    - `git diff origin/<base>...pr-<number>`
-6. 根据 `prompts/pr-review-prompt.md` 生成 prompt。
-7. 在 tmux session 中调用 `codex` 或 `claude` 完成 review。
-8. 10 分钟超时控制，超时或失败会记录日志。
-9. 根据输出包含的决策词执行：
+6. Builds the review prompt from `prompts/pr-review-prompt.md`.
+7. Runs `codex` or `claude` in a tmux session.
+8. Applies timeout and cancellation handling.
+9. Parses recommendation from model output and posts:
    - `APPROVE` -> `gh pr review --approve`
    - `REQUEST_CHANGES` -> `gh pr review --request-changes`
-   - 其他 -> `gh pr comment`
+   - otherwise -> `gh pr comment`
 
-## 6. 日志与排障
+## 6. Logs And Troubleshooting
 
-默认日志文件：
+Default log files:
 
 - `/tmp/pr-review-bot.log`
-- `/tmp/pr-review-bot-stdout.log`（daemon 模式）
-- `/tmp/pr-review-bot-smee.log`（启用 smee 时）
+- `/tmp/pr-review-bot-stdout.log` (daemon mode)
+- `/tmp/pr-review-bot-smee.log` (when smee relay is enabled)
 
-常见问题：
+Common issues:
 
-1. webhook 返回 401  
-   检查 `PR_REVIEW_WEBHOOK_SECRET` 与 GitHub Webhook Secret 是否一致。
+1. Webhook returns 401.
+   Verify `PR_REVIEW_WEBHOOK_SECRET` matches the GitHub webhook secret.
 
-2. review 未回帖  
-   检查 `gh auth status`，确认 token 权限包含 PR review/comment。
+2. No PR review/comment is posted.
+   Run `gh auth status` and verify token permissions for PR reviews/comments.
 
-3. agent 命令失败  
-   确认 `codex` 或 `claude` CLI 可在终端直接执行。
+3. Agent command fails.
+   Verify `codex` or `claude` CLI works directly in the shell.
 
-4. tmux 报错  
-   安装并验证 `tmux -V`。
+4. tmux errors.
+   Install tmux and verify with `tmux -V`.
 
-5. smee 无转发  
-   检查 `SMEE_URL` 是否正确，以及 `npx smee-client` 是否可运行。
+5. smee relay is not forwarding.
+   Verify `SMEE_URL` and test `npx smee-client` manually.

--- a/prompts/pr-review-prompt.md
+++ b/prompts/pr-review-prompt.md
@@ -36,26 +36,50 @@ Read and enforce these project standards (all files are in the repo):
 5. **对照项目标准** — 读 AGENTS.md 和 docs/standards/ 确认合规性
 6. **给出决策建议** — APPROVE / REQUEST_CHANGES / COMMENT
 
-## Output Format (严格遵守)
+## Output: 直接提交 Review
 
-用中文输出，格式如下：
+审查完成后，**直接用 gh CLI 提交 review**，不要写到文件：
+
+```bash
+# 如果有具体行的问题，用 inline comment：
+gh pr review {pr_number} --request-changes --body "你的 review 内容（Markdown 格式，中文）"
+
+# 或者如果一切 OK：
+gh pr review {pr_number} --approve --body "LGTM. 简要说明..."
+
+# 或者只是建议：
+gh pr comment {pr_number} --body "你的评论"
+```
+
+### Review 格式要求（写在 --body 里）
+
+用中文，Markdown 格式：
+
+```
+## 🤖 自动 Code Review
 
 ### Summary
-（一句话总结 PR 做了什么，质量如何）
+（一句话总结）
 
 ### Findings
 
 #### Critical
-（列出，没有则写"无"）
+（没有则写"无"）
 
 #### High
-（列出）
+...
 
 #### Medium
-（列出）
+...
 
 #### Low
-（列出）
+...
 
-### Suggested Decision
-（APPROVE / REQUEST_CHANGES / COMMENT，附一句理由）
+### Decision
+（APPROVE / REQUEST_CHANGES / COMMENT + 理由）
+
+---
+*⚡ Powered by local PR Review Bot*
+```
+
+**重要**：你必须自己执行 `gh pr review` 或 `gh pr comment` 命令。这是你的最终输出。

--- a/prompts/pr-review-prompt.md
+++ b/prompts/pr-review-prompt.md
@@ -1,35 +1,61 @@
-You are reviewing GitHub Pull Request #{pr_number}.
+# PR Review Task
 
-Project standards to enforce:
-- AGENTS.md
-- docs/standards/hard-rules.md
-- docs/standards/validation-and-gates.md
-- docs/standards/e2e-and-evidence.md
-- docs/standards/screenshot-standards.md
-- docs/standards/coding-and-runtime.md
-- docs/standards/workflow-and-review.md
+You are reviewing Pull Request #{pr_number} for the `claude-tap` project.
 
-PR metadata:
-- Title: {pr_title}
-- Head branch: {head_ref}
-- Base branch: {base_ref}
-- Description:
+## Project Standards
+
+Read and enforce these project standards (all files are in the repo):
+- `AGENTS.md` — hard rules index
+- `docs/standards/hard-rules.md`
+- `docs/standards/validation-and-gates.md`
+- `docs/standards/e2e-and-evidence.md`
+- `docs/standards/screenshot-standards.md`
+- `docs/standards/coding-and-runtime.md`
+- `docs/standards/workflow-and-review.md`
+
+## PR Information
+
+- **Title**: {pr_title}
+- **Branch**: `{head_ref}` → `{base_ref}`
+- **Description**:
+
 {pr_body}
 
-Diff to review:
+## Diff
+
 ```diff
 {diff_text}
 ```
 
-Review requirements:
-1. Inspect the diff line by line and identify bugs, regressions, security issues, and maintainability risks.
-2. Check whether the change has adequate test coverage and point out missing tests.
-3. Verify whether the PR description includes screenshot evidence that satisfies repository standards.
-4. Check whether commit/PR title follows Conventional Commits.
-5. Recommend one decision: APPROVE, REQUEST_CHANGES, or COMMENT.
-6. Write the full review in Chinese.
+## Review Requirements
 
-Output format:
-- Summary
-- Findings (sorted by severity: Critical, High, Medium, Low)
-- Suggested decision (APPROVE / REQUEST_CHANGES / COMMENT)
+1. **逐行审查 diff** — 找 bug、回归、安全问题、可维护性风险
+2. **检查测试覆盖** — 是否有足够的测试？缺少哪些场景？
+3. **检查 PR 描述** — 是否有截图证据（如果涉及 UI 变更）
+4. **检查标题规范** — 是否符合 Conventional Commits
+5. **对照项目标准** — 读 AGENTS.md 和 docs/standards/ 确认合规性
+6. **给出决策建议** — APPROVE / REQUEST_CHANGES / COMMENT
+
+## Output Format (严格遵守)
+
+用中文输出，格式如下：
+
+### Summary
+（一句话总结 PR 做了什么，质量如何）
+
+### Findings
+
+#### Critical
+（列出，没有则写"无"）
+
+#### High
+（列出）
+
+#### Medium
+（列出）
+
+#### Low
+（列出）
+
+### Suggested Decision
+（APPROVE / REQUEST_CHANGES / COMMENT，附一句理由）

--- a/prompts/pr-review-prompt.md
+++ b/prompts/pr-review-prompt.md
@@ -42,18 +42,18 @@ Read and enforce these project standards (all files are in the repo):
 
 ```bash
 # 如果有具体行的问题，用 inline comment：
-gh pr review {pr_number} --request-changes --body "你的 review 内容（Markdown 格式，中文）"
+gh pr review {pr_number} --request-changes --body "Your review body in {output_language} Markdown"
 
 # 或者如果一切 OK：
-gh pr review {pr_number} --approve --body "LGTM. 简要说明..."
+gh pr review {pr_number} --approve --body "LGTM. Brief summary..."
 
 # 或者只是建议：
-gh pr comment {pr_number} --body "你的评论"
+gh pr comment {pr_number} --body "Your comment in {output_language}"
 ```
 
 ### Review 格式要求（写在 --body 里）
 
-用中文，Markdown 格式：
+Use {output_language} and Markdown format:
 
 ```
 ## 🤖 自动 Code Review

--- a/prompts/pr-review-prompt.md
+++ b/prompts/pr-review-prompt.md
@@ -5,7 +5,7 @@ You are reviewing Pull Request #{pr_number} for the `claude-tap` project.
 ## Project Standards
 
 Read and enforce these project standards (all files are in the repo):
-- `AGENTS.md` — hard rules index
+- `AGENTS.md` - hard rules index
 - `docs/standards/hard-rules.md`
 - `docs/standards/validation-and-gates.md`
 - `docs/standards/e2e-and-evidence.md`
@@ -16,7 +16,7 @@ Read and enforce these project standards (all files are in the repo):
 ## PR Information
 
 - **Title**: {pr_title}
-- **Branch**: `{head_ref}` → `{base_ref}`
+- **Branch**: `{head_ref}` -> `{base_ref}`
 - **Description**:
 
 {pr_body}
@@ -29,42 +29,41 @@ Read and enforce these project standards (all files are in the repo):
 
 ## Review Requirements
 
-1. **逐行审查 diff** — 找 bug、回归、安全问题、可维护性风险
-2. **检查测试覆盖** — 是否有足够的测试？缺少哪些场景？
-3. **检查 PR 描述** — 是否有截图证据（如果涉及 UI 变更）
-4. **检查标题规范** — 是否符合 Conventional Commits
-5. **对照项目标准** — 读 AGENTS.md 和 docs/standards/ 确认合规性
-6. **给出决策建议** — APPROVE / REQUEST_CHANGES / COMMENT
+1. Review the diff carefully and identify bugs, regressions, security issues, and maintainability risks.
+2. Evaluate test coverage and call out missing scenarios.
+3. Check PR description requirements, including screenshot evidence for UI changes.
+4. Check title and commit conventions expected by the repository standards.
+5. Enforce all rules from `AGENTS.md` and `docs/standards/`.
+6. Provide a recommendation: `APPROVE`, `REQUEST_CHANGES`, or `COMMENT`.
 
-## Output: 直接提交 Review
+## Output Requirements
 
-审查完成后，**直接用 gh CLI 提交 review**，不要写到文件：
+Output review text only (Markdown), using {output_language}.
+Do not run `gh` commands.
 
-```bash
-# 如果有具体行的问题，用 inline comment：
-gh pr review {pr_number} --request-changes --body "Your review body in {output_language} Markdown"
+The output must include one explicit line in this exact format:
 
-# 或者如果一切 OK：
-gh pr review {pr_number} --approve --body "LGTM. Brief summary..."
-
-# 或者只是建议：
-gh pr comment {pr_number} --body "Your comment in {output_language}"
+```text
+Decision: APPROVE
 ```
 
-### Review 格式要求（写在 --body 里）
+Allowed values are:
+- `Decision: APPROVE`
+- `Decision: REQUEST_CHANGES`
+- `Decision: COMMENT`
 
-Use {output_language} and Markdown format:
+Use this review structure:
 
-```
-## 🤖 自动 Code Review
+```markdown
+## Automated Code Review
 
 ### Summary
-（一句话总结）
+(One-sentence summary)
 
 ### Findings
 
 #### Critical
-（没有则写"无"）
+(Write "None" if empty)
 
 #### High
 ...
@@ -76,10 +75,8 @@ Use {output_language} and Markdown format:
 ...
 
 ### Decision
-（APPROVE / REQUEST_CHANGES / COMMENT + 理由）
+(Repeat APPROVE / REQUEST_CHANGES / COMMENT and concise reason)
 
 ---
-*⚡ Powered by local PR Review Bot*
+*Powered by local PR Review Bot*
 ```
-
-**重要**：你必须自己执行 `gh pr review` 或 `gh pr comment` 命令。这是你的最终输出。

--- a/prompts/pr-review-prompt.md
+++ b/prompts/pr-review-prompt.md
@@ -1,0 +1,35 @@
+You are reviewing GitHub Pull Request #{pr_number}.
+
+Project standards to enforce:
+- AGENTS.md
+- docs/standards/hard-rules.md
+- docs/standards/validation-and-gates.md
+- docs/standards/e2e-and-evidence.md
+- docs/standards/screenshot-standards.md
+- docs/standards/coding-and-runtime.md
+- docs/standards/workflow-and-review.md
+
+PR metadata:
+- Title: {pr_title}
+- Head branch: {head_ref}
+- Base branch: {base_ref}
+- Description:
+{pr_body}
+
+Diff to review:
+```diff
+{diff_text}
+```
+
+Review requirements:
+1. Inspect the diff line by line and identify bugs, regressions, security issues, and maintainability risks.
+2. Check whether the change has adequate test coverage and point out missing tests.
+3. Verify whether the PR description includes screenshot evidence that satisfies repository standards.
+4. Check whether commit/PR title follows Conventional Commits.
+5. Recommend one decision: APPROVE, REQUEST_CHANGES, or COMMENT.
+6. Write the full review in Chinese.
+
+Output format:
+- Summary
+- Findings (sorted by severity: Critical, High, Medium, Low)
+- Suggested decision (APPROVE / REQUEST_CHANGES / COMMENT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,10 @@ dev = [
     "pexpect>=4.9",
     "ruff>=0.11",
 ]
+review-bot = [
+    "fastapi>=0.115,<1",
+    "uvicorn>=0.31,<1",
+]
 
 [tool.ruff]
 target-version = "py311"

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -137,25 +137,23 @@ def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> 
 
 
 def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
-    """Run Codex/Claude to review a PR. Writes prompt to file, captures output from file."""
+    """Run Codex/Claude to review a PR. Agent posts review directly via gh CLI."""
     prompt = build_review_prompt(pr, diff)
     pr_num = pr["number"]
     run_id = uuid.uuid4().hex[:6]
     session_name = f"pr-review-{pr_num}-{run_id}"
 
-    # Write prompt and diff to temp files (avoid shell arg length limits)
+    # Write prompt to temp file (avoid shell arg length limits)
     work_dir = Path(tempfile.mkdtemp(prefix=f"pr-review-{pr_num}-"))
     prompt_file = work_dir / "prompt.md"
-    output_file = work_dir / "review-output.md"
     prompt_file.write_text(prompt, encoding="utf-8")
 
-    # Instruct agent to read prompt from file and write review to output file
+    # Agent reads prompt and posts review directly via gh CLI
     agent_task = (
-        f"Read the PR review prompt from {prompt_file}. "
-        f"Follow the instructions exactly. "
-        f"After completing the review, write ONLY the final review text "
-        f"(Summary + Findings + Suggested decision) to {output_file}. "
-        f"Do not include any other content in that file."
+        f"Read the PR review instructions from {prompt_file}. "
+        f"Review the code carefully following the project standards. "
+        f"Then post your review directly using gh pr review or gh pr comment. "
+        f"The PR number is {pr_num}."
     )
 
     if config.review_agent == "codex":
@@ -169,6 +167,7 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
         timeout=10,
     )
 
+    # Wait for agent to finish
     deadline = time.time() + config.review_timeout
     while time.time() < deadline:
         result = subprocess.run(
@@ -177,83 +176,38 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
         )
         if result.returncode != 0:
             break
-        # Also check if output file exists (agent finished writing)
-        if output_file.exists() and output_file.stat().st_size > 100:
-            LOG.info("Review output file detected for PR #%d", pr_num)
-            time.sleep(5)  # Give agent a moment to finish writing
-            break
         time.sleep(15)
 
-    # Try to read from output file first (clean output)
-    review_text = ""
-    if output_file.exists():
-        review_text = output_file.read_text(encoding="utf-8").strip()
-        LOG.info("Read review from output file (%d chars) for PR #%d", len(review_text), pr_num)
+    timed_out = time.time() >= deadline
 
-    # Fallback: extract from tmux capture if output file is empty
-    if not review_text or len(review_text) < 50:
-        LOG.warning("Output file empty/missing for PR #%d, falling back to tmux capture", pr_num)
-        output = subprocess.run(
-            ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-500"],
-            capture_output=True, text=True,
-        )
-        if output.returncode == 0:
-            review_text = _extract_review_from_tmux(output.stdout)
+    # Capture tmux output to extract decision for notification
+    output = subprocess.run(
+        ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-500"],
+        capture_output=True, text=True,
+    )
+    raw_output = output.stdout if output.returncode == 0 else ""
 
     # Cleanup
     subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
     import shutil
     shutil.rmtree(work_dir, ignore_errors=True)
 
-    return review_text or "(review 输出为空，请检查 agent 日志)"
+    if timed_out:
+        LOG.warning("Review timed out for PR #%d", pr_num)
+        return "(review timed out)"
+
+    LOG.info("Agent finished review for PR #%d", pr_num)
+    return raw_output
 
 
-def _extract_review_from_tmux(raw: str) -> str:
-    """Extract the review section from raw tmux output."""
-    lines = raw.split("\n")
-    # Look for Summary section start
-    review_lines: list[str] = []
-    capturing = False
-    for line in lines:
-        stripped = line.strip()
-        # Start capturing at "Summary" or "## Summary"
-        if not capturing and ("Summary" in stripped and len(stripped) < 50):
-            capturing = True
-        if capturing:
-            # Stop at Codex/Claude UI elements
-            if stripped.startswith("›") or "gpt-5" in stripped or "esc to interrupt" in stripped:
-                continue
-            review_lines.append(line)
-    if review_lines:
-        return "\n".join(review_lines).strip()
-    # If no structured output found, return last 100 meaningful lines
-    meaningful = [l for l in lines if l.strip() and not l.strip().startswith("•") and "Working" not in l]
-    return "\n".join(meaningful[-100:]).strip()
 
-
-def post_review(pr_number: int, review_text: str, repo: str, agent: str = "codex") -> None:
-    """Post formatted review comment to GitHub PR."""
-    # Format as a clean GitHub comment
-    body = (
-        f"## 🤖 自动 Code Review\n\n"
-        f"> 由本地 {agent.capitalize()} 自动生成\n\n"
-        f"---\n\n"
-        f"{review_text}\n\n"
-        f"---\n"
-        f"*⚡ Powered by local PR Review Bot*"
-    )
-    # Write to temp file to avoid shell arg length issues
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-        f.write(body)
-        body_file = f.name
-    try:
-        subprocess.run(
-            ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body-file", body_file],
-            timeout=30,
-        )
-        LOG.info("Posted review to PR #%d", pr_number)
-    finally:
-        Path(body_file).unlink(missing_ok=True)
+def extract_decision(raw_output: str) -> str:
+    """Extract review decision from agent output."""
+    if "request-changes" in raw_output.lower() or "REQUEST_CHANGES" in raw_output:
+        return "REQUEST_CHANGES"
+    if "--approve" in raw_output.lower() or "APPROVE" in raw_output:
+        return "APPROVE"
+    return "COMMENT"
 
 
 # ---------------------------------------------------------------------------
@@ -351,15 +305,10 @@ class ReviewOrchestrator:
                 if not diff.strip():
                     LOG.warning("Empty diff for PR #%d, skipping", pr_num)
                     return
-                review = run_review(self._config, pr, diff)
-                post_review(pr_num, review, repo, self._config.review_agent)
-                # Determine decision from review text
-                decision = "COMMENT"
-                if "REQUEST_CHANGES" in review:
-                    decision = "REQUEST_CHANGES"
-                elif "APPROVE" in review and "REQUEST_CHANGES" not in review:
-                    decision = "APPROVE"
-                notify_openclaw(pr_num, review, repo, decision)
+                raw_output = run_review(self._config, pr, diff)
+                decision = extract_decision(raw_output)
+                LOG.info("Review decision for PR #%d: %s", pr_num, decision)
+                notify_openclaw(pr_num, raw_output, repo, decision)
             except Exception:
                 LOG.exception("Review failed for PR #%d", pr_num)
 

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -172,7 +172,7 @@ def run_review(
     diff: str,
     cancel_event: threading.Event,
 ) -> str:
-    """Run Codex/Claude to review a PR. Agent posts review directly via gh CLI."""
+    """Run Codex/Claude to review a PR and return raw model output."""
     prompt = build_review_prompt(pr, diff, config.output_language)
     pr_num = pr["number"]
     run_id = uuid.uuid4().hex[:6]
@@ -185,12 +185,13 @@ def run_review(
     status_file = work_dir / "agent-status.txt"
     prompt_file.write_text(prompt, encoding="utf-8")
 
-    # Agent reads prompt and posts review directly via gh CLI
+    # Agent reads prompt and prints review markdown plus a Decision marker.
     agent_task = (
         f"Read the PR review instructions from {prompt_file}. "
         f"Review the code carefully following the project standards. "
-        f"Then post your review directly using gh pr review or gh pr comment. "
-        f"The PR number is {pr_num}."
+        "Output only the review body markdown and include one explicit line "
+        "formatted exactly as: `Decision: APPROVE`, `Decision: REQUEST_CHANGES`, "
+        "or `Decision: COMMENT`."
     )
 
     cmd = _agent_shell_command(config.review_agent, agent_task, output_file, status_file)
@@ -240,6 +241,81 @@ def extract_decision(raw_output: str) -> str:
     if re.search(r"\bgh\s+pr\s+comment\b", raw_output, re.IGNORECASE):
         return "COMMENT"
     return "COMMENT"
+
+
+def extract_review_body(raw_output: str) -> str:
+    """Build comment/review body from model output."""
+    lines = raw_output.splitlines()
+    filtered_lines = []
+    for line in lines:
+        normalized = line.strip().upper()
+        if normalized.startswith("DECISION:") or normalized.startswith("SUGGESTED DECISION:"):
+            continue
+        filtered_lines.append(line)
+    review_body = "\n".join(filtered_lines).strip()
+    if not review_body:
+        return "Automated review completed, but the agent did not provide review content."
+    return review_body
+
+
+def post_review(pr_number: int, review_text: str, repo: str, recommendation: str) -> None:
+    """Submit review result to GitHub using gh CLI."""
+    normalized = (recommendation or "COMMENT").strip().upper()
+
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".md", delete=False) as tmp:
+        tmp.write(review_text)
+        body_file = tmp.name
+
+    try:
+        if normalized == "APPROVE":
+            cmd = [
+                "gh",
+                "pr",
+                "review",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--approve",
+                "--body-file",
+                body_file,
+            ]
+        elif normalized == "REQUEST_CHANGES":
+            cmd = [
+                "gh",
+                "pr",
+                "review",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--request-changes",
+                "--body-file",
+                body_file,
+            ]
+        else:
+            cmd = [
+                "gh",
+                "pr",
+                "comment",
+                str(pr_number),
+                "--repo",
+                repo,
+                "--body-file",
+                body_file,
+            ]
+        subprocess.run(cmd, capture_output=True, text=True, timeout=60, check=True)
+        LOG.info("Posted %s to PR #%d", normalized, pr_number)
+    except subprocess.CalledProcessError as exc:
+        LOG.error(
+            "Failed to post %s to PR #%d: rc=%s stdout=%s stderr=%s",
+            normalized,
+            pr_number,
+            exc.returncode,
+            exc.stdout,
+            exc.stderr,
+        )
+        raise
+    finally:
+        Path(body_file).unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -366,11 +442,15 @@ class ReviewOrchestrator:
                     return
                 raw_output = run_review(self._config, pr, diff, cancel_event)
                 if cancel_event.is_set():
-                    LOG.info("Skipping notification for cancelled review PR #%d", pr_num)
+                    LOG.info("Skipping post for cancelled review PR #%d", pr_num)
                     return
-                decision = extract_decision(raw_output)
-                LOG.info("Review decision for PR #%d: %s", pr_num, decision)
-                notify_openclaw(pr_num, raw_output, repo, decision)
+                recommendation = extract_decision(raw_output)
+                review_text = extract_review_body(raw_output)
+                if cancel_event.is_set():
+                    LOG.info("Skipping post for cancelled review PR #%d", pr_num)
+                    return
+                post_review(pr_num, review_text, repo, recommendation)
+                notify_openclaw(pr_num, review_text, repo, recommendation)
             except TimeoutError:
                 LOG.info("Review cancelled for PR #%d", pr_num)
             except Exception:

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -18,347 +18,225 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-try:
-    from scripts.pr_review_bot_config import ReviewBotConfig, load_config
-except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
-    from pr_review_bot_config import ReviewBotConfig, load_config
+LOG = logging.getLogger("pr-review-bot")
 
-LOG = logging.getLogger("pr_review_bot")
-PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "prompts" / "pr-review-prompt.md"
 
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
 
 @dataclass
-class ReviewWorker:
-    thread: threading.Thread
-    cancel_event: threading.Event
-    run_id: str
+class ReviewBotConfig:
+    webhook_secret: str
+    repo_path: str
+    review_agent: str
+    review_timeout: int
+    port: int
+    ignore_users: set[str]
+    log_file: str
 
 
-def setup_logging(log_file: Path) -> None:
-    LOG.setLevel(logging.INFO)
-    if LOG.handlers:
-        return
+def load_config() -> ReviewBotConfig:
+    import os
+    return ReviewBotConfig(
+        webhook_secret=os.environ.get("PR_REVIEW_WEBHOOK_SECRET", ""),
+        repo_path=os.environ.get("PR_REVIEW_REPO_PATH", os.getcwd()),
+        review_agent=os.environ.get("PR_REVIEW_AGENT", "codex"),
+        review_timeout=int(os.environ.get("PR_REVIEW_TIMEOUT", "600")),
+        port=int(os.environ.get("PR_REVIEW_PORT", "3456")),
+        ignore_users=set(
+            u.strip()
+            for u in os.environ.get(
+                "PR_REVIEW_IGNORE_USERS",
+                "github-actions[bot],dependabot[bot]",
+            ).split(",")
+            if u.strip()
+        ),
+        log_file=os.environ.get("PR_REVIEW_LOG_FILE", "/tmp/pr-review-bot.log"),
+    )
 
-    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
-    stream_handler = logging.StreamHandler()
-    stream_handler.setFormatter(formatter)
 
-    file_handler = logging.FileHandler(log_file, encoding="utf-8")
-    file_handler.setFormatter(formatter)
+def setup_logging(log_file: str) -> None:
+    fmt = "%(asctime)s %(levelname)s %(message)s"
+    logging.basicConfig(level=logging.INFO, format=fmt)
+    if log_file:
+        fh = logging.FileHandler(log_file)
+        fh.setFormatter(logging.Formatter(fmt))
+        logging.getLogger().addHandler(fh)
 
-    LOG.addHandler(stream_handler)
-    LOG.addHandler(file_handler)
 
+# ---------------------------------------------------------------------------
+# Webhook helpers
+# ---------------------------------------------------------------------------
 
 def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
     if not secret:
         return True
     if not signature_header.startswith("sha256="):
         return False
-    provided = signature_header.split("=", 1)[1]
-    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(expected, provided)
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, signature_header)
 
 
 def should_process_pull_request(
-    event_name: str,
+    event: str,
     payload: dict[str, Any],
-    ignore_users: set[str] | frozenset[str],
+    ignore_users: set[str],
 ) -> tuple[bool, str]:
-    if event_name != "pull_request":
-        return False, "not a pull_request event"
-
-    action = payload.get("action")
-    if action not in {"opened", "synchronize"}:
-        return False, f"ignored action={action}"
-
-    sender_login = str(payload.get("sender", {}).get("login", ""))
-    if sender_login in ignore_users or sender_login.endswith("[bot]"):
-        return False, f"ignored sender={sender_login}"
-
-    pr = payload.get("pull_request")
-    if not isinstance(pr, dict) or "number" not in pr:
-        return False, "missing pull_request payload"
-    return True, "accepted"
+    if event != "pull_request":
+        return False, f"event={event} not pull_request"
+    action = payload.get("action", "")
+    if action not in ("opened", "synchronize"):
+        return False, f"action={action} not opened/synchronize"
+    sender = payload.get("sender", {})
+    login = sender.get("login", "")
+    if login in ignore_users:
+        return False, f"sender={login} in ignore list"
+    if sender.get("type", "").lower() == "bot":
+        return False, f"sender={login} is bot"
+    return True, "ok"
 
 
-def build_review_prompt(
-    *,
-    template_text: str,
-    pr_number: int,
-    pr_title: str,
-    pr_body: str,
-    head_ref: str,
-    base_ref: str,
-    diff_text: str,
-) -> str:
-    safe_body = pr_body.strip() or "(No PR description)"
-    safe_diff = diff_text.strip() or "(No diff content)"
-    return template_text.format(
-        pr_number=pr_number,
-        pr_title=pr_title.strip(),
-        pr_body=safe_body,
-        head_ref=head_ref.strip(),
-        base_ref=base_ref.strip(),
-        diff_text=safe_diff,
+# ---------------------------------------------------------------------------
+# Review logic
+# ---------------------------------------------------------------------------
+
+def build_review_prompt(pr: dict[str, Any], diff: str) -> str:
+    prompt_path = Path(__file__).parent.parent / "prompts" / "pr-review-prompt.md"
+    template = prompt_path.read_text() if prompt_path.exists() else "Review this PR diff."
+    return (
+        f"{template}\n\n"
+        f"## PR #{pr['number']}: {pr['title']}\n\n"
+        f"### Description\n{pr.get('body', '') or '(empty)'}\n\n"
+        f"### Diff\n```diff\n{diff[:50000]}\n```\n"
     )
 
+
+def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> str:
+    cwd = repo_path
+    subprocess.run(
+        ["git", "fetch", "origin", f"pull/{pr_number}/head:pr-{pr_number}"],
+        cwd=cwd, capture_output=True, timeout=60,
+    )
+    result = subprocess.run(
+        ["git", "diff", f"origin/{base_ref}...pr-{pr_number}"],
+        cwd=cwd, capture_output=True, text=True, timeout=60,
+    )
+    return result.stdout
+
+
+def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
+    prompt = build_review_prompt(pr, diff)
+    pr_num = pr["number"]
+    session_name = f"pr-review-{pr_num}-{uuid.uuid4().hex[:6]}"
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(prompt)
+        prompt_file = f.name
+
+    if config.review_agent == "codex":
+        cmd = f'codex --dangerously-bypass-approvals-and-sandbox "$(cat {shlex.quote(prompt_file)})"'
+    else:
+        cmd = f'claude --dangerously-skip-permissions "$(cat {shlex.quote(prompt_file)})"'
+
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", session_name, cmd],
+        timeout=10,
+    )
+
+    deadline = time.time() + config.review_timeout
+    while time.time() < deadline:
+        result = subprocess.run(
+            ["tmux", "has-session", "-t", session_name],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            break
+        time.sleep(15)
+
+    output = subprocess.run(
+        ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-200"],
+        capture_output=True, text=True,
+    )
+    review_text = output.stdout if output.returncode == 0 else "(review capture failed)"
+
+    subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
+    Path(prompt_file).unlink(missing_ok=True)
+    return review_text
+
+
+def post_review(pr_number: int, review_text: str, repo: str) -> None:
+    body = f"🤖 **自动 Review（本地 Codex）**\n\n{review_text}"
+    subprocess.run(
+        ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body", body],
+        timeout=30,
+    )
+    LOG.info("Posted review to PR #%d", pr_number)
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
 
 class ReviewOrchestrator:
     def __init__(self, config: ReviewBotConfig) -> None:
-        self.config = config
-        self._workers: dict[int, ReviewWorker] = {}
+        self._config = config
         self._lock = threading.Lock()
+        self._active: dict[int, threading.Thread] = {}
 
     def submit_review(self, payload: dict[str, Any]) -> None:
         pr = payload["pull_request"]
-        pr_number = int(pr["number"])
-        run_id = uuid.uuid4().hex[:8]
-        cancel_event = threading.Event()
-
-        worker = ReviewWorker(
-            thread=threading.Thread(
-                target=self._review_pr_thread,
-                args=(pr_number, payload, cancel_event, run_id),
-                daemon=True,
-            ),
-            cancel_event=cancel_event,
-            run_id=run_id,
-        )
+        pr_num = pr["number"]
+        repo = payload["repository"]["full_name"]
 
         with self._lock:
-            previous = self._workers.get(pr_number)
-            if previous:
-                LOG.info("Cancelling previous worker for PR #%s run=%s", pr_number, previous.run_id)
-                previous.cancel_event.set()
-            self._workers[pr_number] = worker
-        LOG.info("Starting worker for PR #%s run=%s", pr_number, run_id)
-        worker.thread.start()
+            old = self._active.pop(pr_num, None)
+            if old and old.is_alive():
+                LOG.info("Cancelling previous review for PR #%d", pr_num)
 
-    def _review_pr_thread(
-        self,
-        pr_number: int,
-        payload: dict[str, Any],
-        cancel_event: threading.Event,
-        run_id: str,
-    ) -> None:
-        try:
-            review_text, recommendation = run_review_pipeline(
-                config=self.config,
-                pr_number=pr_number,
-                payload=payload,
-                cancel_event=cancel_event,
-                run_id=run_id,
-            )
-            if cancel_event.is_set():
-                LOG.info("Worker finished but was cancelled for PR #%s run=%s", pr_number, run_id)
-                return
-            post_review(self.config, pr_number=pr_number, review_text=review_text, recommendation=recommendation)
-        except Exception:
-            LOG.exception("Worker failed for PR #%s run=%s", pr_number, run_id)
-        finally:
-            with self._lock:
-                current = self._workers.get(pr_number)
-                if current and current.run_id == run_id:
-                    self._workers.pop(pr_number, None)
+        def _worker() -> None:
+            try:
+                LOG.info("Starting review for PR #%d", pr_num)
+                diff = fetch_diff(
+                    self._config.repo_path,
+                    pr_num,
+                    pr["base"]["ref"],
+                    pr["head"]["ref"],
+                )
+                if not diff.strip():
+                    LOG.warning("Empty diff for PR #%d, skipping", pr_num)
+                    return
+                review = run_review(self._config, pr, diff)
+                post_review(pr_num, review, repo)
+            except Exception:
+                LOG.exception("Review failed for PR #%d", pr_num)
+
+        t = threading.Thread(target=_worker, name=f"review-pr-{pr_num}", daemon=True)
+        with self._lock:
+            self._active[pr_num] = t
+        t.start()
 
 
-def _run_git(repo_path: Path, args: list[str]) -> str:
-    result = subprocess.run(
-        ["git", *args],
-        cwd=repo_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
-    return result.stdout
-
-
-def _run_cmd(repo_path: Path, args: list[str]) -> str:
-    result = subprocess.run(args, cwd=repo_path, capture_output=True, text=True, check=False)
-    if result.returncode != 0:
-        raise RuntimeError(f"{' '.join(args)} failed: {result.stderr.strip()}")
-    return result.stdout
-
-
-def _agent_shell_command(agent: str, prompt_file: Path, output_file: Path, status_file: Path) -> str:
-    if agent == "claude":
-        runner = f"claude --print < {shlex.quote(str(prompt_file))}"
-    else:
-        runner = f"codex exec < {shlex.quote(str(prompt_file))}"
-    return (
-        f"set -euo pipefail; {runner} > {shlex.quote(str(output_file))} 2>&1; echo 0 > {shlex.quote(str(status_file))}"
-    )
-
-
-def _wait_for_agent(
-    *,
-    session_name: str,
-    status_file: Path,
-    timeout_seconds: int,
-    cancel_event: threading.Event,
-) -> None:
-    deadline = time.time() + timeout_seconds
-    while time.time() < deadline:
-        if cancel_event.is_set():
-            raise TimeoutError("review cancelled by newer event")
-        if status_file.exists():
-            return
-        time.sleep(2)
-    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
-    raise TimeoutError(f"agent timeout after {timeout_seconds}s")
-
-
-def run_review_pipeline(
-    *,
-    config: ReviewBotConfig,
-    pr_number: int,
-    payload: dict[str, Any],
-    cancel_event: threading.Event,
-    run_id: str,
-) -> tuple[str, str]:
-    repo_path = config.repo_path
-    pr = payload["pull_request"]
-    pr_title = str(pr.get("title", ""))
-    pr_body = str(pr.get("body", ""))
-    head_ref = str(pr.get("head", {}).get("ref", ""))
-    base_ref = str(pr.get("base", {}).get("ref", "main"))
-
-    LOG.info("PR #%s run=%s fetching branch", pr_number, run_id)
-    _run_git(repo_path, ["fetch", "origin", f"pull/{pr_number}/head:pr-{pr_number}"])
-
-    diff_text = _run_git(repo_path, ["diff", f"{base_ref}...pr-{pr_number}"])
-    diff_path = Path(tempfile.gettempdir()) / f"pr-{pr_number}.diff"
-    diff_path.write_text(diff_text, encoding="utf-8")
-
-    template_text = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
-    prompt = build_review_prompt(
-        template_text=template_text,
-        pr_number=pr_number,
-        pr_title=pr_title,
-        pr_body=pr_body,
-        head_ref=head_ref,
-        base_ref=base_ref,
-        diff_text=diff_text,
-    )
-
-    run_tmp_dir = Path(tempfile.gettempdir()) / f"pr-review-bot-{pr_number}-{run_id}"
-    run_tmp_dir.mkdir(parents=True, exist_ok=True)
-    prompt_file = run_tmp_dir / "prompt.md"
-    output_file = run_tmp_dir / "review.txt"
-    status_file = run_tmp_dir / "status.txt"
-    prompt_file.write_text(prompt, encoding="utf-8")
-
-    session_name = f"pr-review-{pr_number}-{run_id}"
-    command = _agent_shell_command(config.review_agent, prompt_file, output_file, status_file)
-    LOG.info("PR #%s run=%s starting tmux session=%s", pr_number, run_id, session_name)
-    tmux_result = subprocess.run(
-        ["tmux", "new-session", "-d", "-s", session_name, command],
-        cwd=repo_path,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if tmux_result.returncode != 0:
-        raise RuntimeError(f"tmux session start failed: {tmux_result.stderr.strip()}")
-
-    _wait_for_agent(
-        session_name=session_name,
-        status_file=status_file,
-        timeout_seconds=config.review_timeout,
-        cancel_event=cancel_event,
-    )
-    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
-
-    review_text = output_file.read_text(encoding="utf-8").strip()
-    if not review_text:
-        review_text = "Review agent returned empty output."
-    review_text = review_text[:65000]
-    recommendation = parse_recommendation(review_text)
-    return review_text, recommendation
-
-
-def parse_recommendation(review_text: str) -> str:
-    upper = review_text.upper()
-    if "REQUEST_CHANGES" in upper:
-        return "REQUEST_CHANGES"
-    if "APPROVE" in upper:
-        return "APPROVE"
-    return "COMMENT"
-
-
-def post_review(config: ReviewBotConfig, *, pr_number: int, review_text: str, recommendation: str) -> None:
-    repo_path = config.repo_path
-    temp_path = Path(tempfile.gettempdir()) / f"pr-{pr_number}-review-body.txt"
-    temp_path.write_text(review_text, encoding="utf-8")
-    LOG.info("Posting %s review for PR #%s", recommendation, pr_number)
-
-    if recommendation == "APPROVE":
-        _run_cmd(
-            repo_path,
-            [
-                "gh",
-                "pr",
-                "review",
-                str(pr_number),
-                "--approve",
-                "--body-file",
-                str(temp_path),
-            ],
-        )
-        return
-
-    if recommendation == "REQUEST_CHANGES":
-        _run_cmd(
-            repo_path,
-            [
-                "gh",
-                "pr",
-                "review",
-                str(pr_number),
-                "--request-changes",
-                "--body-file",
-                str(temp_path),
-            ],
-        )
-        return
-
-    _run_cmd(
-        repo_path,
-        [
-            "gh",
-            "pr",
-            "comment",
-            str(pr_number),
-            "--body-file",
-            str(temp_path),
-        ],
-    )
-
+# ---------------------------------------------------------------------------
+# ASGI app (Starlette for raw body access)
+# ---------------------------------------------------------------------------
 
 def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any:
-    try:
-        from fastapi import FastAPI, Header, HTTPException, Request
-    except ImportError as exc:
-        raise RuntimeError("FastAPI is required. Install with: uv sync --extra review-bot") from exc
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
 
-    app = FastAPI(title="Local PR Review Bot")
+    async def health(request: Request) -> JSONResponse:
+        return JSONResponse({"status": "ok"})
 
-    @app.get("/health")
-    async def health() -> dict[str, str]:
-        return {"status": "ok"}
-
-    @app.post("/webhook")
-    async def webhook(
-        request: Request,
-        x_github_event: str = Header(default=""),
-        x_hub_signature_256: str = Header(default=""),
-    ) -> dict[str, Any]:
+    async def webhook(request: Request) -> JSONResponse:
+        x_github_event = request.headers.get("x-github-event", "")
+        x_hub_signature_256 = request.headers.get("x-hub-signature-256", "")
         body = await request.body()
+
         if not verify_webhook_signature(config.webhook_secret, body, x_hub_signature_256):
-            raise HTTPException(status_code=401, detail="invalid signature")
+            return JSONResponse({"error": "invalid signature"}, status_code=401)
 
         payload = json.loads(body.decode("utf-8"))
         ok, reason = should_process_pull_request(
@@ -367,22 +245,26 @@ def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any
             config.ignore_users,
         )
         if not ok:
-            return {"accepted": False, "reason": reason}
+            return JSONResponse({"accepted": False, "reason": reason})
 
         orchestrator.submit_review(payload)
-        return {"accepted": True, "reason": "scheduled"}
+        return JSONResponse({"accepted": True, "reason": "scheduled"})
 
-    return app
+    return Starlette(routes=[
+        Route("/health", health, methods=["GET"]),
+        Route("/webhook", webhook, methods=["POST"]),
+    ])
 
 
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run local GitHub PR review webhook server.")
-    parser.add_argument("--dry-run", action="store_true", help="Validate imports/configuration and exit.")
-    return parser.parse_args()
-
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
 
 def main() -> int:
-    args = parse_args()
+    parser = argparse.ArgumentParser(description="Run local GitHub PR review webhook server.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate imports/configuration and exit.")
+    args = parser.parse_args()
+
     config = load_config()
     setup_logging(config.log_file)
     LOG.info(
@@ -402,7 +284,7 @@ def main() -> int:
     try:
         import uvicorn
     except ImportError as exc:
-        raise RuntimeError("uvicorn is required. Install with: uv sync --extra review-bot") from exc
+        raise RuntimeError("uvicorn is required: uv sync --extra review-bot") from exc
     uvicorn.run(app, host="0.0.0.0", port=config.port)
     return 0
 

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -260,6 +260,69 @@ def post_review(pr_number: int, review_text: str, repo: str, agent: str = "codex
 # Orchestrator
 # ---------------------------------------------------------------------------
 
+
+
+def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) -> None:
+    """Send notification to Feishu group chat via bot API to trigger OpenClaw processing loop."""
+    import os
+    import urllib.request
+
+    chat_id = os.environ.get("PR_REVIEW_NOTIFY_CHAT", "")
+    if not chat_id:
+        LOG.info("PR_REVIEW_NOTIFY_CHAT not set, skipping notification")
+        return
+
+    app_id = os.environ.get("FEISHU_APP_ID", "")
+    app_secret = os.environ.get("FEISHU_APP_SECRET", "")
+    if not app_id or not app_secret:
+        LOG.warning("FEISHU_APP_ID/FEISHU_APP_SECRET not set, skipping notification")
+        return
+
+    try:
+        # Get tenant access token
+        token_data = json.dumps({"app_id": app_id, "app_secret": app_secret}).encode()
+        token_req = urllib.request.Request(
+            "https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal",
+            data=token_data,
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(token_req, timeout=10) as resp:
+            token = json.loads(resp.read())["tenant_access_token"]
+
+        # Build message
+        short_review = review_text[:800]
+        msg_content = (
+            f"🔄 PR #{pr_number} 自动 Review 完成\n\n"
+            f"仓库: {repo}\n"
+            f"决策: {decision}\n\n"
+            f"请根据 review findings 修复代码并 push，触发下一轮 review。\n\n"
+            f"Review 摘要:\n{short_review}"
+        )
+
+        # Send to group chat
+        send_data = json.dumps({
+            "receive_id": chat_id,
+            "msg_type": "text",
+            "content": json.dumps({"text": msg_content}),
+        }).encode()
+        send_req = urllib.request.Request(
+            "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id",
+            data=send_data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {token}",
+            },
+        )
+        with urllib.request.urlopen(send_req, timeout=10) as resp:
+            result = json.loads(resp.read())
+            if result.get("code") == 0:
+                LOG.info("Notified OpenClaw chat %s for PR #%d", chat_id, pr_number)
+            else:
+                LOG.warning("Feishu send failed: %s", result)
+    except Exception:
+        LOG.exception("Failed to notify OpenClaw for PR #%d", pr_number)
+
+
 class ReviewOrchestrator:
     def __init__(self, config: ReviewBotConfig) -> None:
         self._config = config
@@ -290,6 +353,13 @@ class ReviewOrchestrator:
                     return
                 review = run_review(self._config, pr, diff)
                 post_review(pr_num, review, repo, self._config.review_agent)
+                # Determine decision from review text
+                decision = "COMMENT"
+                if "REQUEST_CHANGES" in review:
+                    decision = "REQUEST_CHANGES"
+                elif "APPROVE" in review and "REQUEST_CHANGES" not in review:
+                    decision = "APPROVE"
+                notify_openclaw(pr_num, review, repo, decision)
             except Exception:
                 LOG.exception("Review failed for PR #%d", pr_num)
 

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -8,7 +8,10 @@ import hashlib
 import hmac
 import json
 import logging
+import os
+import re
 import shlex
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -29,8 +32,10 @@ LOG = logging.getLogger("pr-review-bot")
 @dataclass
 class ReviewBotConfig:
     webhook_secret: str
+    allow_insecure_webhooks: bool
     repo_path: str
     review_agent: str
+    output_language: str
     review_timeout: int
     port: int
     ignore_users: set[str]
@@ -38,12 +43,25 @@ class ReviewBotConfig:
 
 
 def load_config() -> ReviewBotConfig:
-    import os
+    review_agent = (os.environ.get("PR_REVIEW_AGENT", "codex") or "").strip().lower()
+    if review_agent not in {"codex", "claude"}:
+        LOG.warning("Unsupported PR_REVIEW_AGENT=%r, fallback to codex", review_agent)
+        review_agent = "codex"
+
+    output_language = (os.environ.get("PR_REVIEW_OUTPUT_LANGUAGE", "zh") or "").strip().lower()
+    if output_language not in {"zh", "en"}:
+        LOG.warning("Unsupported PR_REVIEW_OUTPUT_LANGUAGE=%r, fallback to zh", output_language)
+        output_language = "zh"
+
+    insecure_raw = (os.environ.get("PR_REVIEW_ALLOW_INSECURE_WEBHOOKS", "") or "").strip().lower()
+    allow_insecure_webhooks = insecure_raw in {"1", "true", "yes", "on"}
 
     return ReviewBotConfig(
         webhook_secret=os.environ.get("PR_REVIEW_WEBHOOK_SECRET", ""),
+        allow_insecure_webhooks=allow_insecure_webhooks,
         repo_path=os.environ.get("PR_REVIEW_REPO_PATH", os.getcwd()),
-        review_agent=os.environ.get("PR_REVIEW_AGENT", "codex"),
+        review_agent=review_agent,
+        output_language=output_language,
         review_timeout=int(os.environ.get("PR_REVIEW_TIMEOUT", "600")),
         port=int(os.environ.get("PR_REVIEW_PORT", "3456")),
         ignore_users=set(
@@ -74,7 +92,7 @@ def setup_logging(log_file: str) -> None:
 
 def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
     if not secret:
-        return True
+        return False
     if not signature_header.startswith("sha256="):
         return False
     expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
@@ -105,7 +123,7 @@ def should_process_pull_request(
 # ---------------------------------------------------------------------------
 
 
-def build_review_prompt(pr: dict[str, Any], diff: str) -> str:
+def build_review_prompt(pr: dict[str, Any], diff: str, output_language: str) -> str:
     """Build review prompt from template, substituting PR metadata."""
     prompt_path = Path(__file__).parent.parent / "prompts" / "pr-review-prompt.md"
     template = (
@@ -125,17 +143,29 @@ def build_review_prompt(pr: dict[str, Any], diff: str) -> str:
         pr_body=pr.get("body", "") or "(empty)",
         head_ref=pr.get("head", {}).get("ref", "unknown"),
         base_ref=pr.get("base", {}).get("ref", "main"),
+        output_language=output_language,
         diff_text=truncated_diff,
     )
 
 
 def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> str:
+    _ = head_ref
     cwd = repo_path
     subprocess.run(
-        ["git", "fetch", "origin", f"pull/{pr_number}/head:pr-{pr_number}"],
+        ["git", "fetch", "origin", f"+pull/{pr_number}/head:pr-{pr_number}"],
         cwd=cwd,
         capture_output=True,
+        text=True,
         timeout=60,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "fetch", "origin", base_ref],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=60,
+        check=True,
     )
     result = subprocess.run(
         ["git", "diff", f"origin/{base_ref}...pr-{pr_number}"],
@@ -143,13 +173,60 @@ def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> 
         capture_output=True,
         text=True,
         timeout=60,
+        check=True,
     )
     return result.stdout
 
 
-def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
+def _agent_shell_command(agent: str, agent_task: str, output_file: Path, status_file: Path) -> str:
+    if agent == "claude":
+        runner = f"claude --dangerously-skip-permissions {shlex.quote(agent_task)}"
+    else:
+        runner = f"codex --dangerously-bypass-approvals-and-sandbox {shlex.quote(agent_task)}"
+    return (
+        "set -uo pipefail; "
+        f"{runner} > {shlex.quote(str(output_file))} 2>&1; "
+        f"status=$?; printf '%s' \"$status\" > {shlex.quote(str(status_file))}; "
+        'exit "$status"'
+    )
+
+
+def _wait_for_agent(
+    *,
+    session_name: str,
+    status_file: Path,
+    timeout_seconds: int,
+    cancel_event: threading.Event,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if cancel_event.is_set():
+            subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
+            raise TimeoutError("review cancelled by newer event")
+        if status_file.exists():
+            status = status_file.read_text(encoding="utf-8").strip() or "1"
+            if status != "0":
+                raise RuntimeError(f"agent exited with status {status}")
+            return
+        tmux_state = subprocess.run(
+            ["tmux", "has-session", "-t", session_name],
+            capture_output=True,
+        )
+        if tmux_state.returncode != 0:
+            raise RuntimeError("agent session terminated unexpectedly before reporting status")
+        time.sleep(2)
+    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
+    raise TimeoutError(f"agent timeout after {timeout_seconds}s")
+
+
+def run_review(
+    config: ReviewBotConfig,
+    pr: dict[str, Any],
+    diff: str,
+    cancel_event: threading.Event,
+) -> str:
     """Run Codex/Claude to review a PR. Agent posts review directly via gh CLI."""
-    prompt = build_review_prompt(pr, diff)
+    prompt = build_review_prompt(pr, diff, config.output_language)
     pr_num = pr["number"]
     run_id = uuid.uuid4().hex[:6]
     session_name = f"pr-review-{pr_num}-{run_id}"
@@ -157,6 +234,8 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
     # Write prompt to temp file (avoid shell arg length limits)
     work_dir = Path(tempfile.mkdtemp(prefix=f"pr-review-{pr_num}-"))
     prompt_file = work_dir / "prompt.md"
+    output_file = work_dir / "agent-output.log"
+    status_file = work_dir / "agent-status.txt"
     prompt_file.write_text(prompt, encoding="utf-8")
 
     # Agent reads prompt and posts review directly via gh CLI
@@ -167,58 +246,52 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
         f"The PR number is {pr_num}."
     )
 
-    if config.review_agent == "codex":
-        cmd = f"codex --dangerously-bypass-approvals-and-sandbox {shlex.quote(agent_task)}"
-    else:
-        cmd = f"claude --dangerously-skip-permissions {shlex.quote(agent_task)}"
+    cmd = _agent_shell_command(config.review_agent, agent_task, output_file, status_file)
 
     subprocess.run(
         ["tmux", "new-session", "-d", "-s", session_name, cmd],
         cwd=str(config.repo_path),
         timeout=10,
+        check=True,
     )
 
-    # Wait for agent to finish
-    deadline = time.time() + config.review_timeout
-    while time.time() < deadline:
-        result = subprocess.run(
-            ["tmux", "has-session", "-t", session_name],
-            capture_output=True,
+    try:
+        _wait_for_agent(
+            session_name=session_name,
+            status_file=status_file,
+            timeout_seconds=config.review_timeout,
+            cancel_event=cancel_event,
         )
-        if result.returncode != 0:
-            break
-        time.sleep(15)
-
-    timed_out = time.time() >= deadline
-
-    # Capture tmux output to extract decision for notification
-    output = subprocess.run(
-        ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-500"],
-        capture_output=True,
-        text=True,
-    )
-    raw_output = output.stdout if output.returncode == 0 else ""
-
-    # Cleanup
-    subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
-    import shutil
-
-    shutil.rmtree(work_dir, ignore_errors=True)
-
-    if timed_out:
+        raw_output = output_file.read_text(encoding="utf-8") if output_file.exists() else ""
+        LOG.info("Agent finished review for PR #%d", pr_num)
+        return raw_output
+    except TimeoutError:
+        if cancel_event.is_set():
+            raise
         LOG.warning("Review timed out for PR #%d", pr_num)
         return "(review timed out)"
-
-    LOG.info("Agent finished review for PR #%d", pr_num)
-    return raw_output
+    finally:
+        subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
+        shutil.rmtree(work_dir, ignore_errors=True)
 
 
 def extract_decision(raw_output: str) -> str:
     """Extract review decision from agent output."""
-    if "request-changes" in raw_output.lower() or "REQUEST_CHANGES" in raw_output:
+    for line in raw_output.splitlines():
+        normalized = line.strip().upper()
+        if normalized.startswith("DECISION:") or normalized.startswith("SUGGESTED DECISION:"):
+            if re.search(r"\bREQUEST_CHANGES\b", normalized):
+                return "REQUEST_CHANGES"
+            if re.search(r"\bAPPROVE\b", normalized):
+                return "APPROVE"
+            if re.search(r"\bCOMMENT\b", normalized):
+                return "COMMENT"
+    if re.search(r"\bgh\s+pr\s+review\b[^\n]*\s--request-changes\b", raw_output, re.IGNORECASE):
         return "REQUEST_CHANGES"
-    if "--approve" in raw_output.lower() or "APPROVE" in raw_output:
+    if re.search(r"\bgh\s+pr\s+review\b[^\n]*\s--approve\b", raw_output, re.IGNORECASE):
         return "APPROVE"
+    if re.search(r"\bgh\s+pr\s+comment\b", raw_output, re.IGNORECASE):
+        return "COMMENT"
     return "COMMENT"
 
 
@@ -252,7 +325,15 @@ def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) 
             headers={"Content-Type": "application/json"},
         )
         with urllib.request.urlopen(token_req, timeout=10) as resp:
-            token = json.loads(resp.read())["tenant_access_token"]
+            raw_token_body = resp.read().decode("utf-8")
+            if resp.getcode() != 200:
+                LOG.warning("Feishu token request HTTP %s: %s", resp.getcode(), raw_token_body)
+                return
+            token_resp = json.loads(raw_token_body)
+            token = token_resp.get("tenant_access_token")
+            if token_resp.get("code") != 0 or not token:
+                LOG.warning("Feishu token request failed: %s", raw_token_body)
+                return
 
         # Build message
         short_review = review_text[:800]
@@ -295,6 +376,7 @@ class ReviewOrchestrator:
         self._config = config
         self._lock = threading.Lock()
         self._active: dict[int, threading.Thread] = {}
+        self._cancel: dict[int, threading.Event] = {}
 
     def submit_review(self, payload: dict[str, Any]) -> None:
         pr = payload["pull_request"]
@@ -303,8 +385,17 @@ class ReviewOrchestrator:
 
         with self._lock:
             old = self._active.pop(pr_num, None)
+            old_cancel = self._cancel.pop(pr_num, None)
             if old and old.is_alive():
                 LOG.info("Cancelling previous review for PR #%d", pr_num)
+                if old_cancel:
+                    old_cancel.set()
+        if old and old.is_alive():
+            old.join(timeout=5)
+            if old.is_alive():
+                LOG.warning("Previous review thread still running for PR #%d", pr_num)
+
+        cancel_event = threading.Event()
 
         def _worker() -> None:
             try:
@@ -318,16 +409,27 @@ class ReviewOrchestrator:
                 if not diff.strip():
                     LOG.warning("Empty diff for PR #%d, skipping", pr_num)
                     return
-                raw_output = run_review(self._config, pr, diff)
+                raw_output = run_review(self._config, pr, diff, cancel_event)
+                if cancel_event.is_set():
+                    LOG.info("Skipping notification for cancelled review PR #%d", pr_num)
+                    return
                 decision = extract_decision(raw_output)
                 LOG.info("Review decision for PR #%d: %s", pr_num, decision)
                 notify_openclaw(pr_num, raw_output, repo, decision)
+            except TimeoutError:
+                LOG.info("Review cancelled for PR #%d", pr_num)
             except Exception:
                 LOG.exception("Review failed for PR #%d", pr_num)
+            finally:
+                with self._lock:
+                    if self._active.get(pr_num) is threading.current_thread():
+                        self._active.pop(pr_num, None)
+                        self._cancel.pop(pr_num, None)
 
         t = threading.Thread(target=_worker, name=f"review-pr-{pr_num}", daemon=True)
         with self._lock:
             self._active[pr_num] = t
+            self._cancel[pr_num] = cancel_event
         t.start()
 
 
@@ -349,7 +451,10 @@ def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any
         x_github_event = request.headers.get("x-github-event", "")
         x_hub_signature_256 = request.headers.get("x-hub-signature-256", "")
         body = await request.body()
-        payload = json.loads(body.decode("utf-8"))
+        try:
+            payload = json.loads(body.decode("utf-8"))
+        except json.JSONDecodeError:
+            return JSONResponse({"error": "invalid json payload"}, status_code=400)
 
         # smee-client wraps the payload: {"payload": "<json string>", "x-github-event": "..."}
         if "payload" in payload and isinstance(payload.get("payload"), str):
@@ -357,12 +462,19 @@ def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any
             inner_sig = payload.get("x-hub-signature-256", "")
             inner_event = payload.get("x-github-event", x_github_event)
             inner_body = payload["payload"].encode("utf-8")
-            if inner_sig and config.webhook_secret:
+            if config.webhook_secret and not inner_sig:
+                return JSONResponse({"error": "missing signature"}, status_code=401)
+            if config.webhook_secret:
                 if not verify_webhook_signature(config.webhook_secret, inner_body, inner_sig):
                     return JSONResponse({"error": "invalid signature"}, status_code=401)
             x_github_event = inner_event
-            payload = json.loads(payload["payload"])
-        elif x_hub_signature_256 and config.webhook_secret:
+            try:
+                payload = json.loads(payload["payload"])
+            except json.JSONDecodeError:
+                return JSONResponse({"error": "invalid json payload"}, status_code=400)
+        elif config.webhook_secret:
+            if not x_hub_signature_256:
+                return JSONResponse({"error": "missing signature"}, status_code=401)
             if not verify_webhook_signature(config.webhook_secret, body, x_hub_signature_256):
                 return JSONResponse({"error": "invalid signature"}, status_code=401)
         ok, reason = should_process_pull_request(
@@ -396,12 +508,16 @@ def main() -> int:
 
     config = load_config()
     setup_logging(config.log_file)
+    if not args.dry_run and not config.webhook_secret and not config.allow_insecure_webhooks:
+        raise RuntimeError("PR_REVIEW_WEBHOOK_SECRET is required unless PR_REVIEW_ALLOW_INSECURE_WEBHOOKS is set")
     LOG.info(
-        "Loaded config: agent=%s repo=%s timeout=%ss port=%s",
+        "Loaded config: agent=%s repo=%s timeout=%ss port=%s output_language=%s insecure_webhooks=%s",
         config.review_agent,
         config.repo_path,
         config.review_timeout,
         config.port,
+        config.output_language,
+        config.allow_insecure_webhooks,
     )
 
     if args.dry_run:

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -25,6 +25,7 @@ LOG = logging.getLogger("pr-review-bot")
 # Config
 # ---------------------------------------------------------------------------
 
+
 @dataclass
 class ReviewBotConfig:
     webhook_secret: str
@@ -38,6 +39,7 @@ class ReviewBotConfig:
 
 def load_config() -> ReviewBotConfig:
     import os
+
     return ReviewBotConfig(
         webhook_secret=os.environ.get("PR_REVIEW_WEBHOOK_SECRET", ""),
         repo_path=os.environ.get("PR_REVIEW_REPO_PATH", os.getcwd()),
@@ -68,6 +70,7 @@ def setup_logging(log_file: str) -> None:
 # ---------------------------------------------------------------------------
 # Webhook helpers
 # ---------------------------------------------------------------------------
+
 
 def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
     if not secret:
@@ -101,11 +104,14 @@ def should_process_pull_request(
 # Review logic
 # ---------------------------------------------------------------------------
 
+
 def build_review_prompt(pr: dict[str, Any], diff: str) -> str:
     """Build review prompt from template, substituting PR metadata."""
     prompt_path = Path(__file__).parent.parent / "prompts" / "pr-review-prompt.md"
-    template = prompt_path.read_text() if prompt_path.exists() else (
-        "Review PR #{pr_number}: {pr_title}\n{pr_body}\nDiff:\n{diff_text}"
+    template = (
+        prompt_path.read_text()
+        if prompt_path.exists()
+        else ("Review PR #{pr_number}: {pr_title}\n{pr_body}\nDiff:\n{diff_text}")
     )
     # Truncate diff to avoid overwhelming the agent
     max_diff = 80000
@@ -127,11 +133,16 @@ def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> 
     cwd = repo_path
     subprocess.run(
         ["git", "fetch", "origin", f"pull/{pr_number}/head:pr-{pr_number}"],
-        cwd=cwd, capture_output=True, timeout=60,
+        cwd=cwd,
+        capture_output=True,
+        timeout=60,
     )
     result = subprocess.run(
         ["git", "diff", f"origin/{base_ref}...pr-{pr_number}"],
-        cwd=cwd, capture_output=True, text=True, timeout=60,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
     return result.stdout
 
@@ -183,13 +194,15 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
     # Capture tmux output to extract decision for notification
     output = subprocess.run(
         ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-500"],
-        capture_output=True, text=True,
+        capture_output=True,
+        text=True,
     )
     raw_output = output.stdout if output.returncode == 0 else ""
 
     # Cleanup
     subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
     import shutil
+
     shutil.rmtree(work_dir, ignore_errors=True)
 
     if timed_out:
@@ -198,7 +211,6 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
 
     LOG.info("Agent finished review for PR #%d", pr_num)
     return raw_output
-
 
 
 def extract_decision(raw_output: str) -> str:
@@ -213,7 +225,6 @@ def extract_decision(raw_output: str) -> str:
 # ---------------------------------------------------------------------------
 # Orchestrator
 # ---------------------------------------------------------------------------
-
 
 
 def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) -> None:
@@ -254,11 +265,13 @@ def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) 
         )
 
         # Send to group chat
-        send_data = json.dumps({
-            "receive_id": chat_id,
-            "msg_type": "text",
-            "content": json.dumps({"text": msg_content}),
-        }).encode()
+        send_data = json.dumps(
+            {
+                "receive_id": chat_id,
+                "msg_type": "text",
+                "content": json.dumps({"text": msg_content}),
+            }
+        ).encode()
         send_req = urllib.request.Request(
             "https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=chat_id",
             data=send_data,
@@ -322,6 +335,7 @@ class ReviewOrchestrator:
 # ASGI app (Starlette for raw body access)
 # ---------------------------------------------------------------------------
 
+
 def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any:
     from starlette.applications import Starlette
     from starlette.requests import Request
@@ -362,15 +376,18 @@ def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any
         orchestrator.submit_review(payload)
         return JSONResponse({"accepted": True, "reason": "scheduled"})
 
-    return Starlette(routes=[
-        Route("/health", health, methods=["GET"]),
-        Route("/webhook", webhook, methods=["POST"]),
-    ])
+    return Starlette(
+        routes=[
+            Route("/health", health, methods=["GET"]),
+            Route("/webhook", webhook, methods=["POST"]),
+        ]
+    )
 
 
 # ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
+
 
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run local GitHub PR review webhook server.")

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -8,7 +8,6 @@ import hashlib
 import hmac
 import json
 import logging
-import os
 import re
 import shlex
 import shutil
@@ -17,66 +16,15 @@ import tempfile
 import threading
 import time
 import uuid
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from scripts.pr_review_bot_config import ReviewBotConfig, load_config
 
 LOG = logging.getLogger("pr-review-bot")
 
 
-# ---------------------------------------------------------------------------
-# Config
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class ReviewBotConfig:
-    webhook_secret: str
-    allow_insecure_webhooks: bool
-    repo_path: str
-    review_agent: str
-    output_language: str
-    review_timeout: int
-    port: int
-    ignore_users: set[str]
-    log_file: str
-
-
-def load_config() -> ReviewBotConfig:
-    review_agent = (os.environ.get("PR_REVIEW_AGENT", "codex") or "").strip().lower()
-    if review_agent not in {"codex", "claude"}:
-        LOG.warning("Unsupported PR_REVIEW_AGENT=%r, fallback to codex", review_agent)
-        review_agent = "codex"
-
-    output_language = (os.environ.get("PR_REVIEW_OUTPUT_LANGUAGE", "zh") or "").strip().lower()
-    if output_language not in {"zh", "en"}:
-        LOG.warning("Unsupported PR_REVIEW_OUTPUT_LANGUAGE=%r, fallback to zh", output_language)
-        output_language = "zh"
-
-    insecure_raw = (os.environ.get("PR_REVIEW_ALLOW_INSECURE_WEBHOOKS", "") or "").strip().lower()
-    allow_insecure_webhooks = insecure_raw in {"1", "true", "yes", "on"}
-
-    return ReviewBotConfig(
-        webhook_secret=os.environ.get("PR_REVIEW_WEBHOOK_SECRET", ""),
-        allow_insecure_webhooks=allow_insecure_webhooks,
-        repo_path=os.environ.get("PR_REVIEW_REPO_PATH", os.getcwd()),
-        review_agent=review_agent,
-        output_language=output_language,
-        review_timeout=int(os.environ.get("PR_REVIEW_TIMEOUT", "600")),
-        port=int(os.environ.get("PR_REVIEW_PORT", "3456")),
-        ignore_users=set(
-            u.strip()
-            for u in os.environ.get(
-                "PR_REVIEW_IGNORE_USERS",
-                "github-actions[bot],dependabot[bot]",
-            ).split(",")
-            if u.strip()
-        ),
-        log_file=os.environ.get("PR_REVIEW_LOG_FILE", "/tmp/pr-review-bot.log"),
-    )
-
-
-def setup_logging(log_file: str) -> None:
+def setup_logging(log_file: Path) -> None:
     fmt = "%(asctime)s %(levelname)s %(message)s"
     logging.basicConfig(level=logging.INFO, format=fmt)
     if log_file:
@@ -93,7 +41,7 @@ def setup_logging(log_file: str) -> None:
 def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
     if not secret:
         return False
-    if not signature_header.startswith("sha256="):
+    if not signature_header or not signature_header.startswith("sha256="):
         return False
     expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
     return hmac.compare_digest(expected, signature_header)
@@ -102,7 +50,7 @@ def verify_webhook_signature(secret: str, body: bytes, signature_header: str) ->
 def should_process_pull_request(
     event: str,
     payload: dict[str, Any],
-    ignore_users: set[str],
+    ignore_users: frozenset[str],
 ) -> tuple[bool, str]:
     if event != "pull_request":
         return False, f"event={event} not pull_request"
@@ -148,9 +96,8 @@ def build_review_prompt(pr: dict[str, Any], diff: str, output_language: str) -> 
     )
 
 
-def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> str:
-    _ = head_ref
-    cwd = repo_path
+def fetch_diff(repo_path: Path, pr_number: int, base_ref: str) -> str:
+    cwd = str(repo_path)
     subprocess.run(
         ["git", "fetch", "origin", f"+pull/{pr_number}/head:pr-{pr_number}"],
         cwd=cwd,
@@ -329,7 +276,11 @@ def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) 
             if resp.getcode() != 200:
                 LOG.warning("Feishu token request HTTP %s: %s", resp.getcode(), raw_token_body)
                 return
-            token_resp = json.loads(raw_token_body)
+            try:
+                token_resp = json.loads(raw_token_body)
+            except json.JSONDecodeError:
+                LOG.warning("Feishu token response is not valid JSON: %s", raw_token_body)
+                return
             token = token_resp.get("tenant_access_token")
             if token_resp.get("code") != 0 or not token:
                 LOG.warning("Feishu token request failed: %s", raw_token_body)
@@ -338,11 +289,11 @@ def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) 
         # Build message
         short_review = review_text[:800]
         msg_content = (
-            f"🔄 PR #{pr_number} 自动 Review 完成\n\n"
-            f"仓库: {repo}\n"
-            f"决策: {decision}\n\n"
-            f"请根据 review findings 修复代码并 push，触发下一轮 review。\n\n"
-            f"Review 摘要:\n{short_review}"
+            f"PR #{pr_number} automated review completed.\n\n"
+            f"Repository: {repo}\n"
+            f"Decision: {decision}\n\n"
+            "Please apply fixes from the review findings and push updates for the next cycle.\n\n"
+            f"Review summary:\n{short_review}"
         )
 
         # Send to group chat
@@ -362,7 +313,12 @@ def notify_openclaw(pr_number: int, review_text: str, repo: str, decision: str) 
             },
         )
         with urllib.request.urlopen(send_req, timeout=10) as resp:
-            result = json.loads(resp.read())
+            raw_send_body = resp.read().decode("utf-8")
+            try:
+                result = json.loads(raw_send_body)
+            except json.JSONDecodeError:
+                LOG.warning("Feishu send response is not valid JSON: %s", raw_send_body)
+                return
             if result.get("code") == 0:
                 LOG.info("Notified OpenClaw chat %s for PR #%d", chat_id, pr_number)
             else:
@@ -404,7 +360,6 @@ class ReviewOrchestrator:
                     self._config.repo_path,
                     pr_num,
                     pr["base"]["ref"],
-                    pr["head"]["ref"],
                 )
                 if not diff.strip():
                     LOG.warning("Empty diff for PR #%d, skipping", pr_num)

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Webhook-driven local PR review bot."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import logging
+import shlex
+import subprocess
+import tempfile
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+try:
+    from scripts.pr_review_bot_config import ReviewBotConfig, load_config
+except ModuleNotFoundError:  # pragma: no cover - direct script execution fallback
+    from pr_review_bot_config import ReviewBotConfig, load_config
+
+LOG = logging.getLogger("pr_review_bot")
+PROMPT_TEMPLATE_PATH = Path(__file__).resolve().parent.parent / "prompts" / "pr-review-prompt.md"
+
+
+@dataclass
+class ReviewWorker:
+    thread: threading.Thread
+    cancel_event: threading.Event
+    run_id: str
+
+
+def setup_logging(log_file: Path) -> None:
+    LOG.setLevel(logging.INFO)
+    if LOG.handlers:
+        return
+
+    formatter = logging.Formatter("%(asctime)s %(levelname)s %(message)s")
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(formatter)
+
+    file_handler = logging.FileHandler(log_file, encoding="utf-8")
+    file_handler.setFormatter(formatter)
+
+    LOG.addHandler(stream_handler)
+    LOG.addHandler(file_handler)
+
+
+def verify_webhook_signature(secret: str, body: bytes, signature_header: str) -> bool:
+    if not secret:
+        return True
+    if not signature_header.startswith("sha256="):
+        return False
+    provided = signature_header.split("=", 1)[1]
+    expected = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, provided)
+
+
+def should_process_pull_request(
+    event_name: str,
+    payload: dict[str, Any],
+    ignore_users: set[str] | frozenset[str],
+) -> tuple[bool, str]:
+    if event_name != "pull_request":
+        return False, "not a pull_request event"
+
+    action = payload.get("action")
+    if action not in {"opened", "synchronize"}:
+        return False, f"ignored action={action}"
+
+    sender_login = str(payload.get("sender", {}).get("login", ""))
+    if sender_login in ignore_users or sender_login.endswith("[bot]"):
+        return False, f"ignored sender={sender_login}"
+
+    pr = payload.get("pull_request")
+    if not isinstance(pr, dict) or "number" not in pr:
+        return False, "missing pull_request payload"
+    return True, "accepted"
+
+
+def build_review_prompt(
+    *,
+    template_text: str,
+    pr_number: int,
+    pr_title: str,
+    pr_body: str,
+    head_ref: str,
+    base_ref: str,
+    diff_text: str,
+) -> str:
+    safe_body = pr_body.strip() or "(No PR description)"
+    safe_diff = diff_text.strip() or "(No diff content)"
+    return template_text.format(
+        pr_number=pr_number,
+        pr_title=pr_title.strip(),
+        pr_body=safe_body,
+        head_ref=head_ref.strip(),
+        base_ref=base_ref.strip(),
+        diff_text=safe_diff,
+    )
+
+
+class ReviewOrchestrator:
+    def __init__(self, config: ReviewBotConfig) -> None:
+        self.config = config
+        self._workers: dict[int, ReviewWorker] = {}
+        self._lock = threading.Lock()
+
+    def submit_review(self, payload: dict[str, Any]) -> None:
+        pr = payload["pull_request"]
+        pr_number = int(pr["number"])
+        run_id = uuid.uuid4().hex[:8]
+        cancel_event = threading.Event()
+
+        worker = ReviewWorker(
+            thread=threading.Thread(
+                target=self._review_pr_thread,
+                args=(pr_number, payload, cancel_event, run_id),
+                daemon=True,
+            ),
+            cancel_event=cancel_event,
+            run_id=run_id,
+        )
+
+        with self._lock:
+            previous = self._workers.get(pr_number)
+            if previous:
+                LOG.info("Cancelling previous worker for PR #%s run=%s", pr_number, previous.run_id)
+                previous.cancel_event.set()
+            self._workers[pr_number] = worker
+        LOG.info("Starting worker for PR #%s run=%s", pr_number, run_id)
+        worker.thread.start()
+
+    def _review_pr_thread(
+        self,
+        pr_number: int,
+        payload: dict[str, Any],
+        cancel_event: threading.Event,
+        run_id: str,
+    ) -> None:
+        try:
+            review_text, recommendation = run_review_pipeline(
+                config=self.config,
+                pr_number=pr_number,
+                payload=payload,
+                cancel_event=cancel_event,
+                run_id=run_id,
+            )
+            if cancel_event.is_set():
+                LOG.info("Worker finished but was cancelled for PR #%s run=%s", pr_number, run_id)
+                return
+            post_review(self.config, pr_number=pr_number, review_text=review_text, recommendation=recommendation)
+        except Exception:
+            LOG.exception("Worker failed for PR #%s run=%s", pr_number, run_id)
+        finally:
+            with self._lock:
+                current = self._workers.get(pr_number)
+                if current and current.run_id == run_id:
+                    self._workers.pop(pr_number, None)
+
+
+def _run_git(repo_path: Path, args: list[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _run_cmd(repo_path: Path, args: list[str]) -> str:
+    result = subprocess.run(args, cwd=repo_path, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(f"{' '.join(args)} failed: {result.stderr.strip()}")
+    return result.stdout
+
+
+def _agent_shell_command(agent: str, prompt_file: Path, output_file: Path, status_file: Path) -> str:
+    if agent == "claude":
+        runner = f"claude --print < {shlex.quote(str(prompt_file))}"
+    else:
+        runner = f"codex exec < {shlex.quote(str(prompt_file))}"
+    return (
+        f"set -euo pipefail; {runner} > {shlex.quote(str(output_file))} 2>&1; echo 0 > {shlex.quote(str(status_file))}"
+    )
+
+
+def _wait_for_agent(
+    *,
+    session_name: str,
+    status_file: Path,
+    timeout_seconds: int,
+    cancel_event: threading.Event,
+) -> None:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        if cancel_event.is_set():
+            raise TimeoutError("review cancelled by newer event")
+        if status_file.exists():
+            return
+        time.sleep(2)
+    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
+    raise TimeoutError(f"agent timeout after {timeout_seconds}s")
+
+
+def run_review_pipeline(
+    *,
+    config: ReviewBotConfig,
+    pr_number: int,
+    payload: dict[str, Any],
+    cancel_event: threading.Event,
+    run_id: str,
+) -> tuple[str, str]:
+    repo_path = config.repo_path
+    pr = payload["pull_request"]
+    pr_title = str(pr.get("title", ""))
+    pr_body = str(pr.get("body", ""))
+    head_ref = str(pr.get("head", {}).get("ref", ""))
+    base_ref = str(pr.get("base", {}).get("ref", "main"))
+
+    LOG.info("PR #%s run=%s fetching branch", pr_number, run_id)
+    _run_git(repo_path, ["fetch", "origin", f"pull/{pr_number}/head:pr-{pr_number}"])
+
+    diff_text = _run_git(repo_path, ["diff", f"{base_ref}...pr-{pr_number}"])
+    diff_path = Path(tempfile.gettempdir()) / f"pr-{pr_number}.diff"
+    diff_path.write_text(diff_text, encoding="utf-8")
+
+    template_text = PROMPT_TEMPLATE_PATH.read_text(encoding="utf-8")
+    prompt = build_review_prompt(
+        template_text=template_text,
+        pr_number=pr_number,
+        pr_title=pr_title,
+        pr_body=pr_body,
+        head_ref=head_ref,
+        base_ref=base_ref,
+        diff_text=diff_text,
+    )
+
+    run_tmp_dir = Path(tempfile.gettempdir()) / f"pr-review-bot-{pr_number}-{run_id}"
+    run_tmp_dir.mkdir(parents=True, exist_ok=True)
+    prompt_file = run_tmp_dir / "prompt.md"
+    output_file = run_tmp_dir / "review.txt"
+    status_file = run_tmp_dir / "status.txt"
+    prompt_file.write_text(prompt, encoding="utf-8")
+
+    session_name = f"pr-review-{pr_number}-{run_id}"
+    command = _agent_shell_command(config.review_agent, prompt_file, output_file, status_file)
+    LOG.info("PR #%s run=%s starting tmux session=%s", pr_number, run_id, session_name)
+    tmux_result = subprocess.run(
+        ["tmux", "new-session", "-d", "-s", session_name, command],
+        cwd=repo_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if tmux_result.returncode != 0:
+        raise RuntimeError(f"tmux session start failed: {tmux_result.stderr.strip()}")
+
+    _wait_for_agent(
+        session_name=session_name,
+        status_file=status_file,
+        timeout_seconds=config.review_timeout,
+        cancel_event=cancel_event,
+    )
+    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, capture_output=True)
+
+    review_text = output_file.read_text(encoding="utf-8").strip()
+    if not review_text:
+        review_text = "Review agent returned empty output."
+    review_text = review_text[:65000]
+    recommendation = parse_recommendation(review_text)
+    return review_text, recommendation
+
+
+def parse_recommendation(review_text: str) -> str:
+    upper = review_text.upper()
+    if "REQUEST_CHANGES" in upper:
+        return "REQUEST_CHANGES"
+    if "APPROVE" in upper:
+        return "APPROVE"
+    return "COMMENT"
+
+
+def post_review(config: ReviewBotConfig, *, pr_number: int, review_text: str, recommendation: str) -> None:
+    repo_path = config.repo_path
+    temp_path = Path(tempfile.gettempdir()) / f"pr-{pr_number}-review-body.txt"
+    temp_path.write_text(review_text, encoding="utf-8")
+    LOG.info("Posting %s review for PR #%s", recommendation, pr_number)
+
+    if recommendation == "APPROVE":
+        _run_cmd(
+            repo_path,
+            [
+                "gh",
+                "pr",
+                "review",
+                str(pr_number),
+                "--approve",
+                "--body-file",
+                str(temp_path),
+            ],
+        )
+        return
+
+    if recommendation == "REQUEST_CHANGES":
+        _run_cmd(
+            repo_path,
+            [
+                "gh",
+                "pr",
+                "review",
+                str(pr_number),
+                "--request-changes",
+                "--body-file",
+                str(temp_path),
+            ],
+        )
+        return
+
+    _run_cmd(
+        repo_path,
+        [
+            "gh",
+            "pr",
+            "comment",
+            str(pr_number),
+            "--body-file",
+            str(temp_path),
+        ],
+    )
+
+
+def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any:
+    try:
+        from fastapi import FastAPI, Header, HTTPException, Request
+    except ImportError as exc:
+        raise RuntimeError("FastAPI is required. Install with: uv sync --extra review-bot") from exc
+
+    app = FastAPI(title="Local PR Review Bot")
+
+    @app.get("/health")
+    async def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/webhook")
+    async def webhook(
+        request: Request,
+        x_github_event: str = Header(default=""),
+        x_hub_signature_256: str = Header(default=""),
+    ) -> dict[str, Any]:
+        body = await request.body()
+        if not verify_webhook_signature(config.webhook_secret, body, x_hub_signature_256):
+            raise HTTPException(status_code=401, detail="invalid signature")
+
+        payload = json.loads(body.decode("utf-8"))
+        ok, reason = should_process_pull_request(
+            x_github_event,
+            payload,
+            config.ignore_users,
+        )
+        if not ok:
+            return {"accepted": False, "reason": reason}
+
+        orchestrator.submit_review(payload)
+        return {"accepted": True, "reason": "scheduled"}
+
+    return app
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run local GitHub PR review webhook server.")
+    parser.add_argument("--dry-run", action="store_true", help="Validate imports/configuration and exit.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = load_config()
+    setup_logging(config.log_file)
+    LOG.info(
+        "Loaded config: agent=%s repo=%s timeout=%ss port=%s",
+        config.review_agent,
+        config.repo_path,
+        config.review_timeout,
+        config.port,
+    )
+
+    if args.dry_run:
+        LOG.info("Dry run OK")
+        return 0
+
+    orchestrator = ReviewOrchestrator(config)
+    app = create_app(config, orchestrator)
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise RuntimeError("uvicorn is required. Install with: uv sync --extra review-bot") from exc
+    uvicorn.run(app, host="0.0.0.0", port=config.port)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -102,13 +102,24 @@ def should_process_pull_request(
 # ---------------------------------------------------------------------------
 
 def build_review_prompt(pr: dict[str, Any], diff: str) -> str:
+    """Build review prompt from template, substituting PR metadata."""
     prompt_path = Path(__file__).parent.parent / "prompts" / "pr-review-prompt.md"
-    template = prompt_path.read_text() if prompt_path.exists() else "Review this PR diff."
-    return (
-        f"{template}\n\n"
-        f"## PR #{pr['number']}: {pr['title']}\n\n"
-        f"### Description\n{pr.get('body', '') or '(empty)'}\n\n"
-        f"### Diff\n```diff\n{diff[:50000]}\n```\n"
+    template = prompt_path.read_text() if prompt_path.exists() else (
+        "Review PR #{pr_number}: {pr_title}\n{pr_body}\nDiff:\n{diff_text}"
+    )
+    # Truncate diff to avoid overwhelming the agent
+    max_diff = 80000
+    truncated_diff = diff[:max_diff]
+    if len(diff) > max_diff:
+        truncated_diff += f"\n\n... (diff truncated, {len(diff) - max_diff} chars omitted)"
+
+    return template.format(
+        pr_number=pr["number"],
+        pr_title=pr["title"],
+        pr_body=pr.get("body", "") or "(empty)",
+        head_ref=pr.get("head", {}).get("ref", "unknown"),
+        base_ref=pr.get("base", {}).get("ref", "main"),
+        diff_text=truncated_diff,
     )
 
 
@@ -126,21 +137,35 @@ def fetch_diff(repo_path: str, pr_number: int, base_ref: str, head_ref: str) -> 
 
 
 def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
+    """Run Codex/Claude to review a PR. Writes prompt to file, captures output from file."""
     prompt = build_review_prompt(pr, diff)
     pr_num = pr["number"]
-    session_name = f"pr-review-{pr_num}-{uuid.uuid4().hex[:6]}"
+    run_id = uuid.uuid4().hex[:6]
+    session_name = f"pr-review-{pr_num}-{run_id}"
 
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
-        f.write(prompt)
-        prompt_file = f.name
+    # Write prompt and diff to temp files (avoid shell arg length limits)
+    work_dir = Path(tempfile.mkdtemp(prefix=f"pr-review-{pr_num}-"))
+    prompt_file = work_dir / "prompt.md"
+    output_file = work_dir / "review-output.md"
+    prompt_file.write_text(prompt, encoding="utf-8")
+
+    # Instruct agent to read prompt from file and write review to output file
+    agent_task = (
+        f"Read the PR review prompt from {prompt_file}. "
+        f"Follow the instructions exactly. "
+        f"After completing the review, write ONLY the final review text "
+        f"(Summary + Findings + Suggested decision) to {output_file}. "
+        f"Do not include any other content in that file."
+    )
 
     if config.review_agent == "codex":
-        cmd = f'codex --dangerously-bypass-approvals-and-sandbox "$(cat {shlex.quote(prompt_file)})"'
+        cmd = f"codex --dangerously-bypass-approvals-and-sandbox {shlex.quote(agent_task)}"
     else:
-        cmd = f'claude --dangerously-skip-permissions "$(cat {shlex.quote(prompt_file)})"'
+        cmd = f"claude --dangerously-skip-permissions {shlex.quote(agent_task)}"
 
     subprocess.run(
         ["tmux", "new-session", "-d", "-s", session_name, cmd],
+        cwd=str(config.repo_path),
         timeout=10,
     )
 
@@ -152,26 +177,83 @@ def run_review(config: ReviewBotConfig, pr: dict[str, Any], diff: str) -> str:
         )
         if result.returncode != 0:
             break
+        # Also check if output file exists (agent finished writing)
+        if output_file.exists() and output_file.stat().st_size > 100:
+            LOG.info("Review output file detected for PR #%d", pr_num)
+            time.sleep(5)  # Give agent a moment to finish writing
+            break
         time.sleep(15)
 
-    output = subprocess.run(
-        ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-200"],
-        capture_output=True, text=True,
-    )
-    review_text = output.stdout if output.returncode == 0 else "(review capture failed)"
+    # Try to read from output file first (clean output)
+    review_text = ""
+    if output_file.exists():
+        review_text = output_file.read_text(encoding="utf-8").strip()
+        LOG.info("Read review from output file (%d chars) for PR #%d", len(review_text), pr_num)
 
+    # Fallback: extract from tmux capture if output file is empty
+    if not review_text or len(review_text) < 50:
+        LOG.warning("Output file empty/missing for PR #%d, falling back to tmux capture", pr_num)
+        output = subprocess.run(
+            ["tmux", "capture-pane", "-t", session_name, "-p", "-S", "-500"],
+            capture_output=True, text=True,
+        )
+        if output.returncode == 0:
+            review_text = _extract_review_from_tmux(output.stdout)
+
+    # Cleanup
     subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
-    Path(prompt_file).unlink(missing_ok=True)
-    return review_text
+    import shutil
+    shutil.rmtree(work_dir, ignore_errors=True)
+
+    return review_text or "(review 输出为空，请检查 agent 日志)"
 
 
-def post_review(pr_number: int, review_text: str, repo: str) -> None:
-    body = f"🤖 **自动 Review（本地 Codex）**\n\n{review_text}"
-    subprocess.run(
-        ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body", body],
-        timeout=30,
+def _extract_review_from_tmux(raw: str) -> str:
+    """Extract the review section from raw tmux output."""
+    lines = raw.split("\n")
+    # Look for Summary section start
+    review_lines: list[str] = []
+    capturing = False
+    for line in lines:
+        stripped = line.strip()
+        # Start capturing at "Summary" or "## Summary"
+        if not capturing and ("Summary" in stripped and len(stripped) < 50):
+            capturing = True
+        if capturing:
+            # Stop at Codex/Claude UI elements
+            if stripped.startswith("›") or "gpt-5" in stripped or "esc to interrupt" in stripped:
+                continue
+            review_lines.append(line)
+    if review_lines:
+        return "\n".join(review_lines).strip()
+    # If no structured output found, return last 100 meaningful lines
+    meaningful = [l for l in lines if l.strip() and not l.strip().startswith("•") and "Working" not in l]
+    return "\n".join(meaningful[-100:]).strip()
+
+
+def post_review(pr_number: int, review_text: str, repo: str, agent: str = "codex") -> None:
+    """Post formatted review comment to GitHub PR."""
+    # Format as a clean GitHub comment
+    body = (
+        f"## 🤖 自动 Code Review\n\n"
+        f"> 由本地 {agent.capitalize()} 自动生成\n\n"
+        f"---\n\n"
+        f"{review_text}\n\n"
+        f"---\n"
+        f"*⚡ Powered by local PR Review Bot*"
     )
-    LOG.info("Posted review to PR #%d", pr_number)
+    # Write to temp file to avoid shell arg length issues
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+        f.write(body)
+        body_file = f.name
+    try:
+        subprocess.run(
+            ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body-file", body_file],
+            timeout=30,
+        )
+        LOG.info("Posted review to PR #%d", pr_number)
+    finally:
+        Path(body_file).unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -207,7 +289,7 @@ class ReviewOrchestrator:
                     LOG.warning("Empty diff for PR #%d, skipping", pr_num)
                     return
                 review = run_review(self._config, pr, diff)
-                post_review(pr_num, review, repo)
+                post_review(pr_num, review, repo, self._config.review_agent)
             except Exception:
                 LOG.exception("Review failed for PR #%d", pr_num)
 

--- a/scripts/pr_review_bot.py
+++ b/scripts/pr_review_bot.py
@@ -234,11 +234,22 @@ def create_app(config: ReviewBotConfig, orchestrator: ReviewOrchestrator) -> Any
         x_github_event = request.headers.get("x-github-event", "")
         x_hub_signature_256 = request.headers.get("x-hub-signature-256", "")
         body = await request.body()
-
-        if not verify_webhook_signature(config.webhook_secret, body, x_hub_signature_256):
-            return JSONResponse({"error": "invalid signature"}, status_code=401)
-
         payload = json.loads(body.decode("utf-8"))
+
+        # smee-client wraps the payload: {"payload": "<json string>", "x-github-event": "..."}
+        if "payload" in payload and isinstance(payload.get("payload"), str):
+            LOG.info("Detected smee-wrapped payload, unwrapping")
+            inner_sig = payload.get("x-hub-signature-256", "")
+            inner_event = payload.get("x-github-event", x_github_event)
+            inner_body = payload["payload"].encode("utf-8")
+            if inner_sig and config.webhook_secret:
+                if not verify_webhook_signature(config.webhook_secret, inner_body, inner_sig):
+                    return JSONResponse({"error": "invalid signature"}, status_code=401)
+            x_github_event = inner_event
+            payload = json.loads(payload["payload"])
+        elif x_hub_signature_256 and config.webhook_secret:
+            if not verify_webhook_signature(config.webhook_secret, body, x_hub_signature_256):
+                return JSONResponse({"error": "invalid signature"}, status_code=401)
         ok, reason = should_process_pull_request(
             x_github_event,
             payload,

--- a/scripts/pr_review_bot_config.py
+++ b/scripts/pr_review_bot_config.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Configuration helpers for the local PR review bot."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ReviewBotConfig:
+    webhook_secret: str
+    review_agent: str
+    repo_path: Path
+    review_timeout: int
+    port: int
+    log_file: Path
+    ignore_users: frozenset[str]
+
+
+def load_config() -> ReviewBotConfig:
+    webhook_secret = os.getenv("PR_REVIEW_WEBHOOK_SECRET", "")
+    review_agent = os.getenv("PR_REVIEW_AGENT", "codex").strip().lower() or "codex"
+    repo_path = Path(os.getenv("PR_REVIEW_REPO_PATH", Path.cwd())).expanduser().resolve()
+    review_timeout = int(os.getenv("PR_REVIEW_TIMEOUT", "600"))
+    port = int(os.getenv("PR_REVIEW_PORT", "3456"))
+    log_file = Path(os.getenv("PR_REVIEW_LOG_FILE", "/tmp/pr-review-bot.log"))
+    ignore_users = frozenset(
+        value.strip()
+        for value in os.getenv(
+            "PR_REVIEW_IGNORE_USERS",
+            "github-actions[bot],dependabot[bot],claude[bot],codex[bot]",
+        ).split(",")
+        if value.strip()
+    )
+    return ReviewBotConfig(
+        webhook_secret=webhook_secret,
+        review_agent=review_agent,
+        repo_path=repo_path,
+        review_timeout=review_timeout,
+        port=port,
+        log_file=log_file,
+        ignore_users=ignore_users,
+    )

--- a/scripts/pr_review_bot_config.py
+++ b/scripts/pr_review_bot_config.py
@@ -11,7 +11,9 @@ from pathlib import Path
 @dataclass(frozen=True)
 class ReviewBotConfig:
     webhook_secret: str
+    allow_insecure_webhooks: bool
     review_agent: str
+    output_language: str
     repo_path: Path
     review_timeout: int
     port: int
@@ -21,7 +23,14 @@ class ReviewBotConfig:
 
 def load_config() -> ReviewBotConfig:
     webhook_secret = os.getenv("PR_REVIEW_WEBHOOK_SECRET", "")
-    review_agent = os.getenv("PR_REVIEW_AGENT", "codex").strip().lower() or "codex"
+    review_agent = (os.getenv("PR_REVIEW_AGENT", "codex") or "").strip().lower()
+    if review_agent not in {"codex", "claude"}:
+        review_agent = "codex"
+    output_language = (os.getenv("PR_REVIEW_OUTPUT_LANGUAGE", "zh") or "").strip().lower()
+    if output_language not in {"zh", "en"}:
+        output_language = "zh"
+    insecure_raw = (os.getenv("PR_REVIEW_ALLOW_INSECURE_WEBHOOKS", "") or "").strip().lower()
+    allow_insecure_webhooks = insecure_raw in {"1", "true", "yes", "on"}
     repo_path = Path(os.getenv("PR_REVIEW_REPO_PATH", Path.cwd())).expanduser().resolve()
     review_timeout = int(os.getenv("PR_REVIEW_TIMEOUT", "600"))
     port = int(os.getenv("PR_REVIEW_PORT", "3456"))
@@ -36,7 +45,9 @@ def load_config() -> ReviewBotConfig:
     )
     return ReviewBotConfig(
         webhook_secret=webhook_secret,
+        allow_insecure_webhooks=allow_insecure_webhooks,
         review_agent=review_agent,
+        output_language=output_language,
         repo_path=repo_path,
         review_timeout=review_timeout,
         port=port,

--- a/scripts/start_review_bot.sh
+++ b/scripts/start_review_bot.sh
@@ -35,6 +35,10 @@ done
 
 port="${PR_REVIEW_PORT:-3456}"
 repo_path="${PR_REVIEW_REPO_PATH:-$(pwd)}"
+cd "$repo_path" || {
+  echo "error: failed to cd to repo path: $repo_path" >&2
+  exit 1
+}
 mkdir -p /tmp
 
 echo "Installing review bot dependencies..."
@@ -63,5 +67,4 @@ if [ "$daemon" -eq 1 ]; then
   exit 0
 fi
 
-cd "$repo_path"
 python3 scripts/pr_review_bot.py

--- a/scripts/start_review_bot.sh
+++ b/scripts/start_review_bot.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+set -eu
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/start_review_bot.sh [--daemon]
+
+Environment:
+  PR_REVIEW_PORT            Webhook server port (default: 3456)
+  PR_REVIEW_REPO_PATH       Repository path for git/gh commands
+  PR_REVIEW_WEBHOOK_SECRET  GitHub webhook secret
+  PR_REVIEW_AGENT           codex or claude (default: codex)
+  SMEE_URL                  Optional smee relay URL
+EOF
+}
+
+daemon=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --daemon)
+      daemon=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+port="${PR_REVIEW_PORT:-3456}"
+repo_path="${PR_REVIEW_REPO_PATH:-$(pwd)}"
+mkdir -p /tmp
+
+echo "Installing review bot dependencies..."
+uv sync --extra review-bot --dev
+
+smee_pid=""
+if [ -n "${SMEE_URL:-}" ]; then
+  echo "Starting smee relay from ${SMEE_URL} to http://127.0.0.1:${port}/webhook"
+  if command -v npx >/dev/null 2>&1; then
+    npx smee-client --url "$SMEE_URL" --path /webhook --target "http://127.0.0.1:${port}" >/tmp/pr-review-bot-smee.log 2>&1 &
+    smee_pid=$!
+  else
+    echo "warning: npx not found; skipping smee relay startup" >&2
+  fi
+fi
+
+if [ "$daemon" -eq 1 ]; then
+  echo "Starting review bot in daemon mode on port ${port}"
+  nohup python3 scripts/pr_review_bot.py >/tmp/pr-review-bot-stdout.log 2>&1 &
+  bot_pid=$!
+  echo "$bot_pid" >/tmp/pr-review-bot.pid
+  if [ -n "$smee_pid" ]; then
+    echo "$smee_pid" >/tmp/pr-review-bot-smee.pid
+  fi
+  echo "Bot PID: $bot_pid"
+  exit 0
+fi
+
+cd "$repo_path"
+python3 scripts/pr_review_bot.py

--- a/tests/test_pr_review_bot.py
+++ b/tests/test_pr_review_bot.py
@@ -7,16 +7,19 @@ import hmac
 import json
 import os
 import subprocess
+import time
 from collections.abc import Iterable
 from pathlib import Path
 
 from scripts.pr_review_bot import (
     ReviewBotConfig,
+    ReviewOrchestrator,
     build_review_prompt,
     create_app,
     extract_decision,
     fetch_diff,
     load_config,
+    post_review,
     should_process_pull_request,
     verify_webhook_signature,
 )
@@ -250,3 +253,103 @@ def test_fetch_diff_raises_when_git_fetch_fails(monkeypatch) -> None:
         assert "fetch failed" in str(exc.stderr)
     else:
         raise AssertionError("fetch_diff should raise CalledProcessError")
+
+
+def test_post_review_uses_review_for_approve(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.pr_review_bot.subprocess.run", _fake_run)
+    post_review(28, "LGTM", "owner/repo", "APPROVE")
+    assert commands[0][:4] == ["gh", "pr", "review", "28"]
+    assert "--approve" in commands[0]
+
+
+def test_post_review_uses_review_for_request_changes(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.pr_review_bot.subprocess.run", _fake_run)
+    post_review(28, "Needs fixes", "owner/repo", "REQUEST_CHANGES")
+    assert commands[0][:4] == ["gh", "pr", "review", "28"]
+    assert "--request-changes" in commands[0]
+
+
+def test_post_review_uses_comment_for_default(monkeypatch) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.pr_review_bot.subprocess.run", _fake_run)
+    post_review(28, "General comment", "owner/repo", "COMMENT")
+    assert commands[0][:4] == ["gh", "pr", "comment", "28"]
+
+
+def test_submit_review_cancels_previous_worker(monkeypatch) -> None:
+    config = _base_config()
+    orchestrator = ReviewOrchestrator(config)
+    posted: list[tuple[int, str]] = []
+    run_calls = {"count": 0}
+
+    payload = {
+        "repository": {"full_name": "owner/repo"},
+        "pull_request": {
+            "number": 7,
+            "base": {"ref": "main"},
+            "head": {"ref": "feature"},
+            "title": "Test PR",
+            "body": "",
+        },
+    }
+
+    def _fake_fetch_diff(repo_path: Path, pr_number: int, base_ref: str) -> str:
+        assert repo_path == config.repo_path
+        assert pr_number == 7
+        assert base_ref == "main"
+        return "diff --git a/x b/x"
+
+    def _fake_run_review(
+        _config: ReviewBotConfig,
+        _pr: dict[str, object],
+        _diff: str,
+        cancel_event,
+    ) -> str:
+        run_calls["count"] += 1
+        if run_calls["count"] == 1:
+            while not cancel_event.is_set():
+                time.sleep(0.01)
+            raise TimeoutError("review cancelled by newer event")
+        return "Decision: COMMENT\nAll good."
+
+    def _fake_post_review(pr_number: int, review_text: str, repo: str, recommendation: str) -> None:
+        posted.append((pr_number, recommendation))
+        assert review_text == "All good."
+        assert repo == "owner/repo"
+
+    monkeypatch.setattr("scripts.pr_review_bot.fetch_diff", _fake_fetch_diff)
+    monkeypatch.setattr("scripts.pr_review_bot.run_review", _fake_run_review)
+    monkeypatch.setattr("scripts.pr_review_bot.post_review", _fake_post_review)
+    monkeypatch.setattr("scripts.pr_review_bot.notify_openclaw", lambda *args, **kwargs: None)
+
+    orchestrator.submit_review(payload)
+    time.sleep(0.05)
+    orchestrator.submit_review(payload)
+
+    deadline = time.time() + 2
+    while time.time() < deadline:
+        with orchestrator._lock:
+            active = orchestrator._active.get(7)
+        if active is None:
+            break
+        time.sleep(0.05)
+
+    assert run_calls["count"] == 2
+    assert posted == [(7, "COMMENT")]

--- a/tests/test_pr_review_bot.py
+++ b/tests/test_pr_review_bot.py
@@ -1,0 +1,70 @@
+"""Tests for webhook review bot helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from scripts.pr_review_bot import (
+    build_review_prompt,
+    should_process_pull_request,
+    verify_webhook_signature,
+)
+
+
+def test_verify_webhook_signature_accepts_valid_hmac() -> None:
+    secret = "top-secret"
+    body = b'{"action":"opened"}'
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
+
+    assert verify_webhook_signature(secret, body, f"sha256={digest}") is True
+    assert verify_webhook_signature(secret, body, "sha256=invalid") is False
+
+
+def test_event_filter_only_accepts_opened_and_synchronize() -> None:
+    payload = {
+        "action": "opened",
+        "sender": {"login": "octocat"},
+        "pull_request": {"number": 42},
+    }
+    ignore_users = {"github-actions[bot]"}
+
+    ok_opened, _ = should_process_pull_request("pull_request", payload, ignore_users)
+    assert ok_opened is True
+
+    payload["action"] = "synchronize"
+    ok_sync, _ = should_process_pull_request("pull_request", payload, ignore_users)
+    assert ok_sync is True
+
+    payload["action"] = "edited"
+    ok_edited, _ = should_process_pull_request("pull_request", payload, ignore_users)
+    assert ok_edited is False
+
+
+def test_event_filter_rejects_bot_sender() -> None:
+    payload = {
+        "action": "opened",
+        "sender": {"login": "dependabot[bot]"},
+        "pull_request": {"number": 42},
+    }
+    ok, reason = should_process_pull_request("pull_request", payload, {"dependabot[bot]"})
+    assert ok is False
+    assert "ignored sender" in reason
+
+
+def test_build_review_prompt_includes_pr_metadata_and_diff() -> None:
+    template = "PR #{pr_number}: {pr_title}\n{pr_body}\n{head_ref}->{base_ref}\n{diff_text}"
+    prompt = build_review_prompt(
+        template_text=template,
+        pr_number=7,
+        pr_title="feat: add worker",
+        pr_body="Describe changes",
+        head_ref="feature/worker",
+        base_ref="main",
+        diff_text="diff --git a/x b/x",
+    )
+
+    assert "PR #7" in prompt
+    assert "feat: add worker" in prompt
+    assert "feature/worker->main" in prompt
+    assert "diff --git" in prompt

--- a/tests/test_pr_review_bot.py
+++ b/tests/test_pr_review_bot.py
@@ -6,13 +6,16 @@ import hashlib
 import hmac
 import json
 import os
+import subprocess
 from collections.abc import Iterable
+from pathlib import Path
 
 from scripts.pr_review_bot import (
     ReviewBotConfig,
     build_review_prompt,
     create_app,
     extract_decision,
+    fetch_diff,
     load_config,
     should_process_pull_request,
     verify_webhook_signature,
@@ -110,13 +113,13 @@ def _base_config() -> ReviewBotConfig:
     return ReviewBotConfig(
         webhook_secret="top-secret",
         allow_insecure_webhooks=False,
-        repo_path=os.getcwd(),
+        repo_path=Path(os.getcwd()),
         review_agent="codex",
         output_language="zh",
         review_timeout=30,
         port=3456,
-        ignore_users=set(),
-        log_file="",
+        ignore_users=frozenset(),
+        log_file=Path("/tmp/pr-review-bot-test.log"),
     )
 
 
@@ -213,3 +216,37 @@ async def test_webhook_requires_wrapped_signature_when_secret_is_set() -> None:
     )
     assert status == 401
     assert response["error"] == "missing signature"
+
+
+def test_fetch_diff_uses_force_refspec_and_base_fetch(monkeypatch) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((cmd, kwargs))
+        if cmd[:2] == ["git", "diff"]:
+            return subprocess.CompletedProcess(cmd, 0, stdout="diff-content", stderr="")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("scripts.pr_review_bot.subprocess.run", _fake_run)
+
+    diff = fetch_diff(Path("/tmp/repo"), 28, "main")
+
+    assert diff == "diff-content"
+    assert calls[0][0] == ["git", "fetch", "origin", "+pull/28/head:pr-28"]
+    assert calls[1][0] == ["git", "fetch", "origin", "main"]
+    assert calls[2][0] == ["git", "diff", "origin/main...pr-28"]
+    assert all(call_kwargs["check"] is True for _, call_kwargs in calls)
+
+
+def test_fetch_diff_raises_when_git_fetch_fails(monkeypatch) -> None:
+    def _fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.CalledProcessError(returncode=1, cmd=cmd, output="", stderr="fetch failed")
+
+    monkeypatch.setattr("scripts.pr_review_bot.subprocess.run", _fake_run)
+
+    try:
+        fetch_diff(Path("/tmp/repo"), 28, "main")
+    except subprocess.CalledProcessError as exc:
+        assert "fetch failed" in str(exc.stderr)
+    else:
+        raise AssertionError("fetch_diff should raise CalledProcessError")

--- a/tests/test_pr_review_bot.py
+++ b/tests/test_pr_review_bot.py
@@ -49,22 +49,19 @@ def test_event_filter_rejects_bot_sender() -> None:
     }
     ok, reason = should_process_pull_request("pull_request", payload, {"dependabot[bot]"})
     assert ok is False
-    assert "ignored sender" in reason
+    assert "ignore" in reason.lower()
 
 
 def test_build_review_prompt_includes_pr_metadata_and_diff() -> None:
-    template = "PR #{pr_number}: {pr_title}\n{pr_body}\n{head_ref}->{base_ref}\n{diff_text}"
-    prompt = build_review_prompt(
-        template_text=template,
-        pr_number=7,
-        pr_title="feat: add worker",
-        pr_body="Describe changes",
-        head_ref="feature/worker",
-        base_ref="main",
-        diff_text="diff --git a/x b/x",
-    )
+    pr = {
+        "number": 7,
+        "title": "feat: add worker",
+        "body": "Describe changes",
+        "head": {"ref": "feature/worker"},
+        "base": {"ref": "main"},
+    }
+    prompt = build_review_prompt(pr, "diff --git a/x b/x")
 
-    assert "PR #7" in prompt
+    assert "7" in prompt
     assert "feat: add worker" in prompt
-    assert "feature/worker->main" in prompt
     assert "diff --git" in prompt

--- a/tests/test_pr_review_bot.py
+++ b/tests/test_pr_review_bot.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
+import os
+from collections.abc import Iterable
 
 from scripts.pr_review_bot import (
+    ReviewBotConfig,
     build_review_prompt,
+    create_app,
+    extract_decision,
+    load_config,
     should_process_pull_request,
     verify_webhook_signature,
 )
@@ -19,6 +26,10 @@ def test_verify_webhook_signature_accepts_valid_hmac() -> None:
 
     assert verify_webhook_signature(secret, body, f"sha256={digest}") is True
     assert verify_webhook_signature(secret, body, "sha256=invalid") is False
+
+
+def test_verify_webhook_signature_rejects_when_secret_missing() -> None:
+    assert verify_webhook_signature("", b"{}", "sha256=abc") is False
 
 
 def test_event_filter_only_accepts_opened_and_synchronize() -> None:
@@ -60,8 +71,145 @@ def test_build_review_prompt_includes_pr_metadata_and_diff() -> None:
         "head": {"ref": "feature/worker"},
         "base": {"ref": "main"},
     }
-    prompt = build_review_prompt(pr, "diff --git a/x b/x")
+    prompt = build_review_prompt(pr, "diff --git a/x b/x", "zh")
 
     assert "7" in prompt
     assert "feat: add worker" in prompt
     assert "diff --git" in prompt
+
+
+def test_load_config_normalizes_agent_and_language(monkeypatch) -> None:
+    monkeypatch.setenv("PR_REVIEW_AGENT", " Claude ")
+    monkeypatch.setenv("PR_REVIEW_OUTPUT_LANGUAGE", " EN ")
+    config = load_config()
+
+    assert config.review_agent == "claude"
+    assert config.output_language == "en"
+
+
+def test_load_config_fallbacks_for_invalid_agent_and_language(monkeypatch) -> None:
+    monkeypatch.setenv("PR_REVIEW_AGENT", "bad")
+    monkeypatch.setenv("PR_REVIEW_OUTPUT_LANGUAGE", "bad")
+    config = load_config()
+
+    assert config.review_agent == "codex"
+    assert config.output_language == "zh"
+
+
+def test_extract_decision_uses_strict_markers() -> None:
+    text = """The options are APPROVE / REQUEST_CHANGES / COMMENT.
+Decision: COMMENT
+"""
+    assert extract_decision(text) == "COMMENT"
+
+    assert extract_decision("gh pr review 7 --request-changes --body x") == "REQUEST_CHANGES"
+    assert extract_decision("gh pr review 7 --approve --body x") == "APPROVE"
+
+
+def _base_config() -> ReviewBotConfig:
+    return ReviewBotConfig(
+        webhook_secret="top-secret",
+        allow_insecure_webhooks=False,
+        repo_path=os.getcwd(),
+        review_agent="codex",
+        output_language="zh",
+        review_timeout=30,
+        port=3456,
+        ignore_users=set(),
+        log_file="",
+    )
+
+
+class _NoopOrchestrator:
+    def submit_review(self, payload: dict[str, object]) -> None:
+        """No-op."""
+
+
+async def _post_webhook(
+    app,
+    *,
+    body: bytes,
+    headers: Iterable[tuple[str, str]],
+) -> tuple[int, dict[str, object]]:
+    header_bytes = [(k.lower().encode("utf-8"), v.encode("utf-8")) for k, v in headers]
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": "/webhook",
+        "raw_path": b"/webhook",
+        "query_string": b"",
+        "headers": header_bytes,
+        "client": ("testclient", 123),
+        "server": ("testserver", 80),
+    }
+    sent_start: dict[str, object] = {}
+    sent_body = b""
+    done = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal done
+        if not done:
+            done = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, object]) -> None:
+        nonlocal sent_start, sent_body
+        if message["type"] == "http.response.start":
+            sent_start = message
+        elif message["type"] == "http.response.body":
+            sent_body += message.get("body", b"")
+
+    await app(scope, receive, send)
+    return int(sent_start["status"]), json.loads(sent_body.decode("utf-8"))
+
+
+async def test_webhook_rejects_invalid_json_with_400() -> None:
+    app = create_app(_base_config(), _NoopOrchestrator())
+    status, payload = await _post_webhook(
+        app,
+        body=b"{bad",
+        headers=[("x-github-event", "pull_request")],
+    )
+    assert status == 400
+    assert payload["error"] == "invalid json payload"
+
+
+async def test_webhook_requires_signature_when_secret_is_set() -> None:
+    app = create_app(_base_config(), _NoopOrchestrator())
+    payload = {
+        "action": "opened",
+        "sender": {"login": "octocat", "type": "User"},
+        "pull_request": {"number": 1},
+    }
+    status, response = await _post_webhook(
+        app,
+        body=json.dumps(payload).encode("utf-8"),
+        headers=[("x-github-event", "pull_request"), ("content-type", "application/json")],
+    )
+    assert status == 401
+    assert response["error"] == "missing signature"
+
+
+async def test_webhook_requires_wrapped_signature_when_secret_is_set() -> None:
+    app = create_app(_base_config(), _NoopOrchestrator())
+    wrapped = {
+        "payload": json.dumps(
+            {
+                "action": "opened",
+                "sender": {"login": "octocat", "type": "User"},
+                "pull_request": {"number": 1},
+            }
+        ),
+        "x-github-event": "pull_request",
+    }
+    status, response = await _post_webhook(
+        app,
+        body=json.dumps(wrapped).encode("utf-8"),
+        headers=[("x-github-event", "pull_request"), ("content-type", "application/json")],
+    )
+    assert status == 401
+    assert response["error"] == "missing signature"

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,37 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -305,6 +336,10 @@ dev = [
     { name = "pytest-timeout" },
     { name = "ruff" },
 ]
+review-bot = [
+    { name = "fastapi" },
+    { name = "uvicorn" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -316,16 +351,30 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9,<4" },
     { name = "backports-zstd", specifier = ">=1.0" },
     { name = "cryptography", specifier = ">=42.0" },
+    { name = "fastapi", marker = "extra == 'review-bot'", specifier = ">=0.115,<1" },
     { name = "pexpect", marker = "extra == 'dev'", specifier = ">=4.9" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11" },
+    { name = "uvicorn", marker = "extra == 'review-bot'", specifier = ">=0.31,<1" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "review-bot"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "playwright", specifier = ">=1.58.0" }]
+
+[[package]]
+name = "click"
+version = "8.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+]
 
 [[package]]
 name = "colorama"
@@ -393,6 +442,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
     { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
     { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
 ]
 
 [[package]]
@@ -550,6 +615,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
     { url = "https://files.pythonhosted.org/packages/29/4b/45d90626aef8e65336bed690106d1382f7a43665e2249017e9527df8823b/greenlet-3.3.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c04c5e06ec3e022cbfe2cd4a846e1d4e50087444f875ff6d2c2ad8445495cf1a", size = 237086, upload-time = "2026-02-20T20:20:45.786Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -854,6 +928,118 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -941,12 +1127,50 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

每次 PR 都需要手动 review，希望有一个自动化的 review 机器人，当 GitHub 有新 PR 时自动启动本地 Codex/Claude 进行 review，结果贴回 PR。

## 架构

```
GitHub Webhook (PR opened/synchronize)
  → smee.io proxy（免公网 IP）
  → 本地 FastAPI server（端口 3456）
  → 独立线程：git fetch diff → Codex/Claude tmux review → gh pr comment
```

## 包含文件

- `scripts/pr_review_bot.py` — 主程序（FastAPI webhook server）
- `scripts/pr_review_bot_config.py` — 配置（环境变量驱动）
- `scripts/start_review_bot.sh` — 启动脚本（含 smee client）
- `prompts/pr-review-prompt.md` — review prompt 模板
- `tests/test_pr_review_bot.py` — 测试（签名验证、事件过滤、prompt 构造）
- `docs/guides/pr-review-bot.md` — 使用文档（中文）
- `pyproject.toml` — 新增 `[review-bot]` optional dependency

## 功能
- HMAC-SHA256 webhook 签名验证
- 只处理 PR opened/synchronize 事件
- 忽略 bot 自己的 PR（防循环）
- 每个 PR 独立线程 review
- 同一 PR 多次 push 取消旧 review
- 10 分钟超时
- review 内容包含：代码质量、测试覆盖、截图证据、标题规范
- 中文输出

## 验证
- `uv run ruff check .` ✅
- `uv run ruff format --check .` ✅
- `python3 scripts/pr_review_bot.py --dry-run` ✅
- 新增 4 个测试全部通过
- `test_e2e_with_cleanup` 偶发端口冲突（已知 flaky，非本 PR 引入）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local webhook-driven PR review bot that posts automated reviews/comments; foreground, daemon, dry-run modes, health endpoint, and optional webhook relay.
  * Start/management script to launch the bot and optional relay.
  * Configurable via environment variables; supports pluggable review agents and timeouts.
  * Standardized PR review prompt/template (Chinese) for consistent reviews.

* **Documentation**
  * Detailed guide for setup, webhook configuration, running modes, and troubleshooting.

* **Tests**
  * Unit tests for signature validation, event filtering, and prompt construction.

* **Chores**
  * Added optional dependency group for running the review service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->