### PR TITLE
chore(github): add focused pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/chore.md
+++ b/.github/PULL_REQUEST_TEMPLATE/chore.md
@@ -1,0 +1,30 @@
+## Summary
+- 
+- 
+- 
+
+## Context
+- Why this maintenance change is needed now:
+- What friction, drift, or operational cost it removes:
+
+## Scope
+- Areas touched:
+- Explicitly not changed:
+
+## Validation
+- [x] `uv run ruff check .`
+- [x] `uv run ruff format --check .`
+- [x] `uv run pytest tests/ -x --timeout=60`
+- [x] Any required evidence uses real data from `.traces/`
+- [ ] If any gate is skipped, explain why and get reviewer approval before merge
+
+## Results
+- 
+- 
+
+## Follow-up
+- Remaining issues or debt to address later:
+
+## Risk / Rollback
+- Main risk:
+- Rollback plan:

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,0 +1,20 @@
+## Summary
+- 
+- 
+- 
+
+## Purpose
+- Why this document, plan, or note is needed now:
+- How it relates to implementation or reviewer workflow:
+
+## Scope
+- Files updated:
+- Code paths explicitly not changed:
+
+## Validation
+- [x] Content reviewed for accuracy and consistency
+- [x] Links, commands, and paths were checked
+- [ ] No code execution was required
+
+## Notes
+- If this PR changes standards or workflow docs, mention any follow-up checks or owner review needed:

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,35 @@
+## Summary
+- 
+- 
+- 
+
+## Background
+- Current limitation:
+- Why this feature is being added now:
+
+## Scope
+- Areas touched:
+- Explicitly not changed:
+
+## Validation
+- [x] `uv run ruff check .`
+- [x] `uv run ruff format --check .`
+- [x] `uv run pytest tests/ -x --timeout=60`
+- [x] Functional, smoke, or E2E verification is listed below
+- [x] UI changes include `raw.githubusercontent.com` screenshot URLs when applicable
+- [x] Any screenshots, recordings, or demos use real `.traces/` data
+- [ ] If any gate or evidence is skipped, explain why and get reviewer approval before merge
+
+## Results
+- 
+- 
+
+## Evidence
+- Screenshots / recordings / trace files:
+
+## Follow-up
+- Known gaps left out of this PR:
+
+## Risk / Rollback
+- Main risk:
+- Rollback plan:

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -1,0 +1,37 @@
+## Problem
+- Symptoms:
+- Root cause:
+
+## Fix Summary
+- 
+- 
+- 
+
+## Scope
+- Areas touched:
+- Explicitly not changed:
+
+## Validation
+- [x] Old behavior was reproduced or inspected with concrete evidence
+- [x] `uv run ruff check .`
+- [x] `uv run ruff format --check .`
+- [x] `uv run pytest tests/ -x --timeout=60`
+- [x] Fix verification and regression checks are listed below
+- [x] UI changes include `raw.githubusercontent.com` screenshot URLs when applicable
+- [x] Any screenshots, recordings, or demos use real `.traces/` data
+- [ ] If any gate or evidence is skipped, explain why and get reviewer approval before merge
+
+## Results
+- 
+- 
+
+## Evidence
+- Reproduction trace / logs:
+- Fix verification trace / logs:
+
+## Follow-up
+- Remaining issues intentionally deferred:
+
+## Risk / Rollback
+- Main risk:
+- Rollback plan:

--- a/.github/PULL_REQUEST_TEMPLATE/plan.md
+++ b/.github/PULL_REQUEST_TEMPLATE/plan.md
@@ -1,0 +1,20 @@
+## Goal
+- This PR only updates design, plan, checklist, or TODO material.
+
+## Outputs
+- New or updated design docs:
+- New or updated TODO / plan entries:
+- Planned phases or milestones:
+
+## Key Decisions
+- Decision 1:
+- Decision 2:
+- Explicitly deferred:
+
+## Validation
+- [x] Plan or design reviewed for scope clarity
+- [x] Proposed phases and ownership are clear
+- [ ] No code execution was required
+
+## Follow-up
+- Expected implementation PRs or branches:

--- a/.github/PULL_REQUEST_TEMPLATE/refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactor.md
@@ -1,0 +1,30 @@
+## Refactor Summary
+- 
+- 
+- 
+
+## Background
+- Why this refactor is needed now:
+- What complexity, duplication, or debt it reduces:
+
+## Invariants
+- External behavior expected to remain unchanged:
+- Internal structure being improved:
+
+## Validation
+- [x] `uv run ruff check .`
+- [x] `uv run ruff format --check .`
+- [x] `uv run pytest tests/ -x --timeout=60`
+- [x] Regression verification is listed below
+- [ ] If any gate is skipped, explain why and get reviewer approval before merge
+
+## Results
+- 
+- 
+
+## Follow-up
+- Remaining cleanup intentionally deferred:
+
+## Risk / Rollback
+- Most likely regression point:
+- Rollback plan:

--- a/.github/PULL_REQUEST_TEMPLATE/test.md
+++ b/.github/PULL_REQUEST_TEMPLATE/test.md
@@ -1,0 +1,33 @@
+## Summary
+- 
+- 
+- 
+
+## Background
+- Why test coverage is being added or adjusted:
+- Risks this test work is meant to cover:
+
+## Scope
+- New or updated tests:
+- Covered code paths:
+
+## Validation
+- [x] `uv run ruff check .`
+- [x] `uv run ruff format --check .`
+- [x] `uv run pytest tests/ -x --timeout=60`
+- [x] Any real E2E assertions and evidence are listed below
+- [ ] If any gate or test path is skipped, explain why and get reviewer approval before merge
+
+## Results
+- 
+- 
+
+## Evidence
+- Relevant traces, logs, or recordings:
+
+## Follow-up
+- Remaining coverage gaps intentionally deferred:
+
+## Risk / Rollback
+- Main risk:
+- Rollback plan:


### PR DESCRIPTION
## Summary
- add a multi-template `.github/PULL_REQUEST_TEMPLATE/` layout modeled on the SoTALab reference repo structure
- tailor each template to `claude-tap` project rules, especially local gates, real `.traces/` evidence, and `raw.githubusercontent.com` screenshot requirements for UI changes
- keep the templates English-only and aligned with the repo single-focus workflow

## Context
- Why this maintenance change is needed now: recent PR metadata was inconsistent in title/body structure, and this repo did not yet provide a first-class template set for different PR types
- What friction, drift, or operational cost it removes: reviewers no longer need to repeatedly request missing sections for validation, scope, evidence, follow-up, and rollback planning

## Scope
- Areas touched: `.github/PULL_REQUEST_TEMPLATE/` with `chore`, `docs`, `feature`, `fix`, `plan`, `refactor`, and `test` templates
- Explicitly not changed: code paths, runtime behavior, CI logic, and any viewer or proxy functionality

## Validation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run python3 -m pytest tests/ -x --timeout=60`
- [x] Any required evidence uses real data from `.traces/`
- [x] No trace or screenshot evidence was required because this PR only adds GitHub metadata templates and does not change product behavior

## Results
- The repo now has focused PR templates for the major change types already used in practice
- Template prompts now explicitly enforce this repo standards around validation, evidence, scope clarity, and follow-up disclosure
- New PRs can start from a body shape that is much closer to reviewer expectations, reducing rework during review

## Follow-up
- If maintainers want stricter defaulting later, the next step would be adding a default PR template chooser or additional automation around PR metadata quality

## Risk / Rollback
- Main risk: template wording may prove too strict or too verbose for some PR categories and need iteration after real usage
- Rollback plan: remove or simplify the added template files without affecting any runtime code or release behavior