### PR TITLE
fix(cli): unbreak claude-tap on Windows (#83)

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -29,9 +29,12 @@ from claude_tap.proxy import proxy_handler
 from claude_tap.trace import TraceWriter
 from claude_tap.viewer import _generate_html_viewer
 
-# Ensure print output is visible immediately (uv tool pipes stdout with full buffering)
+# Force UTF-8 + line-buffered stdout/stderr so emoji output works on Windows
+# consoles (GBK/cp936) and `uv tool` doesn't fully buffer our progress prints.
 if hasattr(sys.stdout, "reconfigure"):
-    sys.stdout.reconfigure(line_buffering=True)
+    sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace", line_buffering=True)
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
 
 log = logging.getLogger("claude-tap")
 
@@ -100,7 +103,11 @@ async def run_client(
 ) -> int:
     cfg = CLIENT_CONFIGS[client]
 
-    if shutil.which(cfg.cmd) is None:
+    # Resolve to absolute path: on Windows, npm shims like `claude.cmd` are not
+    # found by CreateProcess (used by asyncio.create_subprocess_exec), which
+    # only auto-appends `.exe`.
+    resolved_cmd = shutil.which(cfg.cmd)
+    if resolved_cmd is None:
         print(cfg.missing_help)
         return 1
 
@@ -155,8 +162,9 @@ async def run_client(
     for key in cfg.nesting_env_keys:
         env.pop(key, None)
 
-    cmd = [cfg.cmd] + cmd_args
-    print(f"\n🚀 Starting {cfg.label}: {' '.join(cmd)}")
+    cmd = [resolved_cmd] + cmd_args
+    display_cmd = " ".join([cfg.cmd, *cmd_args]).rstrip()
+    print(f"\n🚀 Starting {cfg.label}: {display_cmd}")
     if proxy_mode == "forward":
         print(f"   HTTPS_PROXY=http://127.0.0.1:{port}")
         if ca_cert_path:
@@ -187,8 +195,9 @@ async def run_client(
     # --- Signal handling: graceful Ctrl+C / Ctrl+Z ---
     loop = asyncio.get_running_loop()
 
-    # Prevent Ctrl+Z from suspending the session
-    old_sigtstp = signal.signal(signal.SIGTSTP, signal.SIG_IGN)
+    # SIGTSTP is Unix-only; on Windows the attribute is absent.
+    sigtstp = getattr(signal, "SIGTSTP", None)
+    old_sigtstp = signal.signal(sigtstp, signal.SIG_IGN) if sigtstp is not None else None
 
     sigint_count = 0
 
@@ -210,7 +219,8 @@ async def run_client(
 
     try:
         loop.add_signal_handler(signal.SIGINT, _handle_sigint)
-        loop.add_signal_handler(signal.SIGTSTP, _handle_sigtstp)
+        if sigtstp is not None:
+            loop.add_signal_handler(sigtstp, _handle_sigtstp)
     except (NotImplementedError, OSError):
         pass
 
@@ -228,15 +238,17 @@ async def run_client(
         signal.signal(signal.SIGTTOU, old_sigttou)
 
     # Restore original SIGTSTP handler and remove async signal handlers
-    signal.signal(signal.SIGTSTP, old_sigtstp)
+    if sigtstp is not None and old_sigtstp is not None:
+        signal.signal(sigtstp, old_sigtstp)
     try:
         loop.remove_signal_handler(signal.SIGINT)
     except (NotImplementedError, OSError):
         pass
-    try:
-        loop.remove_signal_handler(signal.SIGTSTP)
-    except (NotImplementedError, OSError):
-        pass
+    if sigtstp is not None:
+        try:
+            loop.remove_signal_handler(sigtstp)
+        except (NotImplementedError, OSError):
+            pass
 
     print(f"\n📋 {cfg.label} exited with code {code}")
     return code

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -103,9 +103,8 @@ async def run_client(
 ) -> int:
     cfg = CLIENT_CONFIGS[client]
 
-    # Resolve to absolute path: on Windows, npm shims like `claude.cmd` are not
-    # found by CreateProcess (used by asyncio.create_subprocess_exec), which
-    # only auto-appends `.exe`.
+    # asyncio.create_subprocess_exec uses CreateProcess on Windows, which only
+    # auto-appends `.exe`; resolve here so npm `.cmd`/`.bat` shims also work.
     resolved_cmd = shutil.which(cfg.cmd)
     if resolved_cmd is None:
         print(cfg.missing_help)
@@ -163,8 +162,7 @@ async def run_client(
         env.pop(key, None)
 
     cmd = [resolved_cmd] + cmd_args
-    display_cmd = " ".join([cfg.cmd, *cmd_args]).rstrip()
-    print(f"\n🚀 Starting {cfg.label}: {display_cmd}")
+    print(f"\n🚀 Starting {cfg.label}: {' '.join([cfg.cmd, *cmd_args])}")
     if proxy_mode == "forward":
         print(f"   HTTPS_PROXY=http://127.0.0.1:{port}")
         if ca_cert_path:

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -425,9 +425,9 @@ async def async_main(args: argparse.Namespace):
         _generate_html_viewer(trace_path, html_path)
 
         # Register trace and cleanup old ones
-        trace_files = [str(trace_path.relative_to(output_dir)), str(log_path.relative_to(output_dir))]
+        trace_files = [_rel_posix(trace_path, output_dir), _rel_posix(log_path, output_dir)]
         if html_path.exists():
-            trace_files.append(str(html_path.relative_to(output_dir)))
+            trace_files.append(_rel_posix(html_path, output_dir))
         _register_trace(output_dir, ts, trace_files)
         if args.max_traces > 0:
             cleaned = _cleanup_traces(output_dir, args.max_traces)
@@ -457,7 +457,7 @@ async def async_main(args: argparse.Namespace):
         # Open viewer in browser (default: auto-open unless --tap-no-open)
         if args.open_viewer and html_path.exists():
             print("\n🌐 Opening viewer in browser...")
-            _open_browser(f"file://{html_path.absolute()}")
+            _open_browser(html_path.absolute().as_uri())
 
     return exit_code
 
@@ -663,7 +663,10 @@ def _start_background_update(installer: str) -> subprocess.Popen | None:
     """Start a background process to upgrade claude-tap."""
     try:
         if installer == "uv":
-            cmd = ["uv", "tool", "upgrade", "claude-tap"]
+            uv_path = shutil.which("uv")
+            if uv_path is None:
+                return None
+            cmd = [uv_path, "tool", "upgrade", "claude-tap"]
         else:
             cmd = [sys.executable, "-m", "pip", "install", "--upgrade", "claude-tap"]
         return subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -676,6 +679,11 @@ def _start_background_update(installer: str) -> subprocess.Popen | None:
 # ---------------------------------------------------------------------------
 
 _MANIFEST_FILE = ".cloudtap-manifest.json"
+
+
+def _rel_posix(path: Path, base: Path) -> str:
+    # Forward slashes so manifests stay portable when `.traces` is synced across OSes.
+    return path.relative_to(base).as_posix()
 
 
 def _load_manifest(output_dir: Path) -> dict:
@@ -750,12 +758,13 @@ def _cleanup_traces(output_dir: Path, max_traces: int) -> int:
 
 def _maybe_migrate_existing(output_dir: Path, manifest: dict) -> None:
     """Auto-register existing trace_*.jsonl files that are not yet in the manifest."""
-    known_files: set[str] = set()
-    for entry in manifest.get("traces", []):
-        known_files.update(entry.get("files", []))
+    # Normalize separators so manifests written by older Windows builds (with `\`) still match.
+    known_files: set[str] = {
+        f.replace("\\", "/") for entry in manifest.get("traces", []) for f in entry.get("files", [])
+    }
 
     for jsonl in sorted(output_dir.glob("**/trace_*.jsonl")):
-        rel = str(jsonl.relative_to(output_dir))
+        rel = _rel_posix(jsonl, output_dir)
         if rel in known_files or jsonl.name in known_files:
             continue
         stem = jsonl.stem
@@ -767,7 +776,7 @@ def _maybe_migrate_existing(output_dir: Path, manifest: dict) -> None:
         for suffix in [".log", ".html"]:
             companion = jsonl.with_suffix(suffix)
             if companion.exists():
-                files.append(str(companion.relative_to(output_dir)))
+                files.append(_rel_posix(companion, output_dir))
         manifest["traces"].append(
             {
                 "timestamp": ts,

--- a/scripts/verify_screenshots.py
+++ b/scripts/verify_screenshots.py
@@ -13,6 +13,12 @@ from pathlib import Path
 
 from playwright.sync_api import sync_playwright
 
+# Force UTF-8 stdout/stderr so emoji output works on Windows GBK consoles.
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")
+
 
 def verify_viewer_html(html_path: str) -> list[str]:
     issues: list[str] = []
@@ -21,7 +27,7 @@ def verify_viewer_html(html_path: str) -> list[str]:
         page = browser.new_page(viewport={"width": 1400, "height": 900})
         errors: list[str] = []
         page.on("pageerror", lambda e: errors.append(str(e)))
-        page.goto(f"file://{Path(html_path).absolute()}", wait_until="domcontentloaded", timeout=15000)
+        page.goto(Path(html_path).absolute().as_uri(), wait_until="domcontentloaded", timeout=15000)
         page.wait_for_timeout(2000)
         if errors:
             issues.append(f"JS errors: {errors}")

--- a/tests/test_codex_launch.py
+++ b/tests/test_codex_launch.py
@@ -41,7 +41,7 @@ async def test_run_client_codex_reverse_injects_openai_base_url(monkeypatch) -> 
 
     assert code == 0
     assert captured["cmd"] == (
-        "codex",
+        "/tmp/codex",
         "-c",
         'openai_base_url="http://127.0.0.1:43123/v1"',
         "exec",
@@ -71,7 +71,7 @@ async def test_run_client_codex_reverse_respects_existing_openai_base_override(m
 
     assert code == 0
     assert captured["cmd"] == (
-        "codex",
+        "/tmp/codex",
         "-c",
         'openai_base_url="http://example.invalid/v1"',
         "exec",

--- a/tests/test_nav_browser.py
+++ b/tests/test_nav_browser.py
@@ -111,7 +111,7 @@ def _build_test_html() -> str:
 def html_file():
     """Write test HTML to a temp file."""
     html = _build_test_html()
-    with tempfile.NamedTemporaryFile(suffix=".html", delete=False, mode="w") as f:
+    with tempfile.NamedTemporaryFile(suffix=".html", delete=False, mode="w", encoding="utf-8") as f:
         f.write(html)
         return Path(f.name)
 

--- a/tests/test_perf_viewer.py
+++ b/tests/test_perf_viewer.py
@@ -88,7 +88,7 @@ def _build_small_trace_html() -> str:
         ),
     ]
 
-    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w") as trace_f:
+    with tempfile.NamedTemporaryFile(suffix=".jsonl", delete=False, mode="w", encoding="utf-8") as trace_f:
         for e in entries:
             trace_f.write(json.dumps(e) + "\n")
         trace_path = Path(trace_f.name)

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -45,11 +45,7 @@ def _strip_sigtstp(monkeypatch: pytest.MonkeyPatch) -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_does_not_touch_sigtstp_when_absent(monkeypatch) -> None:
-    """run_client must not crash on platforms where signal.SIGTSTP is unavailable."""
-    captured: dict[str, object] = {}
-
     async def fake_create_subprocess_exec(*cmd, **kwargs):
-        captured["cmd"] = cmd
         return _DummyProc()
 
     _strip_sigtstp(monkeypatch)
@@ -63,7 +59,6 @@ async def test_run_client_does_not_touch_sigtstp_when_absent(monkeypatch) -> Non
 
 @pytest.mark.asyncio
 async def test_run_client_passes_resolved_path_for_cmd_shim(monkeypatch) -> None:
-    """The .cmd shim path returned by shutil.which must be passed verbatim to subprocess."""
     captured: dict[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -82,8 +77,7 @@ async def test_run_client_passes_resolved_path_for_cmd_shim(monkeypatch) -> None
 
 
 def test_module_import_reconfigures_stdout_to_utf8() -> None:
-    """The cli module must coerce stdout/stderr to UTF-8 so emoji prints don't crash on GBK."""
-    import claude_tap.cli  # noqa: F401  (side effect)
+    import claude_tap.cli  # noqa: F401
 
     for stream in (sys.stdout, sys.stderr):
         encoding = getattr(stream, "encoding", "")

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -1,0 +1,90 @@
+"""Regression tests for Windows-specific bugs reported in issue #83.
+
+Patches `signal` and `shutil.which` to simulate the Windows environment so the
+tests run identically on Linux/macOS CI and on real Windows.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+import sys
+
+import pytest
+
+from claude_tap.cli import run_client
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.pid = 12345
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def _strip_sigtstp(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove SIGTSTP and force loop.add/remove_signal_handler to NotImplementedError."""
+    if hasattr(signal, "SIGTSTP"):
+        monkeypatch.delattr(signal, "SIGTSTP", raising=False)
+
+    def _not_impl(*_args, **_kwargs):
+        raise NotImplementedError
+
+    monkeypatch.setattr("asyncio.AbstractEventLoop.add_signal_handler", _not_impl, raising=False)
+    monkeypatch.setattr("asyncio.AbstractEventLoop.remove_signal_handler", _not_impl, raising=False)
+
+
+@pytest.mark.asyncio
+async def test_run_client_does_not_touch_sigtstp_when_absent(monkeypatch) -> None:
+    """run_client must not crash on platforms where signal.SIGTSTP is unavailable."""
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _DummyProc()
+
+    _strip_sigtstp(monkeypatch)
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: r"C:\Users\x\.local\bin\claude.cmd")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["--version"], client="claude", proxy_mode="reverse")
+    assert code == 0
+
+
+@pytest.mark.asyncio
+async def test_run_client_passes_resolved_path_for_cmd_shim(monkeypatch) -> None:
+    """The .cmd shim path returned by shutil.which must be passed verbatim to subprocess."""
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _DummyProc()
+
+    shim_path = r"C:\Users\x\.local\bin\claude.cmd"
+    _strip_sigtstp(monkeypatch)
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: shim_path)
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["--version"], client="claude", proxy_mode="reverse")
+    assert code == 0
+    assert captured["cmd"] == (shim_path, "--version")
+
+
+def test_module_import_reconfigures_stdout_to_utf8() -> None:
+    """The cli module must coerce stdout/stderr to UTF-8 so emoji prints don't crash on GBK."""
+    import claude_tap.cli  # noqa: F401  (side effect)
+
+    for stream in (sys.stdout, sys.stderr):
+        encoding = getattr(stream, "encoding", "")
+        assert encoding and encoding.lower().replace("-", "") == "utf8", f"expected UTF-8, got {encoding!r} on {stream}"

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import signal
+import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 
-from claude_tap.cli import run_client
+from claude_tap.cli import _rel_posix, _start_background_update, run_client
 
 
 class _DummyProc:
@@ -82,3 +84,30 @@ def test_module_import_reconfigures_stdout_to_utf8() -> None:
     for stream in (sys.stdout, sys.stderr):
         encoding = getattr(stream, "encoding", "")
         assert encoding and encoding.lower().replace("-", "") == "utf8", f"expected UTF-8, got {encoding!r} on {stream}"
+
+
+def test_rel_posix_uses_forward_slashes(tmp_path: Path) -> None:
+    nested = tmp_path / "2026-04-29" / "trace_001234.jsonl"
+    nested.parent.mkdir(parents=True)
+    nested.write_text("{}\n", encoding="utf-8")
+    assert _rel_posix(nested, tmp_path) == "2026-04-29/trace_001234.jsonl"
+
+
+def test_start_background_update_resolves_uv_shim(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return object()
+
+    shim = r"C:\Users\x\AppData\Local\Programs\uv\uv.cmd"
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda name: shim if name == "uv" else None)
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+
+    _start_background_update("uv")
+    assert captured["cmd"] == [shim, "tool", "upgrade", "claude-tap"]
+
+
+def test_start_background_update_returns_none_when_uv_missing(monkeypatch) -> None:
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: None)
+    assert _start_background_update("uv") is None


### PR DESCRIPTION
## Summary

Closes #83. After the initial three crashes were fixed, a deeper cross-platform audit surfaced more Windows pitfalls in the same codebase. This PR resolves all of them.

### Initial crashes (#83)
- **`AttributeError: module 'signal' has no attribute 'SIGTSTP'`** — `SIGTSTP` is Unix-only; access guarded with `getattr(signal, "SIGTSTP", None)`.
- **`FileNotFoundError [WinError 2]`** — `asyncio.create_subprocess_exec` invokes `CreateProcess`, which only auto-appends `.exe`. Resolve `claude`/`codex` via `shutil.which()` so npm `.cmd`/`.bat` shims also work.
- **`UnicodeEncodeError: 'gbk' codec can't encode character '\U0001f50d'`** — emoji `print` crashed on Chinese Windows GBK consoles. `sys.stdout`/`sys.stderr` reconfigured to UTF-8 with `errors="backslashreplace"` at module load.

### Audit follow-ups
- `_start_background_update` invoked `["uv", ...]` directly — same `.cmd`-shim hazard. Now resolves via `shutil.which("uv")` and bails when missing.
- `f"file://{html_path.absolute()}"` produced malformed URIs on Windows (`file://C:\path\file.html`) and never URL-encoded spaces. Switched to `Path.as_uri()` (RFC 8089-compliant on every OS) in both `cli.py` and `scripts/verify_screenshots.py`.
- `.cloudtap-manifest.json` stored OS-native separators in trace file paths, so a `.traces/` synced between Windows and POSIX would double-register entries. Introduced `_rel_posix()` for writes; normalize backslashes on read so manifests from older builds keep matching.
- `scripts/verify_screenshots.py` printed `❌`/`✅` without the UTF-8 reconfigure block — applied the same pattern as `claude_tap.cli`.
- `tests/test_nav_browser.py` and `tests/test_perf_viewer.py` opened `tempfile.NamedTemporaryFile` in text mode without `encoding=`. Made it explicit (the viewer template embeds an I18N block with CJK that would crash on Chinese Windows otherwise).

### Audit findings deferred to follow-up PRs
The broader test suite still has Windows-only issues that aren't user-facing (PATH separator literals `:` instead of `os.pathsep` in `test_e2e.py`, `#!/usr/bin/env python3` shebang fakes that Windows can't execute, `read_text()` calls without `encoding=` in tests). They block expanding CI to `windows-latest` but don't affect production usage. Tracking them separately keeps this PR focused.

## Reproduction (before fix)

```
$ pip install claude-tap==0.1.36
$ claude-tap -- --version
...
File ".../claude_tap/cli.py", line 191, in run_client
    old_sigtstp = signal.signal(signal.SIGTSTP, signal.SIG_IGN)
AttributeError: module 'signal' has no attribute 'SIGTSTP'
```

## Verification (after fix, locally installed)

```
$ PYTHONIOENCODING=gbk claude-tap --tap-no-update-check -- --version
🚀 Starting Claude Code: claude --version
   ANTHROPIC_BASE_URL=http://127.0.0.1:11972

2.1.121 (Claude Code)

📋 Claude Code exited with code 0
🌐 Opening viewer in browser...
```

End-to-end works under `PYTHONIOENCODING=gbk`; the viewer URL is now an RFC 8089 `file:///` URI; manifest entries written from now on use `/` separators.

## Test plan

- [x] `tests/test_windows_compat.py` — 6 platform-agnostic regressions (SIGTSTP-absent, `.cmd` shim resolved, UTF-8 reconfigure, `_rel_posix`, uv shim resolution, uv-missing bail).
- [x] `tests/test_codex_launch.py` — updated to assert resolved absolute path is forwarded to subprocess.
- [x] `uv run ruff check .` clean / `uv run ruff format --check .` clean.
- [x] `uv run pytest tests/test_codex_launch.py tests/test_windows_compat.py -v` — 10 passed.
- [x] End-to-end smoke: official PyPI install → reproduce all bugs → install local fix → all gone, even with `PYTHONIOENCODING=gbk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)