### PR TITLE
fix(codex): restore proxy compatibility and reconstruct WS traces

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -107,6 +107,7 @@ async def run_client(
     env = os.environ.copy()
 
     cmd_args = list(extra_args)
+    has_openai_base_override = _has_config_override(cmd_args, "openai_base_url")
 
     if proxy_mode == "forward":
         proxy_url = f"http://127.0.0.1:{port}"
@@ -119,6 +120,9 @@ async def run_client(
         env["all_proxy"] = proxy_url
         if ca_cert_path:
             env["NODE_EXTRA_CA_CERTS"] = str(ca_cert_path)
+            # Codex is a Rust binary; NODE_EXTRA_CA_CERTS does not affect its TLS stack.
+            env["SSL_CERT_FILE"] = str(ca_cert_path)
+            env["CODEX_CA_CERTIFICATE"] = str(ca_cert_path)
 
         if client == "claude":
             # Claude Code may source proxy env from settings rather than process env.
@@ -143,6 +147,10 @@ async def run_client(
         base_url = cfg.reverse_base_url(port)
         env[cfg.base_url_env] = base_url
         env["NO_PROXY"] = "127.0.0.1"
+        if client == "codex" and not has_openai_base_override:
+            # Newer Codex builds may ignore OPENAI_BASE_URL in OAuth/WebSocket mode
+            # unless the same value is also supplied as a config override.
+            cmd_args = ["-c", f'openai_base_url="{base_url}"'] + cmd_args
 
     for key in cfg.nesting_env_keys:
         env.pop(key, None)
@@ -232,6 +240,25 @@ async def run_client(
 
     print(f"\n📋 {cfg.label} exited with code {code}")
     return code
+
+
+def _has_config_override(args: list[str], key: str) -> bool:
+    """Return True when argv already contains a matching -c/--config override."""
+    prefixes = (f"{key}=",)
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg in ("-c", "--config"):
+            if i + 1 < len(args) and args[i + 1].startswith(prefixes):
+                return True
+            i += 2
+            continue
+        if arg.startswith("--config="):
+            value = arg.split("=", 1)[1]
+            if value.startswith(prefixes):
+                return True
+        i += 1
+    return False
 
 
 async def async_main(args: argparse.Namespace):

--- a/claude_tap/proxy.py
+++ b/claude_tap/proxy.py
@@ -564,35 +564,18 @@ def _build_ws_record(
     error: str | None = None,
 ) -> dict:
     """Build a trace record for a WebSocket session."""
-    # Parse client messages to find request body
-    req_body = None
-    for msg in client_messages:
-        try:
-            parsed = json.loads(msg)
-            if req_body is None:
-                req_body = parsed
-        except (json.JSONDecodeError, ValueError):
-            pass
+    req_body = _reconstruct_ws_request_body(client_messages)
 
     # Parse server messages into structured events
     ws_events: list[dict] = []
-    resp_body = None
     for msg in server_messages:
         try:
             parsed = json.loads(msg)
             ws_events.append(parsed)
-            # Terminal events carry the final response
-            if parsed.get("type") in ("response.completed", "response.done"):
-                resp_body = parsed.get("response", parsed)
         except (json.JSONDecodeError, ValueError):
             ws_events.append({"raw": msg})
 
-    # Fallback: use response.created if no terminal event seen
-    if resp_body is None:
-        for evt in ws_events:
-            if isinstance(evt, dict) and evt.get("type") == "response.created":
-                resp_body = evt.get("response", evt)
-                break
+    resp_body = _reconstruct_ws_response_body(ws_events)
 
     record: dict = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
@@ -619,3 +602,89 @@ def _build_ws_record(
     if upstream_base_url:
         record["upstream_base_url"] = upstream_base_url
     return record
+
+
+def _reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
+    """Merge client WebSocket messages into the most complete request body."""
+    merged: dict | None = None
+    for msg in client_messages:
+        try:
+            parsed = json.loads(msg)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        if merged is None:
+            merged = parsed.copy()
+            continue
+        for key, value in parsed.items():
+            if key in ("input", "tools"):
+                if value:
+                    merged[key] = value
+                else:
+                    merged.setdefault(key, value)
+                continue
+            if value not in (None, "", [], {}):
+                merged[key] = value
+            else:
+                merged.setdefault(key, value)
+    return merged
+
+
+def _reconstruct_ws_response_body(ws_events: list[dict]) -> dict | None:
+    """Build a best-effort response body from WS events.
+
+    Recent Codex versions may emit multiple response.completed events and keep
+    the actual assistant text inside response.output_item.done rather than the
+    terminal response payload. Reconstruct a richer body for traces/viewer use.
+    """
+    merged: dict | None = None
+    output_items: dict[int, dict] = {}
+
+    for event in ws_events:
+        if not isinstance(event, dict):
+            continue
+
+        event_type = event.get("type")
+        payload = event.get("response", event)
+        if isinstance(payload, dict) and event_type in (
+            "response.created",
+            "response.in_progress",
+            "response.completed",
+            "response.done",
+        ):
+            if merged is None:
+                merged = payload.copy()
+            else:
+                for key, value in payload.items():
+                    if key == "output":
+                        if value:
+                            merged[key] = value
+                        else:
+                            merged.setdefault(key, value)
+                        continue
+                    if key == "usage":
+                        if value:
+                            merged[key] = value
+                        else:
+                            merged.setdefault(key, value)
+                        continue
+                    if value not in (None, "", [], {}):
+                        merged[key] = value
+                    else:
+                        merged.setdefault(key, value)
+
+        if event_type == "response.output_item.done":
+            item = event.get("item")
+            output_index = event.get("output_index")
+            if isinstance(item, dict) and isinstance(output_index, int):
+                output_items[output_index] = item
+
+    if output_items:
+        ordered_output = [output_items[idx] for idx in sorted(output_items)]
+        if merged is None:
+            merged = {"output": ordered_output}
+        elif not merged.get("output"):
+            merged["output"] = ordered_output
+
+    return merged

--- a/tests/test_codex_launch.py
+++ b/tests/test_codex_launch.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from claude_tap.cli import _has_config_override, run_client
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.pid = 12345
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+@pytest.mark.asyncio
+async def test_run_client_codex_reverse_injects_openai_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/codex")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["exec", "hello"], client="codex", proxy_mode="reverse")
+
+    assert code == 0
+    assert captured["cmd"] == (
+        "codex",
+        "-c",
+        'openai_base_url="http://127.0.0.1:43123/v1"',
+        "exec",
+        "hello",
+    )
+    assert captured["env"]["OPENAI_BASE_URL"] == "http://127.0.0.1:43123/v1"
+
+
+@pytest.mark.asyncio
+async def test_run_client_codex_reverse_respects_existing_openai_base_override(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/codex")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(
+        43123,
+        ["-c", 'openai_base_url="http://example.invalid/v1"', "exec", "hello"],
+        client="codex",
+        proxy_mode="reverse",
+    )
+
+    assert code == 0
+    assert captured["cmd"] == (
+        "codex",
+        "-c",
+        'openai_base_url="http://example.invalid/v1"',
+        "exec",
+        "hello",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_client_codex_forward_sets_rust_tls_ca_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    ca_path = Path("/tmp/test-ca.pem")
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/codex")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["exec", "hello"], client="codex", proxy_mode="forward", ca_cert_path=ca_path)
+
+    assert code == 0
+    assert captured["env"]["HTTPS_PROXY"] == "http://127.0.0.1:43123"
+    assert captured["env"]["SSL_CERT_FILE"] == str(ca_path)
+    assert captured["env"]["CODEX_CA_CERTIFICATE"] == str(ca_path)
+
+
+def test_has_config_override_detects_cli_forms() -> None:
+    assert _has_config_override(["-c", 'openai_base_url="http://127.0.0.1:1/v1"'], "openai_base_url") is True
+    assert _has_config_override(["--config", 'openai_base_url="http://127.0.0.1:1/v1"'], "openai_base_url") is True
+    assert _has_config_override(['--config=openai_base_url="http://127.0.0.1:1/v1"'], "openai_base_url") is True
+    assert _has_config_override(["exec", "hello"], "openai_base_url") is False

--- a/tests/test_ws_proxy.py
+++ b/tests/test_ws_proxy.py
@@ -11,7 +11,7 @@ import pytest
 from aiohttp import web
 from yarl import URL
 
-from claude_tap.proxy import _get_ws_proxy_settings, proxy_handler
+from claude_tap.proxy import _build_ws_record, _get_ws_proxy_settings, proxy_handler
 from claude_tap.trace import TraceWriter
 
 
@@ -250,6 +250,75 @@ async def test_websocket_upstream_failure(trace_dir):
     finally:
         await proxy_session.close()
         await proxy_runner.cleanup()
+
+
+def test_build_ws_record_merges_incremental_request_and_output_items() -> None:
+    record = _build_ws_record(
+        req_id="req_test",
+        turn=1,
+        duration_ms=25,
+        path_qs="/v1/responses",
+        req_headers={"Authorization": "Bearer test-token"},
+        client_messages=[
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "model": "gpt-5.4",
+                    "instructions": "You are Codex.",
+                    "input": [],
+                    "tools": [{"type": "function", "name": "exec_command"}],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+                }
+            ),
+        ],
+        server_messages=[
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_1",
+                        "status": "completed",
+                        "output": [],
+                        "usage": {"input_tokens": 10, "output_tokens": 0},
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 1,
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "status": "completed",
+                        "content": [{"type": "output_text", "text": "HELLO_FROM_WS"}],
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_1",
+                        "status": "completed",
+                        "output": [],
+                        "usage": {"input_tokens": 10, "output_tokens": 2},
+                    },
+                }
+            ),
+        ],
+        upstream_base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert record["request"]["body"]["input"][0]["content"][0]["text"] == "hello"
+    assert record["request"]["body"]["tools"][0]["name"] == "exec_command"
+    assert record["response"]["body"]["usage"] == {"input_tokens": 10, "output_tokens": 2}
+    assert record["response"]["body"]["output"][0]["content"][0]["text"] == "HELLO_FROM_WS"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
- Symptoms: recent Codex CLI builds stopped producing usable traces in `claude-tap`. Reverse mode often ended with `API calls: 0`, and captured WebSocket traces could show empty `input` or miss the final assistant output.
- Root cause: Codex CLI v0.122.0-alpha.1 no longer reliably honors plain `OPENAI_BASE_URL` for the traced path, and the existing WebSocket trace builder only kept the first client message plus incomplete terminal response payloads.

## Fix Summary
- inject a Codex-compatible `-c openai_base_url=...` override in reverse mode instead of relying on `OPENAI_BASE_URL` alone
- export Rust TLS CA env vars in forward mode so Codex can trust the local MITM certificate path
- reconstruct WebSocket request and response bodies from incremental Codex messages, including final output items and usage
- add focused regression coverage for Codex launch wiring and WebSocket reconstruction

## Scope
- Areas touched: Codex launch wiring in `claude_tap/cli.py`, WebSocket trace reconstruction in `claude_tap/proxy.py`, and targeted regression tests
- Explicitly not changed: Claude-specific transport behavior, viewer layout, and broader end-to-end coverage beyond this fix

## Validation
- [x] Old behavior was reproduced or inspected with concrete evidence
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run python3 -m pytest tests/ -x --timeout=60`
- [x] Fix verification and regression checks are listed below
- [x] UI changes include `raw.githubusercontent.com` screenshot URLs when applicable
- [x] Any screenshots, recordings, or demos use real `.traces/` data
- [x] No UI screenshot evidence was required because this PR does not change the UI

## Results
- Reverse mode now captures real Codex traffic again instead of finishing with `API calls: 0`
- Captured traces now include the reconstructed request `input`, final assistant `output`, and token `usage` for the tested Codex path
- Targeted regression tests pass locally and full repo gates remain green

## Evidence
- Reproduction trace / logs: before the fix, a real reverse-mode Codex run finished successfully but `claude-tap` reported `API calls: 0`
- Fix verification trace / logs: after the fix, a real reverse-mode run captured `API calls: 1` with request `input` and final `output`; a real forward-mode run captured `16` API calls after WebSocket fallback behavior
- Real validation commands executed: `uv run python3 -m claude_tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex ...` and `uv run python3 -m claude_tap --tap-client codex --tap-proxy-mode forward ...`

## Follow-up
- Broader reliable real Codex E2E coverage is intentionally deferred to follow-up issue #71

## Risk / Rollback
- Main risk: newer Codex builds may change config precedence or WebSocket event shapes again, which would most likely break trace capture rather than normal Codex execution
- Rollback plan: revert this PR to restore the previous Codex launch and WebSocket trace handling behavior