### PR TITLE
feat(skills): add 4 new agent skills and index in AGENTS.md

### DIFF
--- a/.agents/skills/legibility-check.md
+++ b/.agents/skills/legibility-check.md
@@ -1,0 +1,45 @@
+---
+name: legibility-check
+description: Validate docs structure, standards freshness, manifest paths, and plan state. Run this after modifying any file under docs/standards/, docs/plans/, docs/architecture/, or AGENTS.md — it catches stale metadata, broken manifest paths, and plan state drift before CI does.
+user_invocable: true
+---
+
+# Legibility Check
+
+Run deterministic legibility checks that mirror what CI enforces via `.github/workflows/legibility.yml`. Catching these locally saves a round-trip to CI.
+
+## What it checks
+
+1. **Standards freshness** — every `docs/standards/*.md` must have frontmatter with `owner`, `last_reviewed` (ISO date), and `source_of_truth`. Files reviewed more than 60 days ago produce a warning.
+2. **Architecture manifest** — every path listed in `docs/architecture/manifest.yaml` under `expected_paths:` must exist in the repo.
+3. **Plan state drift** — every `docs/plans/**/*.md` must have a `status` frontmatter field (`active`, `completed`, or `cancelled`). Completed plans must not contain unchecked `- [ ]` checkboxes (outside fenced code blocks).
+
+## Run
+
+```bash
+uv run python scripts/check_legibility.py
+```
+
+Options:
+- `--freshness-days N` — change the staleness threshold (default: 60)
+- `--strict-freshness` — promote stale warnings to failures
+- `--repo-root PATH` — override repo root (default: cwd)
+
+## Fixing common failures
+
+| Failure | Fix |
+|---------|-----|
+| `missing frontmatter key 'X'` | Add the missing key to the YAML frontmatter block at the top of the file |
+| `last_reviewed must be ISO date` | Use `YYYY-MM-DD` format |
+| `last_reviewed ... is stale` | Update `last_reviewed` to today's date after reviewing the content |
+| `expected path missing: X` | Either create the file or remove the stale entry from `manifest.yaml` |
+| `status must be one of [...]` | Add `status: active` (or `completed`/`cancelled`) to plan frontmatter |
+| `completed plan still contains unchecked TODO` | Check off remaining items or change status back to `active` |
+
+## After fixing
+
+Re-run the check to confirm all issues are resolved before committing:
+
+```bash
+uv run python scripts/check_legibility.py && echo "All clear"
+```

--- a/.agents/skills/pr-preflight.md
+++ b/.agents/skills/pr-preflight.md
@@ -1,0 +1,79 @@
+---
+name: pr-preflight
+description: Full pre-PR merge-readiness check. Run this before opening or merging a pull request — it validates local gates (lint, format, tests), CI status, screenshot evidence, and PR metadata in one pass. Also useful for reviewing an existing PR's readiness.
+user_invocable: true
+---
+
+# PR Preflight
+
+One-command merge-readiness check that combines local gates, CI status, and PR policy checks. Mirrors what reviewers look for so issues are caught before review, not during.
+
+## Check an existing PR
+
+```bash
+scripts/check_pr.sh <pr_number>
+```
+
+This runs:
+1. **PR metadata** — fetches title, state, draft status, merge state, branch info
+2. **CI checks** — counts pass/fail/pending GitHub Actions checks
+3. **Local gates** — runs lint, format, and tests locally:
+   - `uv run ruff check .`
+   - `uv run ruff format --check .`
+   - `uv run pytest tests/ -x --timeout=60`
+4. **Screenshot evidence** — scans PR body for image links (required by project policy)
+5. **Verdict** — `READY` or `NOT_READY` with specific reasons
+
+### Options
+
+| Flag | Purpose |
+|------|---------|
+| `--repo OWNER/REPO` | Override repository (default: auto-detect via `gh`) |
+| `--no-tests` | Skip local test gates (useful when you just want CI + metadata check) |
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All checks passed — ready to merge |
+| 1 | Script error (missing tool, network failure) |
+| 2 | Not ready — at least one check failed |
+
+## Run local gates only (no PR needed)
+
+If you haven't opened a PR yet and just want to validate locally:
+
+```bash
+uv run ruff check . && uv run ruff format --check . && uv run pytest tests/ -x --timeout=60
+```
+
+Or use the pre-commit hook (auto-runs lint on commit):
+
+```bash
+git config core.hooksPath .githooks
+```
+
+## What blocks merge
+
+The script reports `NOT_READY` if any of these are true:
+- PR is not in OPEN state
+- PR is still a draft
+- Merge state is not CLEAN or HAS_HOOKS
+- Any CI check is failing
+- Any CI check is still pending
+- Local gates (lint/format/tests) fail
+- No screenshot evidence in PR body
+
+## Typical workflow
+
+```bash
+# 1. Make sure local gates pass
+uv run ruff check . && uv run ruff format --check . && uv run pytest tests/ -x --timeout=60
+
+# 2. Push and open PR
+git push origin my-branch
+gh pr create --title "feat: ..." --body "..."
+
+# 3. Wait for CI, then run full preflight
+scripts/check_pr.sh <pr_number>
+```

--- a/.agents/skills/screenshot-validation.md
+++ b/.agents/skills/screenshot-validation.md
@@ -1,0 +1,76 @@
+---
+name: screenshot-validation
+description: Validate screenshot and viewer HTML quality for PR evidence. Run this after adding or modifying images under docs/evidence/ or docs/recordings/, or after generating a new viewer HTML file. Combines image quality checks (resolution, blankness, file size) with Playwright-based viewer rendering verification.
+user_invocable: true
+---
+
+# Screenshot Validation
+
+Validate that evidence images and viewer HTML files meet quality standards before committing. This catches issues that would otherwise fail CI or produce misleading PR evidence.
+
+## Image quality check
+
+Checks PNG/JPG/GIF/WEBP files for:
+- **Minimum dimensions**: 400x400 pixels (hard fail)
+- **Desktop viewport width**: >= 1280px (warning if narrower)
+- **File size**: <= 5MB (warning if larger)
+- **Blankness detection** (PNG only): fails if > 90% of pixels are white/transparent
+
+### Run on specific files or directories
+
+```bash
+uv run python scripts/check_screenshots.py docs/evidence/
+uv run python scripts/check_screenshots.py docs/recordings/
+uv run python scripts/check_screenshots.py path/to/specific-image.png
+```
+
+### Run on git-staged images
+
+```bash
+scripts/check_screenshots.sh
+```
+
+This shell wrapper automatically finds staged PNG/JPG files and runs the quality check on them — useful as a pre-commit sanity check.
+
+## Viewer HTML rendering verification
+
+Uses Playwright (headless Chromium) to verify that generated viewer HTML files actually render correctly — not just raw JSON or Python errors.
+
+Checks:
+- No JavaScript errors on page load
+- Sidebar element exists and has entries
+- Detail panel exists
+- Body text doesn't contain raw JSON dumps or Python tracebacks
+
+### Run
+
+```bash
+uv run python scripts/verify_screenshots.py .traces/trace_*.html
+```
+
+Requires Playwright to be installed (`uv pip install playwright && playwright install chromium`).
+
+## Typical workflow
+
+After generating new evidence for a PR:
+
+```bash
+# 1. Check image quality
+uv run python scripts/check_screenshots.py docs/evidence/
+
+# 2. If you generated new viewer HTML, verify it renders
+uv run python scripts/verify_screenshots.py .traces/trace_*.html
+
+# 3. If all passes, stage and commit
+git add docs/evidence/
+```
+
+## Fixing common failures
+
+| Failure | Fix |
+|---------|-----|
+| `very small image (WxH; minimum is 400x400)` | Retake screenshot at a larger viewport or higher resolution |
+| `narrow desktop viewport (Wpx < 1280px)` | Resize browser window to >= 1280px wide before capturing |
+| `mostly blank/white image` | Ensure the screenshot captures actual content, not an empty page |
+| `No sidebar — viewer not rendered` | Viewer HTML is broken; regenerate from trace JSONL |
+| `JS errors` | Check viewer.html for syntax errors in embedded data |

--- a/.agents/skills/translate-i18n.md
+++ b/.agents/skills/translate-i18n.md
@@ -1,0 +1,69 @@
+---
+name: translate-i18n
+description: Fill missing i18n translations in the viewer HTML. Run this after adding or modifying English or Chinese UI strings in the I18N object inside claude_tap/viewer.html — it auto-translates to ja, ko, fr, ar, de, ru via OpenRouter.
+user_invocable: true
+---
+
+# Translate i18n
+
+Automatically fill missing translations for the viewer's `I18N` object. The script uses English and Chinese as source languages and translates to Japanese, Korean, French, Arabic, German, and Russian.
+
+## Prerequisites
+
+- `OPENROUTER_API_KEY` must be set in the environment (it is in the user's `.zshrc`)
+- Default model: `google/gemini-2.5-flash`
+
+## Workflow
+
+### 1. Check what's missing (dry run)
+
+Always preview first to confirm which keys need translation:
+
+```bash
+uv run python scripts/translate_i18n.py --dry-run
+```
+
+This parses the `I18N` object in `claude_tap/viewer.html`, finds keys present in both `en` and `zh-CN` but missing in other languages, and lists them without modifying the file.
+
+### 2. Run the translation
+
+```bash
+uv run python scripts/translate_i18n.py
+```
+
+The script calls OpenRouter once per target language, then writes the translations back into `viewer.html` in-place — preserving the existing code style (indentation, line endings, packed vs expanded format).
+
+### 3. Verify the result
+
+After translation, run the formatter and tests to make sure nothing broke:
+
+```bash
+uv run ruff format claude_tap/viewer.html
+uv run pytest tests/test_translate_i18n.py -v
+```
+
+## Options
+
+| Flag | Purpose |
+|------|---------|
+| `--dry-run` | Show missing keys only, no file changes |
+| `--model MODEL` | Override the OpenRouter model (default: `google/gemini-2.5-flash`) |
+| `--target {viewer,cli}` | Translation target preset (default: `viewer`) |
+| `--file PATH` | Override target file path |
+| `--object-name NAME` | Override the JS/Python i18n object name |
+
+## How it works
+
+The script:
+1. Extracts the `I18N` JavaScript object from the HTML file using regex
+2. Parses each language block to find existing key-value pairs
+3. Identifies keys present in `en` + `zh-CN` but missing in target languages
+4. Sends a structured prompt to OpenRouter with existing translations for consistency
+5. Normalizes fullwidth punctuation for CJK languages (matching zh-CN style)
+6. Inserts new entries after the last existing key in each language block
+
+## Common scenarios
+
+**Added a new UI string**: Add the key to both `en` and `zh-CN` blocks in the `I18N` object, then run this skill. The other 6 languages will be filled automatically.
+
+**Changed an existing string**: The script only fills *missing* keys. To re-translate an existing key, first delete it from the target language blocks, then run the script.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,45 @@ git config core.hooksPath .githooks
 - 客户端支持矩阵与 URL 构造规则：`docs/support-matrix.md`
 - 标准文档元数据与维护流程：`docs/standards/README.md`
 
+## Skills 目录
+
+可复用的 agent 技能位于 `.agents/skills/`，按功能分类：
+
+### 测试
+- `e2e-test`：pytest E2E 测试套件
+- `real-e2e-test`：真实 Claude CLI E2E 测试（pytest + tmux 模式）
+- `js-in-html-testing`：HTML 内嵌 JS 的两层测试策略（Python 单测 + Playwright）
+
+### 验证
+- `legibility-check`：文档结构、标准 freshness、manifest 路径、plan 状态检查
+- `screenshot-validation`：截图质量 + viewer HTML 渲染验证
+- `pr-preflight`：PR 合并就绪全面检查（lint + test + CI + 截图）
+
+### 翻译
+- `translate-i18n`：自动补全 viewer I18N 缺失翻译（via OpenRouter）
+
+### 发布
+- `push-release`：推送代码并按需 bump 版本触发 PyPI 发布
+
+### 资产生成
+- `demo-video`：从真实 E2E 运行录制演示视频
+- `playwright-screen-recording`：Playwright 录屏用于 PR review
+
+## Scripts 目录
+
+`scripts/` 下的确定性脚本，部分已被 skill 包装：
+
+| 脚本 | 对应 Skill | 用途 |
+|------|-----------|------|
+| `check_legibility.py` | `legibility-check` | 文档可读性检查（CI: `legibility.yml`） |
+| `check_screenshots.py` | `screenshot-validation` | 截图质量检查（CI: `ci.yml`） |
+| `check_screenshots.sh` | `screenshot-validation` | 检查 git staged 图片的 shell 包装 |
+| `verify_screenshots.py` | `screenshot-validation` | Playwright viewer HTML 渲染验证 |
+| `check_pr.sh` | `pr-preflight` | PR 合并就绪检查 |
+| `translate_i18n.py` | `translate-i18n` | 自动翻译 i18n 缺失 key |
+| `run_real_e2e.sh` | `real-e2e-test` | 真实 E2E（非 tmux） |
+| `run_real_e2e_tmux.sh` | `real-e2e-test` | 真实 E2E（tmux 交互模式） |
+
 ## 可读性检查
 
 确定性的可读性检查由 `scripts/check_legibility.py` 实现，并在 CI 中通过 `.github/workflows/legibility.yml` 运行。


### PR DESCRIPTION
## Summary
- Add 4 new agent skills wrapping existing scripts: `legibility-check`, `screenshot-validation`, `pr-preflight`, `translate-i18n`
- Add Skills directory and Scripts directory sections to `AGENTS.md` with categorized index and script-to-skill mapping table
- All 8 scripts now have corresponding skill definitions for agent discoverability

## Test plan
- [ ] Verify new skill files exist under `.agents/skills/`
- [ ] Verify `AGENTS.md` renders correctly with new sections
- [ ] CI lint and legibility checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)