### PR TITLE
chore: bump version to 0.1.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-tap"
-version = "0.1.18"
+version = "0.1.19"
 description = "Trace Claude Code API requests via a local reverse proxy. Inspect system prompts, messages, tools, and token usage."
 requires-python = ">=3.11"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.19 for PyPI release
- After merge, tag `v0.1.19` to trigger the new tag-based publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)