### PR TITLE
feat(codex): auto-detect ChatGPT target and force HTTP transport

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -333,6 +333,7 @@ async def async_main(args: argparse.Namespace):
             "session": session,
             "turn_counter": 0,
             "strip_path_prefix": "/v1" if args.client == "codex" and "api.openai.com" not in args.target else "",
+            "force_http": args.client == "codex",
         }
         app.router.add_route("*", "/{path_info:.*}", proxy_handler)
 
@@ -451,6 +452,27 @@ async def async_main(args: argparse.Namespace):
     return exit_code
 
 
+_CODEX_CHATGPT_TARGET = "https://chatgpt.com/backend-api/codex"
+
+
+def _detect_codex_target() -> str:
+    """Auto-detect the correct upstream target for Codex CLI.
+
+    Reads ``~/.codex/auth.json`` (or ``$CODEX_HOME/auth.json``) to determine
+    the auth mode.  ChatGPT OAuth users (``codex login``) need the chatgpt.com
+    backend; API-key users use api.openai.com.
+    """
+    codex_home = Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
+    auth_file = codex_home / "auth.json"
+    try:
+        data = json.loads(auth_file.read_text(encoding="utf-8"))
+        if isinstance(data, dict) and data.get("auth_mode") == "chatgpt":
+            return _CODEX_CHATGPT_TARGET
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+    return CLIENT_CONFIGS["codex"].default_target
+
+
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse argv, extracting ``--tap-*`` flags for ourselves and forwarding
     everything else to the selected client.
@@ -514,7 +536,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--tap-target",
         default=None,
         dest="target",
-        help="Upstream API URL (default: provider-specific)",
+        help="Upstream API URL (default: auto-detected from auth state)",
     )
     proxy_group.add_argument(
         "--tap-proxy-mode",
@@ -584,7 +606,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     if args.host is None:
         args.host = "0.0.0.0" if args.no_launch else "127.0.0.1"
     if args.target is None:
-        args.target = CLIENT_CONFIGS[args.client].default_target
+        if args.client == "codex":
+            args.target = _detect_codex_target()
+        else:
+            args.target = CLIENT_CONFIGS[args.client].default_target
     return args
 
 

--- a/claude_tap/proxy.py
+++ b/claude_tap/proxy.py
@@ -97,6 +97,11 @@ async def proxy_handler(request: web.Request) -> web.StreamResponse:
 
     # Detect WebSocket upgrade and route to WS proxy
     if request.headers.get("Upgrade", "").lower() == "websocket":
+        # When force_http is set (default for Codex), reject WebSocket upgrades
+        # with 426 so the client immediately falls back to HTTP streaming.
+        if request.app["trace_ctx"].get("force_http"):
+            log.info(f"Rejecting WebSocket upgrade on {request.path} (force_http); client will fallback to HTTP")
+            return web.Response(status=426, text="Upgrade Required")
         return await _handle_websocket(request)
 
     ctx: dict = request.app["trace_ctx"]

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,7 @@ wheels = [
 
 [[package]]
 name = "claude-tap"
-version = "0.1.19"
+version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary

Two independent Codex UX improvements, stacked on top of PR #69's base URL fix:

1. **Auto-detect upstream target** from `~/.codex/auth.json` — ChatGPT OAuth users (via `codex login`) no longer need to pass `--tap-target https://chatgpt.com/backend-api/codex` manually. Falls back to `api.openai.com` for API-key users.

2. **Reject WebSocket upgrades with 426** (default for Codex). Codex v0.120.0+ prefers WebSocket transport, which hides multiple turns inside one long-lived connection — the live viewer only updates when the WS closes. Returning 426 triggers Codex's built-in WS→HTTP fallback immediately (no retry waste), so each turn becomes an independent HTTP/SSE record that appears in real time.

## Test plan
- [x] \`uv run ruff check .\` passes
- [x] \`uv run ruff format --check .\` passes
- [x] \`uv run pytest tests/ --ignore=tests/e2e --ignore=tests/test_e2e.py\` — 110 passed
- [x] Real E2E: \`claude-tap --tap-client codex\` with ChatGPT auth captures 2 API calls (models + responses) with WS 426 fallback working correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)