### PR TITLE
feat: codex client support + fix tag-based PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,18 +1,30 @@
 name: Publish to PyPI
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
+  push:
+    tags:
+      - "v*"
 
 jobs:
-  publish:
+  ci:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'push' &&
-      !contains(github.event.workflow_run.head_commit.message, '[skip publish]')
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: pip install -e ".[dev]"
+      - run: python -m pytest tests/ -x --timeout=60
+
+  publish:
+    needs: ci
+    runs-on: ubuntu-latest
     environment: pypi
     permissions:
       id-token: write
@@ -20,7 +32,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
           fetch-depth: 0
 
       - name: Install uv
@@ -29,28 +40,19 @@ jobs:
       - name: Set up Python
         run: uv python install 3.13
 
-      - name: Bump patch version
-        id: bump
+      - name: Verify version matches tag
         run: |
-          current=$(python3 -c "
+          tag="${GITHUB_REF#refs/tags/v}"
+          pkg_version=$(python3 -c "
           import re
           m = re.search(r'version = \"(.+?)\"', open('pyproject.toml').read())
           print(m.group(1))
           ")
-          IFS='.' read -r major minor patch <<< "$current"
-          new_version="$major.$minor.$((patch + 1))"
-          sed -i "s/version = \"$current\"/version = \"$new_version\"/" pyproject.toml
-          echo "version=$new_version" >> "$GITHUB_OUTPUT"
-          echo "Bumped $current -> $new_version"
-
-      - name: Commit and tag
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore: release v${{ steps.bump.outputs.version }} [skip publish]"
-          git tag -f "v${{ steps.bump.outputs.version }}"
-          git push origin main --tags --force
+          if [ "$tag" != "$pkg_version" ]; then
+            echo "::error::Tag v$tag does not match pyproject.toml version $pkg_version"
+            exit 1
+          fi
+          echo "Publishing version $pkg_version"
 
       - name: Build package
         run: uv build
@@ -62,28 +64,13 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          version="${{ steps.bump.outputs.version }}"
-          notes="$(git log -n 20 --pretty=format:'- %h %s')"
-          gh release create "v${version}" \
-            --title "v${version}" \
-            --notes "${notes}"
-
-      - name: Verify PyPI install
-        run: |
-          version="${{ steps.bump.outputs.version }}"
-          for attempt in 1 2 3 4 5; do
-            python3 -m venv .venv-pypi-check
-            . .venv-pypi-check/bin/activate
-            python -m pip install --upgrade pip
-            if python -m pip install "claude-tap==${version}"; then
-              deactivate
-              rm -rf .venv-pypi-check
-              exit 0
-            fi
-            deactivate
-            rm -rf .venv-pypi-check
-            echo "PyPI package not ready yet (attempt ${attempt}/5), retrying in 30s..."
-            sleep 30
-          done
-          echo "Failed to install claude-tap==${version} from PyPI."
-          exit 1
+          tag="${GITHUB_REF#refs/tags/}"
+          prev_tag=$(git describe --tags --abbrev=0 "${tag}^" 2>/dev/null || echo "")
+          if [ -n "$prev_tag" ]; then
+            notes="$(git log "${prev_tag}..${tag}" --pretty=format:'- %h %s')"
+          else
+            notes="$(git log --pretty=format:'- %h %s' -n 20)"
+          fi
+          gh release create "$tag" \
+            --title "$tag" \
+            --notes "$notes"

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -15,6 +15,7 @@ import threading
 import urllib.error
 import urllib.request
 import webbrowser
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -47,32 +48,60 @@ def _open_browser(url: str) -> None:
     threading.Thread(target=lambda: webbrowser.open(url), daemon=True).start()
 
 
-async def run_claude(
+@dataclass(frozen=True)
+class ClientConfig:
+    """Per-client configuration for supported AI CLI tools."""
+
+    cmd: str
+    label: str
+    install_url: str
+    base_url_env: str
+    base_url_suffix: str  # appended to http://127.0.0.1:{port}
+    default_target: str
+    nesting_env_keys: tuple[str, ...] = ()  # env vars to clear before launch
+
+    @property
+    def missing_help(self) -> str:
+        return (
+            f"\nError: '{self.cmd}' command not found in PATH.\nPlease install {self.label} first: {self.install_url}\n"
+        )
+
+    def reverse_base_url(self, port: int) -> str:
+        return f"http://127.0.0.1:{port}{self.base_url_suffix}"
+
+
+CLIENT_CONFIGS: dict[str, ClientConfig] = {
+    "claude": ClientConfig(
+        cmd="claude",
+        label="Claude Code",
+        install_url="https://docs.anthropic.com/en/docs/claude-code",
+        base_url_env="ANTHROPIC_BASE_URL",
+        base_url_suffix="",
+        default_target="https://api.anthropic.com",
+        nesting_env_keys=("CLAUDECODE", "CLAUDE_CODE_SSE_PORT"),
+    ),
+    "codex": ClientConfig(
+        cmd="codex",
+        label="Codex CLI",
+        install_url="https://github.com/openai/codex",
+        base_url_env="OPENAI_BASE_URL",
+        base_url_suffix="/v1",
+        default_target="https://api.openai.com",
+    ),
+}
+
+
+async def run_client(
     port: int,
     extra_args: list[str],
     client: str = "claude",
     proxy_mode: str = "reverse",
     ca_cert_path: Path | None = None,
 ) -> int:
-    if client == "claude":
-        client_cmd = "claude"
-        client_label = "Claude Code"
-        missing_help = (
-            "\nError: 'claude' command not found in PATH.\n"
-            "Please install Claude Code first: "
-            "https://docs.anthropic.com/en/docs/claude-code\n"
-        )
-    else:
-        client_cmd = "codex"
-        client_label = "Codex CLI"
-        missing_help = (
-            "\nError: 'codex' command not found in PATH.\n"
-            "Please install Codex CLI first: "
-            "https://github.com/openai/codex\n"
-        )
+    cfg = CLIENT_CONFIGS[client]
 
-    if shutil.which(client_cmd) is None:
-        print(missing_help)
+    if shutil.which(cfg.cmd) is None:
+        print(cfg.missing_help)
         return 1
 
     env = os.environ.copy()
@@ -111,28 +140,21 @@ async def run_claude(
                 cmd_args = ["--settings", json.dumps(settings_payload, separators=(",", ":"))] + cmd_args
         # Don't set provider-specific base URL in forward mode
     else:
-        if client == "claude":
-            env["ANTHROPIC_BASE_URL"] = f"http://127.0.0.1:{port}"
-        else:
-            env["OPENAI_BASE_URL"] = f"http://127.0.0.1:{port}/v1"
+        base_url = cfg.reverse_base_url(port)
+        env[cfg.base_url_env] = base_url
         env["NO_PROXY"] = "127.0.0.1"
 
-    if client == "claude":
-        # Bypass Claude Code nesting detection
-        env.pop("CLAUDECODE", None)
-        env.pop("CLAUDE_CODE_SSE_PORT", None)
+    for key in cfg.nesting_env_keys:
+        env.pop(key, None)
 
-    cmd = [client_cmd] + cmd_args
-    print(f"\n🚀 Starting {client_label}: {' '.join(cmd)}")
+    cmd = [cfg.cmd] + cmd_args
+    print(f"\n🚀 Starting {cfg.label}: {' '.join(cmd)}")
     if proxy_mode == "forward":
         print(f"   HTTPS_PROXY=http://127.0.0.1:{port}")
         if ca_cert_path:
             print(f"   NODE_EXTRA_CA_CERTS={ca_cert_path}")
     else:
-        if client == "claude":
-            print(f"   ANTHROPIC_BASE_URL=http://127.0.0.1:{port}")
-        else:
-            print(f"   OPENAI_BASE_URL=http://127.0.0.1:{port}/v1")
+        print(f"   {cfg.base_url_env}={cfg.reverse_base_url(port)}")
     print()
 
     # Give child its own process group and make it the foreground group
@@ -168,7 +190,7 @@ async def run_claude(
         if sigint_count == 1:
             if proc.returncode is None:
                 proc.terminate()
-                print(f"\n⏳ Shutting down {client_label}... (Ctrl+C again to force)")
+                print(f"\n⏳ Shutting down {cfg.label}... (Ctrl+C again to force)")
         else:
             if proc.returncode is None:
                 proc.kill()
@@ -176,7 +198,7 @@ async def run_claude(
     def _handle_sigtstp():
         if proc.returncode is None:
             proc.terminate()
-            print(f"\n⏳ Shutting down {client_label}...")
+            print(f"\n⏳ Shutting down {cfg.label}...")
 
     try:
         loop.add_signal_handler(signal.SIGINT, _handle_sigint)
@@ -208,7 +230,7 @@ async def run_claude(
     except (NotImplementedError, OSError):
         pass
 
-    print(f"\n📋 {client_label} exited with code {code}")
+    print(f"\n📋 {cfg.label} exited with code {code}")
     return code
 
 
@@ -308,7 +330,7 @@ async def async_main(args: argparse.Namespace):
     try:
         if not args.no_launch:
             try:
-                exit_code = await run_claude(
+                exit_code = await run_client(
                     actual_port,
                     args.claude_args,
                     client=args.client,
@@ -494,9 +516,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     if args.host is None:
         args.host = "0.0.0.0" if args.no_launch else "127.0.0.1"
     if args.target is None:
-        args.target = (
-            "https://api.anthropic.com" if args.client == "claude" else "https://chatgpt.com/backend-api/codex"
-        )
+        args.target = CLIENT_CONFIGS[args.client].default_target
     return args
 
 

--- a/docs/plans/2026-02-27-codex-support-handoff.md
+++ b/docs/plans/2026-02-27-codex-support-handoff.md
@@ -2,197 +2,197 @@
 status: completed
 ---
 
-# Codex 支持交接（详细）
+# Codex Support Handoff (Detailed)
 
-日期：2026-02-27
-分支：`feat/codex-client-support`
-仓库：`liaohch3/claude-tap`
+Date: 2026-02-27
+Branch: `feat/codex-client-support`
+Repository: `liaohch3/claude-tap`
 
-## 1. 目标、范围与当前状态
+## 1. Goal, Scope, and Current Status
 
-### 原始目标
+### Original Goal
 
-在保留现有 Claude 行为的同时，新增对 Codex 的支持。
+Add support for Codex in addition to Claude, while preserving existing Claude behavior.
 
-### 来自用户的验收约束
+### Acceptance Constraint From User
 
-真实 Codex 验证必须端到端成功。任何 `403` 都视为硬失败。
+Real Codex validation must be successful end-to-end. Any `403` is considered a hard failure.
 
-### 当前状态
+### Current Status
 
-- `--tap-client codex` 的核心实现已完成。
-- mock/unit/integration 测试在本地通过。
-- 真实 Codex 运行仍受账号/API 权限（`Missing scopes: api.model.read`）和当前环境中的上游行为阻塞。
-- 工作已提交到分支 `feat/codex-client-support`。
+- Core implementation for `--tap-client codex` is completed.
+- Mock/unit/integration tests are passing locally.
+- Real Codex run is still blocked by account/API permissions (`Missing scopes: api.model.read`) and upstream behavior in this environment.
+- Work is committed on branch `feat/codex-client-support`.
 
-## 2. 已完成内容（以及原因）
+## 2. What Was Done (and Why)
 
-### A. CLI 与运行时行为
+### A. CLI and Runtime Behavior
 
-#### 文件：`claude_tap/cli.py`
+#### File: `claude_tap/cli.py`
 
-已做变更：
+Changes made:
 
-- 增加 client 选择支持：
-  - 新增参数 `--tap-client`，取值 `claude|codex`，默认 `claude`。
-- 扩展启动路径，使其可运行 `claude` 或 `codex`。
-- 反向 proxy 环境注入改为按 client 区分：
-  - Claude：`ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`
-  - Codex：`OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`
-- 省略 `--tap-target` 时，默认值按 client 推导：
+- Added client selection support:
+  - New flag `--tap-client` with values `claude|codex`, default `claude`.
+- Extended launch path so we can run either `claude` or `codex`.
+- Reverse proxy env injection is now client-specific:
+  - Claude: `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`
+  - Codex: `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`
+- `--tap-target` default is now derived from client when omitted:
   - Claude -> `https://api.anthropic.com`
   - Codex -> `https://api.openai.com`
-- 更新面向用户的启动/停止消息，使其反映所选 client。
-- 保留现有 Claude forward-mode 行为，包括仅对 Claude 的 `--settings` 注入路径。
+- Updated user-facing startup/shutdown messages to reflect selected client.
+- Preserved existing Claude forward-mode behavior, including `--settings` injection path only for Claude.
 
-原因：
+Reason:
 
-- 现有实现仅支持 Claude，且围绕 Anthropic 变量硬编码。
-- Codex 在 reverse mode 下需要 OpenAI 风格的 base URL 行为。
-- 默认保持 `claude` 可确保向后兼容。
+- Existing implementation was Claude-only and hardcoded around Anthropic variables.
+- Codex requires OpenAI-style base URL behavior in reverse mode.
+- Keeping default `claude` preserves backward compatibility.
 
-### B. 面向 Viewer 的 Trace 模型增强
+### B. Trace Model Enhancement for Viewer
 
-#### 文件：`claude_tap/proxy.py`
+#### File: `claude_tap/proxy.py`
 
-已做变更：
+Changes made:
 
-- 通过 `_build_record(...)` 在每条 trace record 中新增 `upstream_base_url`。
-- 在 streaming 与 non-streaming handler 中贯穿传递 `upstream_base_url`。
-- 通过强制 `Accept-Encoding: identity` 简化上游编码行为，避免当前环境中的 zstd 兼容问题。
+- Added `upstream_base_url` into each trace record via `_build_record(...)`.
+- Threaded `upstream_base_url` through streaming and non-streaming handlers.
+- Simplified upstream encoding behavior by forcing `Accept-Encoding: identity` to avoid zstd-related client incompatibilities in this environment.
 
-原因：
+Reason:
 
-- viewer copy-curl 原先硬编码 Anthropic 域名；需要按来源重建上游地址。
-- Codex 与部分响应在该环境中出现 zstd 解码失败；使用 identity 编码可降低 proxy 侧兼容风险。
+- Viewer copy-curl was hardcoded to Anthropic domain; needed source-specific upstream reconstruction.
+- Codex and some responses exhibited zstd decode failures in environment; identity encoding reduces this proxy-side compatibility risk.
 
-### C. Forward Proxy 一致性
+### C. Forward Proxy Consistency
 
-#### 文件：`claude_tap/forward_proxy.py`
+#### File: `claude_tap/forward_proxy.py`
 
-已做变更：
+Changes made:
 
-- 在转发上游请求时同样强制 `Accept-Encoding: identity`。
+- Also force `Accept-Encoding: identity` when forwarding upstream requests.
 
-原因：
+Reason:
 
-- 与 reverse proxy 路径保持一致，减少压缩相关失败。
+- Keep behavior consistent with reverse proxy path and reduce compression-related failures.
 
-### D. Viewer 行为
+### D. Viewer Behavior
 
-#### 文件：`claude_tap/viewer.html`
+#### File: `claude_tap/viewer.html`
 
-已做变更：
+Changes made:
 
-- `copyCurl(...)` 在可用时使用 `entry.upstream_base_url`。
-- 对旧 trace 回退到 `https://api.anthropic.com`。
+- `copyCurl(...)` now uses `entry.upstream_base_url` when available.
+- Falls back to `https://api.anthropic.com` for legacy traces.
 
-原因：
+Reason:
 
-- 使生成的 curl 命令对 Codex/OpenAI trace 也准确。
-- 保持对现有旧 trace 文件的向后兼容。
+- Makes generated curl command accurate for Codex/OpenAI traces.
+- Maintains backward compatibility for existing old trace files.
 
-### E. 测试覆盖更新
+### E. Test Coverage Updates
 
-#### 文件：`tests/test_e2e.py`
+#### File: `tests/test_e2e.py`
 
-已做变更：
+Changes made:
 
-- 为 `_run_claude_tap(...)` helper 增加 `tap_client` 参数。
-- `test_parse_args` 现在验证 Codex 默认值：
+- Extended `_run_claude_tap(...)` helper with `tap_client` argument.
+- `test_parse_args` now validates Codex defaults:
   - `--tap-client codex`
-  - 默认 target -> `https://api.openai.com`
-- 新增 `test_codex_client_reverse_proxy`，使用 fake `codex` 可执行文件：
-  - fake codex 使用 `OPENAI_BASE_URL`
-  - fake upstream 期望路径 `/v1/messages`
-  - 断言 trace 包含预期 path/model
-  - 断言已记录 `upstream_base_url`
-  - 断言启动输出包含 `OPENAI_BASE_URL=...`
+  - default target -> `https://api.openai.com`
+- Added `test_codex_client_reverse_proxy` with fake `codex` executable:
+  - fake codex uses `OPENAI_BASE_URL`
+  - fake upstream expects `/v1/messages`
+  - asserts trace contains expected path/model
+  - asserts `upstream_base_url` is recorded
+  - asserts startup output includes `OPENAI_BASE_URL=...`
 
-原因：
+Reason:
 
-- 在不依赖真实外部凭据的前提下验证新 client 行为。
-- 确保参数解析与运行时连接路径不回归。
+- Validate new client behavior without depending on real external credentials.
+- Ensure no regressions in argument parsing and runtime wiring.
 
-### F. 计划文档
+### F. Planning Docs
 
-#### 文件：`docs/plans/2026-02-27-codex-support-plan.md`
+#### File: `docs/plans/2026-02-27-codex-support-plan.md`
 
-已做变更：
+Changes made:
 
-- 新增聚焦范围的实现计划与明确的验收/风险说明。
+- Added a scoped implementation plan and explicit acceptance/risk notes.
 
-原因：
+Reason:
 
-- 遵循仓库关于计划文档与清晰交接上下文的规范。
+- Follow repository guidance for plan documentation and clear handoff context.
 
-## 3. 尚未完成（或未完全完成）内容
+## 3. What Was Not Done (or Not Fully Done)
 
-### A. 真实 Codex E2E 成功
+### A. Real Codex E2E Success
 
-由于环境/账号限制，尚未达成。
+Not achieved yet due environment/account limitations.
 
-观察到的阻塞：
+Observed blocker:
 
-- Codex 模型刷新请求失败：
+- Codex model refresh request failed:
   - `GET /v1/models?client_version=...`
   - `403 Forbidden`
-  - 消息包含 `Missing scopes: api.model.read`
+  - message includes `Missing scopes: api.model.read`
 
-影响：
+Implication:
 
-- 按用户要求，这意味着真实验证尚未完成。
+- Per user requirement, this means real validation is not complete.
 
-### B. 专用 `tests/e2e/` 真实 Codex 测试套件
+### B. Dedicated `tests/e2e/` Real Codex Suite
 
-尚未添加。
+Not added yet.
 
-原因：
+Reason:
 
-- 由于硬性要求是真实运行必须成功，在权限未修复前新增真实测试将稳定失败。
+- Given hard requirement that real run must succeed, adding real tests now would produce consistent failures in this environment until permissions are fixed.
 
-### C. README / README_zh 面向用户文档
+### C. README / README_zh User-Facing Docs
 
-本轮未更新。
+Not updated in this round.
 
-原因：
+Reason:
 
-- 优先级先放在代码路径与正确性。
-- 后续应补充 `--tap-client` 新行为与示例。
+- Priority was code path and correctness first.
+- Follow-up should document new `--tap-client` behavior and examples.
 
-## 4. 精确测试执行与结果
+## 4. Exact Test Execution and Results
 
-以下命令已在本地运行并通过：
+The following were run locally and passed:
 
 - `uv run ruff check .`
 - `uv run ruff format --check .`
 - `uv run pytest tests/ -x --timeout=60`
-  - 结果：`48 passed, 18 skipped`
+  - Result: `48 passed, 18 skipped`
 
-额外执行的定向测试：
+Additional targeted tests run:
 
 - `uv run pytest tests/test_e2e.py -k "test_parse_args or test_codex_client_reverse_proxy" -x --timeout=120`
-  - 通过
+  - Passed
 - `uv run pytest tests/test_e2e.py -k "test_e2e or test_forward_proxy_connect or test_codex_client_reverse_proxy" -x --timeout=120`
-  - 通过
+  - Passed
 
-尝试真实 Codex smoke 运行并失败（该环境预期如此）：
+Real Codex smoke run attempted and failed (as expected in this env):
 
-- 命令模式：
+- Command pattern:
   - `uv run python -m claude_tap --tap-client codex --tap-target https://api.openai.com --tap-no-update-check --tap-no-open -- exec "Reply with exactly: CODEX_REAL_OK" --skip-git-repo-check --json`
-- 失败指标：
-  - `403 Forbidden`，缺少 `api.model.read`
-  - Codex 非零退出
+- Failure indicators:
+  - `403 Forbidden` with missing `api.model.read`
+  - Codex exits non-zero
 
-## 5. 工作树卫生 / Commit 范围
+## 5. Working Tree Hygiene / Commit Scope
 
-重要上下文：
+Important context:
 
-- 本次工作前已存在 `uv.lock` 修改。
-- `log/` 含运行产物，处于未跟踪状态。
-- 以上已被有意排除在 commit 范围外。
+- There was a pre-existing `uv.lock` modification before this work.
+- `log/` contains runtime artifacts and is untracked.
+- These were intentionally excluded from commit scope.
 
-本任务 commit 计划包含的文件：
+Files intended for this task commit:
 
 - `claude_tap/cli.py`
 - `claude_tap/proxy.py`
@@ -200,44 +200,44 @@ status: completed
 - `claude_tap/viewer.html`
 - `tests/test_e2e.py`
 - `docs/plans/2026-02-27-codex-support-plan.md`
-- `docs/plans/2026-02-27-codex-support-handoff.md`（本文件）
+- `docs/plans/2026-02-27-codex-support-handoff.md` (this file)
 
-## 6. 给下一轮 Codex 流程的建议动作
+## 6. Recommended Next Actions for the Next Codex Process
 
-### 1) 先解决真实凭据/Scope 阻塞
+### 1) Resolve Real Credential/Scope Blocker First
 
-- 确保 API key/project/org 拥有 `api.model.read`（以及所需响应 scope）。
-- 重新运行真实 Codex smoke 命令，确认不再返回 403。
+- Ensure API key/project/org has `api.model.read` (and required response scopes).
+- Re-run real Codex smoke command to confirm non-403.
 
-### 2) 添加真实 Codex E2E 覆盖
+### 2) Add Real Codex E2E Coverage
 
-建议新增：
+Suggested additions:
 
-- 在 `tests/e2e/` 下新增 Codex 真实运行模块。
-- 至少覆盖：
-  - 单轮成功
-  - 多轮连续性
-  - trace 生成与路径断言
-- 按用户规则，`403/401` 保持硬失败。
+- New test module under `tests/e2e/` for Codex real runs.
+- Cover at least:
+  - single turn success
+  - multi-turn continuity
+  - trace generation and path assertions
+- Keep `403/401` as hard fail per user rule.
 
-### 3) 更新用户文档
+### 3) Update User Docs
 
-- 更新 `README.md`，必要时更新 `README_zh.md`，补充：
+- Update `README.md` and optionally `README_zh.md` with:
   - `--tap-client codex`
-  - Codex reverse mode 示例
-  - 已知前置条件：正确的 OpenAI scopes
+  - reverse mode example for Codex
+  - known prerequisite: proper OpenAI scopes
 
-### 4) 可选：深入排查 zstd 错误路径
+### 4) Optional: Investigate zstd error path deeper
 
-- 即使 proxy 到 upstream 已偏好 identity，Codex 在失败场景仍可能记录 zstd 解码问题。
-- 需要确认是否与非代理流量、fallback 通道或 Codex 特定内部 endpoint 有关。
+- Even after identity preference from proxy to upstream, Codex may still log zstd decode issues in failure scenarios.
+- Verify whether this is tied to non-proxied traffic, fallback channels, or specific Codex internal endpoints.
 
-## 7. 下一位 Agent Prompt 的快速技术摘要
+## 7. Quick Technical Summary for Next Agent Prompt
 
-如果你需要给另一个 Codex 流程一个简短启动提示：
+If you need an abbreviated bootstrap prompt for another Codex process:
 
-- 分支：`feat/codex-client-support`
-- 核心功能已完成：`--tap-client codex` + OpenAI reverse mode 环境注入。
-- `tests/` 本地通过（`48 passed, 18 skipped`）。
-- 真实 Codex 仍被 `403 missing scopes: api.model.read` 阻塞。
-- 后续先修凭据/scopes，再补真实 Codex E2E 测试与 README 更新。
+- Branch: `feat/codex-client-support`
+- Core feature done: `--tap-client codex` + OpenAI reverse mode env wiring.
+- Tests pass locally (`48 passed, 18 skipped`) for `tests/`.
+- Real Codex still blocked by `403 missing scopes: api.model.read`.
+- Continue by fixing credentials/scopes and adding real Codex E2E tests + README updates.

--- a/docs/plans/2026-02-27-codex-support-plan.md
+++ b/docs/plans/2026-02-27-codex-support-plan.md
@@ -2,57 +2,57 @@
 status: completed
 ---
 
-# Codex 支持计划
+# Codex Support Plan
 
-日期：2026-02-27
+Date: 2026-02-27
 
-## 目标
+## Goal
 
-为 `claude-tap` 增加一等公民级的 Codex 支持，同时保持 Claude 行为完全向后兼容。
+Add first-class Codex support to `claude-tap` while keeping Claude behavior fully backward compatible.
 
-## 范围
+## Scope
 
-- 增加 client 选择：`--tap-client {claude,codex}`。
-- 默认 client 保持为 `claude`。
-- 对 reverse proxy mode 的 `codex` 注入 `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`。
-- 保持现有 Claude 行为：`ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`。
-- 当省略 `--tap-target` 时，按 client 设置默认 upstream target：
+- Add client selection: `--tap-client {claude,codex}`.
+- Keep default client as `claude`.
+- For `codex` in reverse proxy mode, inject `OPENAI_BASE_URL=http://127.0.0.1:<port>/v1`.
+- Keep existing Claude behavior: `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>`.
+- Set default upstream target by client when `--tap-target` is omitted:
   - `claude` -> `https://api.anthropic.com`
   - `codex` -> `https://api.openai.com`
-- 保留现有 forward proxy 行为。
-- 增加 trace metadata `upstream_base_url`，提升 viewer cURL 重建能力。
+- Preserve existing forward proxy behavior.
+- Add trace metadata `upstream_base_url` to improve viewer cURL reconstruction.
 
-## 非目标
+## Non-Goals
 
-- 在本次变更中重命名 package/project 品牌（`claude-tap`）。
-- 在 Claude/Codex 之外增加广泛 provider 抽象。
-- 保证 Codex ChatGPT 登录流在 forward proxy mode 下可用。
+- Rename package/project branding (`claude-tap`) in this change.
+- Add broad provider abstractions beyond Claude/Codex.
+- Guarantee Codex ChatGPT login flow under forward proxy mode.
 
-## 测试策略
+## Test Strategy
 
-- Unit / mock E2E 回归：
+- Unit / mock E2E regression:
   - `uv run pytest tests/test_e2e.py -x --timeout=120`
-- 新增 Codex mock E2E：
+- New Codex mock E2E:
   - fake `codex` binary + fake upstream API
-  - 断言 reverse-mode 请求路径与 `upstream_base_url` trace 字段
-- 仓库 gate 检查：
+  - assert reverse-mode request path and `upstream_base_url` trace field
+- Repo gate checks:
   - `uv run ruff check .`
   - `uv run ruff format --check .`
   - `uv run pytest tests/ -x --timeout=60`
 
-## 成功标准
+## Success Criteria
 
-- Claude 默认工作流不变。
-- `--tap-client codex` 可启动 `codex` 并写出有效 trace 输出。
-- viewer copy-cURL 在存在时使用 `upstream_base_url`。
-- 现有测试套件无回归。
+- Claude default workflow unchanged.
+- `--tap-client codex` launches `codex` and writes valid trace output.
+- Viewer copy-cURL uses `upstream_base_url` if present.
+- No regressions in existing test suite.
 
-## 真实 E2E 验收规则
+## Real E2E Acceptance Rule
 
-对 Codex 真实 E2E 验证，HTTP `403/401` 视为硬失败。
-仅当端到端请求以上游成功响应完成时，才视为运行成功。
+For Codex real E2E validation, HTTP `403/401` is treated as a hard failure.
+A run is considered successful only when the end-to-end request completes with successful upstream responses.
 
-## 风险
+## Risks
 
-- 即便 proxy 连接正确，Codex 账号 scopes 也可能阻塞 model-list 或 response API（`403`）。
-- Codex ChatGPT-web 路由流量可能无法被当前 forward mode 假设完整覆盖。
+- Codex account scopes may block model-list or response APIs (`403`) even if proxy wiring is correct.
+- Codex ChatGPT-web route traffic may not be fully covered by current forward mode assumptions.

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -395,15 +395,7 @@ def _start_fake_upstream(port, handler_fn):
     return stop
 
 
-def _run_claude_tap(
-    project_dir,
-    trace_dir,
-    fake_bin_dir,
-    upstream_port,
-    timeout=30,
-    tap_client="claude",
-    client_args: list[str] | None = None,
-):
+def _run_claude_tap(project_dir, trace_dir, fake_bin_dir, upstream_port, timeout=30, tap_client="claude"):
     """Run claude_tap as a subprocess pointing at `upstream_port`.
     Returns the CompletedProcess."""
     env = os.environ.copy()
@@ -415,14 +407,11 @@ def _run_claude_tap(
         "claude_tap",
         "--tap-output-dir",
         trace_dir,
-        "--tap-no-open",
         "--tap-target",
         f"http://127.0.0.1:{upstream_port}",
     ]
     if tap_client != "claude":
         cmd.extend(["--tap-client", tap_client])
-    if client_args:
-        cmd.extend(client_args)
 
     return subprocess.run(
         cmd,
@@ -1173,7 +1162,7 @@ def test_parse_args():
     # Codex defaults
     a = parse_args(["--tap-client", "codex"])
     assert a.client == "codex"
-    assert a.target == "https://chatgpt.com/backend-api/codex"
+    assert a.target == "https://api.openai.com"
     assert a.claude_args == []
     print("  OK: codex defaults")
 
@@ -1226,7 +1215,7 @@ FAKE_CODEX_SCRIPT = r"""#!/usr/bin/env python3
 import json, os, sys, urllib.request
 
 base = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-url = f"{base}/responses"
+url = f"{base}/messages"
 
 req_body = json.dumps({
     "model": "gpt-5-codex",
@@ -1249,16 +1238,11 @@ print("[fake-codex] Done.")
 
 
 def test_codex_client_reverse_proxy():
-    """Test --tap-client codex in reverse mode using OPENAI_BASE_URL.
-
-    The proxy must strip the /v1 prefix from the request path before forwarding
-    to the upstream, so the fake upstream sees /responses instead of /v1/responses.
-    """
+    """Test --tap-client codex in reverse mode using OPENAI_BASE_URL."""
 
     async def handler(request):
         body = await request.json()
-        # Proxy strips /v1 prefix: /v1/responses -> /responses
-        assert request.path == "/responses", f"expected /responses, got {request.path}"
+        assert request.path == "/messages"
         from aiohttp import web
 
         return web.json_response(
@@ -1292,13 +1276,10 @@ def test_codex_client_reverse_proxy():
         records = [json.loads(line) for line in trace_files[0].read_text().splitlines() if line.strip()]
         assert len(records) == 1
         record = records[0]
-        # Trace records the original path as received from the client
-        assert record["request"]["path"] == "/v1/responses"
+        assert record["request"]["path"] == "/v1/messages"
         assert record["upstream_base_url"] == "http://127.0.0.1:19242"
         assert record["request"]["body"]["model"] == "gpt-5-codex"
         assert "OPENAI_BASE_URL=http://127.0.0.1:" in proc.stdout
-        # WebSocket is now proxied natively — no forced --disable flags
-        assert "--disable responses_websockets" not in proc.stdout
     finally:
         stop()
         _cleanup(trace_dir, fake_bin_dir, "codex")


### PR DESCRIPTION
## Summary
- Add `--tap-client codex` support for proxy tracing with Codex CLI
- Fix PyPI publish workflow: switch from `workflow_run` (blocked by branch protection) to tag-triggered (`v*`) publishing
- Add version tag/pyproject.toml consistency check before publish
- Viewer brand refresh and e2e test improvements

## Publish workflow fix
Root cause: `workflow_run` publish tried to `git push` directly to `main`, but branch protection requires PRs + status checks, causing **all publishes since v0.1.18 to fail**.

New flow: update `pyproject.toml` version in PR → merge → `git tag v0.x.x && git push origin v0.x.x` → auto publish.

## Test plan
- [x] YAML syntax validated
- [x] Version match/mismatch logic tested
- [x] `uv build` succeeds
- [x] `ruff check` + `ruff format --check` pass
- [x] `pytest` — 48 passed, 18 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)