### PR TITLE
feat: make --tap-live the default, add --tap-no-live to opt out

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -432,12 +432,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "All flags not listed below are forwarded to the selected client.",
         epilog=(
             "claude code:\n"
-            "  claude-tap                            Basic tracing\n"
-            "  claude-tap --tap-live                 Real-time viewer in browser\n"
+            "  claude-tap                            Trace with real-time viewer (default)\n"
+            "  claude-tap --tap-no-live              Record only, no live viewer\n"
             "  claude-tap -- --model claude-opus-4-6  Pass flags to Claude Code\n"
             "  claude-tap -- -c                      Continue last conversation\n"
             "  claude-tap -- --dangerously-skip-permissions  Auto-accept tool calls\n"
-            "  claude-tap --tap-live -- --dangerously-skip-permissions --model claude-sonnet-4-6\n"
+            "  claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6\n"
             "\n"
             "codex cli:\n"
             "  # API Key users (OPENAI_API_KEY) — default target works out of the box\n"
@@ -505,10 +505,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Don't auto-open HTML viewer after exit",
     )
     viewer_group.add_argument(
-        "--tap-live",
-        action="store_true",
+        "--tap-no-live",
+        action="store_false",
         dest="live_viewer",
-        help="Start real-time viewer server (auto-opens browser)",
+        default=True,
+        help="Disable real-time viewer server (only record traces)",
     )
     viewer_group.add_argument(
         "--tap-live-port",


### PR DESCRIPTION
## Summary

- Live viewer is the most common use case — defaulting to it removes the need to remember the `--tap-live` flag
- Users who only want trace recording can pass `--tap-no-live`

## Changes

- Replace `--tap-live` (opt-in) with `--tap-no-live` (opt-out), default `live_viewer=True`
- Update help text and examples in CLI epilog

## Test plan

- [x] `test_parse_args` passes
- [x] All 116 existing non-browser tests pass
- [x] Manual verification: `claude-tap` now opens live viewer by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)