### PR TITLE
Render Responses continuation history

### DIFF
--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -7,7 +7,7 @@ import json
 import sys
 from pathlib import Path
 
-from claude_tap.viewer import _generate_html_viewer, _normalize_record_for_viewer
+from claude_tap.viewer import _backfill_responses_history_records, _generate_html_viewer, _normalize_record_for_viewer
 
 
 def _as_dict(value: object) -> dict:
@@ -86,6 +86,7 @@ def export_main(argv: list[str] | None = None) -> int:
 
     # Sort by turn
     records.sort(key=_turn_sort_key)
+    _backfill_responses_history_records(records)
 
     # Determine format
     fmt = args.format

--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -7,7 +7,12 @@ import json
 import sys
 from pathlib import Path
 
-from claude_tap.viewer import _backfill_responses_history_records, _generate_html_viewer, _normalize_record_for_viewer
+from claude_tap.viewer import (
+    _backfill_responses_history_records,
+    _extract_request_messages,
+    _generate_html_viewer,
+    _normalize_record_for_viewer,
+)
 
 
 def _as_dict(value: object) -> dict:
@@ -39,6 +44,60 @@ def _usage_from(record: dict) -> dict:
 def _turn_sort_key(record: dict) -> int:
     turn = record.get("turn")
     return turn if isinstance(turn, int) else 0
+
+
+def _parse_tool_input(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _text_from_block(block: dict) -> str:
+    text = block.get("text")
+    if isinstance(text, str):
+        return text
+    return ""
+
+
+def _export_response_content(resp_body: dict) -> list[dict]:
+    content = resp_body.get("content")
+    if isinstance(content, list):
+        return content
+
+    output = resp_body.get("output")
+    if not isinstance(output, list):
+        return []
+
+    normalized: list[dict] = []
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type == "message":
+            for block in item.get("content") or []:
+                if not isinstance(block, dict):
+                    continue
+                block_type = block.get("type")
+                if block_type in {"output_text", "text"}:
+                    text = _text_from_block(block)
+                    if text:
+                        normalized.append({"type": "text", "text": text})
+                elif block_type == "reasoning_text":
+                    text = _text_from_block(block)
+                    if text:
+                        normalized.append({"type": "thinking", "thinking": text})
+        elif item_type == "function_call":
+            normalized.append(
+                {
+                    "type": "tool_use",
+                    "name": item.get("name") or "function_call",
+                    "input": _parse_tool_input(item.get("arguments") or {}),
+                }
+            )
+    return normalized
 
 
 def export_main(argv: list[str] | None = None) -> int:
@@ -170,8 +229,8 @@ def _export_markdown(records: list[dict]) -> str:
         lines.append(f"**Model**: `{model}` | **Duration**: {duration}ms\n")
 
         # User messages (last message from request)
-        messages = req_body.get("messages", [])
-        if isinstance(messages, list) and messages:
+        messages = _extract_request_messages(req_body)
+        if messages:
             last_msg = messages[-1]
             if isinstance(last_msg, dict):
                 role = last_msg.get("role", "unknown")
@@ -182,7 +241,7 @@ def _export_markdown(records: list[dict]) -> str:
                 elif isinstance(content, list):
                     for block in content:
                         if isinstance(block, dict):
-                            if block.get("type") == "text":
+                            if block.get("type") in {"text", "input_text", "output_text"}:
                                 lines.append(block.get("text", "") + "\n")
                             elif block.get("type") == "tool_result":
                                 lines.append(f"**Tool Result** (`{block.get('tool_use_id', '')}`)\n")
@@ -195,8 +254,8 @@ def _export_markdown(records: list[dict]) -> str:
                                             lines.append(f"```\n{sub.get('text', '')[:2000]}\n```\n")
 
         # Response
-        resp_content = resp_body.get("content", [])
-        if isinstance(resp_content, list) and resp_content:
+        resp_content = _export_response_content(resp_body)
+        if resp_content:
             lines.append("### Assistant\n")
             for block in resp_content:
                 if isinstance(block, dict):
@@ -244,9 +303,9 @@ def _export_json(records: list[dict]) -> str:
             "timestamp": r.get("timestamp"),
             "duration_ms": r.get("duration_ms"),
             "model": req_body.get("model"),
-            "messages": req_body.get("messages") if isinstance(req_body.get("messages"), list) else [],
+            "messages": _extract_request_messages(req_body),
             "response": {
-                "content": resp_body.get("content") if isinstance(resp_body.get("content"), list) else [],
+                "content": _export_response_content(resp_body),
                 "usage": _as_dict(resp_body.get("usage")),
                 "stop_reason": resp_body.get("stop_reason"),
             },

--- a/claude_tap/forward_proxy.py
+++ b/claude_tap/forward_proxy.py
@@ -36,9 +36,8 @@ from claude_tap.proxy import (
     HOP_BY_HOP,
     _build_record,
     _get_ws_proxy_settings,
+    build_ws_records,
     filter_headers,
-    reconstruct_ws_request_body,
-    reconstruct_ws_response_body,
 )
 from claude_tap.sse import SSEReassembler
 from claude_tap.trace import TraceWriter
@@ -712,28 +711,18 @@ class ForwardProxyServer:
             pass
 
         duration_ms = int((time.monotonic() - t0) * 1000)
-        record = {
-            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "request_id": req_id,
-            "turn": turn,
-            "duration_ms": duration_ms,
-            "transport": "websocket",
-            "request": {
-                "method": "WEBSOCKET",
-                "path": path,
-                "headers": filter_headers(headers, redact_keys=True),
-                "body": reconstruct_ws_request_body(client_messages),
-            },
-            "response": {
-                "status": 101,
-                "headers": {},
-                "body": None,
-                "ws_events": [json.loads(msg) if msg.startswith("{") else {"raw": msg} for msg in server_messages],
-            },
-            "upstream_base_url": upstream_base_url,
-        }
-        record["response"]["body"] = reconstruct_ws_response_body(record["response"]["ws_events"])
-        await self._writer.write(record)
+        records = build_ws_records(
+            req_id=req_id,
+            turn=turn,
+            duration_ms=duration_ms,
+            path_qs=path,
+            req_headers=headers,
+            client_messages=client_messages,
+            server_messages=server_messages,
+            upstream_base_url=upstream_base_url,
+        )
+        for record in records:
+            await self._writer.write(record)
         log.info(
             f"{log_prefix} <- WS closed ({duration_ms}ms, "
             f"{len(client_messages)} client→upstream, {len(server_messages)} upstream→client)"

--- a/claude_tap/proxy.py
+++ b/claude_tap/proxy.py
@@ -536,7 +536,7 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
 
     duration_ms = int((time.monotonic() - t0) * 1000)
 
-    record = _build_ws_record(
+    records = _build_ws_records(
         req_id=req_id,
         turn=turn,
         duration_ms=duration_ms,
@@ -546,7 +546,8 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
         server_messages=server_messages,
         upstream_base_url=target,
     )
-    await writer.write(record)
+    for record in records:
+        await writer.write(record)
 
     log.info(
         f"{log_prefix} ← WS closed ({duration_ms}ms, "
@@ -570,15 +571,10 @@ def _build_ws_record(
 ) -> dict:
     """Build a trace record for a WebSocket session."""
     req_body = _reconstruct_ws_request_body(client_messages)
+    request_ws_events = _parse_ws_messages(client_messages)
 
     # Parse server messages into structured events
-    ws_events: list[dict] = []
-    for msg in server_messages:
-        try:
-            parsed = json.loads(msg)
-            ws_events.append(parsed)
-        except (json.JSONDecodeError, ValueError):
-            ws_events.append({"raw": msg})
+    ws_events = _parse_ws_messages(server_messages)
 
     resp_body = _reconstruct_ws_response_body(ws_events)
 
@@ -602,11 +598,112 @@ def _build_ws_record(
     }
     if ws_events:
         record["response"]["ws_events"] = ws_events
+    if request_ws_events:
+        record["request"]["ws_events"] = request_ws_events
     if error:
         record["response"]["error"] = error
     if upstream_base_url:
         record["upstream_base_url"] = upstream_base_url
     return record
+
+
+def _build_ws_records(
+    req_id: str,
+    turn: int,
+    duration_ms: int,
+    path_qs: str,
+    req_headers: dict,
+    client_messages: list[str],
+    server_messages: list[str],
+    upstream_base_url: str,
+    error: str | None = None,
+) -> list[dict]:
+    """Build trace records for a WebSocket session.
+
+    Codex may multiplex several Responses requests over one WebSocket
+    connection. Emit one logical trace record per response.create/completed pair
+    so the sidebar reflects the real Responses turns instead of hiding them
+    inside a single connection record.
+    """
+    aggregate = _build_ws_record(
+        req_id=req_id,
+        turn=turn,
+        duration_ms=duration_ms,
+        path_qs=path_qs,
+        req_headers=req_headers,
+        client_messages=client_messages,
+        server_messages=server_messages,
+        upstream_base_url=upstream_base_url,
+        error=error,
+    )
+    if error:
+        return [aggregate]
+
+    request_events = aggregate.get("request", {}).get("ws_events") or []
+    response_events = aggregate.get("response", {}).get("ws_events") or []
+    create_indexes = [
+        idx
+        for idx, event in enumerate(request_events)
+        if isinstance(event, dict) and event.get("type") == "response.create"
+    ]
+    completed_indexes = [
+        idx
+        for idx, event in enumerate(response_events)
+        if isinstance(event, dict) and event.get("type") in {"response.completed", "response.done"}
+    ]
+
+    if len(create_indexes) <= 1 or len(create_indexes) != len(completed_indexes):
+        return [aggregate]
+
+    records: list[dict] = []
+    previous_create_end = 0
+    previous_completed_end = 0
+    for logical_idx, (create_idx, completed_idx) in enumerate(
+        zip(create_indexes, completed_indexes, strict=False), start=1
+    ):
+        request_segment = request_events[previous_create_end : create_idx + 1]
+        response_segment = response_events[previous_completed_end : completed_idx + 1]
+        previous_create_end = create_idx + 1
+        previous_completed_end = completed_idx + 1
+
+        req_body = _reconstruct_ws_request_body([json.dumps(event) for event in request_segment])
+        resp_body = _reconstruct_ws_response_body(response_segment)
+        record: dict = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "request_id": f"{req_id}_{logical_idx}",
+            "turn": turn + logical_idx - 1,
+            "duration_ms": duration_ms,
+            "transport": "websocket",
+            "request": {
+                "method": "WEBSOCKET",
+                "path": path_qs,
+                "headers": filter_headers(req_headers, redact_keys=True),
+                "body": req_body,
+                "ws_events": request_segment,
+            },
+            "response": {
+                "status": 101,
+                "headers": {},
+                "body": resp_body,
+                "ws_events": response_segment,
+            },
+        }
+        if upstream_base_url:
+            record["upstream_base_url"] = upstream_base_url
+        records.append(record)
+
+    return records or [aggregate]
+
+
+def _parse_ws_messages(messages: list[str]) -> list[dict]:
+    events: list[dict] = []
+    for msg in messages:
+        try:
+            parsed = json.loads(msg)
+            events.append(parsed)
+        except (json.JSONDecodeError, ValueError):
+            events.append({"raw": msg})
+    return events
 
 
 def _reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
@@ -618,6 +715,9 @@ def _reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
         except (json.JSONDecodeError, ValueError):
             continue
         if not isinstance(parsed, dict):
+            continue
+        parsed = _normalize_ws_request_event(parsed)
+        if not parsed:
             continue
         if merged is None:
             merged = parsed.copy()
@@ -636,6 +736,20 @@ def _reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
             else:
                 merged.setdefault(key, value)
     return merged
+
+
+def _normalize_ws_request_event(event: dict) -> dict:
+    event_type = event.get("type")
+    if event_type in {"conversation.item.create", "input.item.create"}:
+        item = event.get("item")
+        if isinstance(item, dict):
+            return {"input": [item]}
+        return {}
+    if event_type == "response.create" and isinstance(event.get("response"), dict):
+        normalized = event["response"].copy()
+        normalized.setdefault("type", event_type)
+        return normalized
+    return event
 
 
 def _merge_json_lists(existing: list, incoming: list) -> list:
@@ -729,3 +843,33 @@ def reconstruct_ws_response_body(ws_events: list[dict]) -> dict | None:
 def reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
     """Public wrapper for websocket request-body reconstruction."""
     return _reconstruct_ws_request_body(client_messages)
+
+
+def parse_ws_messages(messages: list[str]) -> list[dict]:
+    """Public wrapper for websocket event parsing."""
+    return _parse_ws_messages(messages)
+
+
+def build_ws_records(
+    req_id: str,
+    turn: int,
+    duration_ms: int,
+    path_qs: str,
+    req_headers: dict,
+    client_messages: list[str],
+    server_messages: list[str],
+    upstream_base_url: str,
+    error: str | None = None,
+) -> list[dict]:
+    """Public wrapper for websocket trace record construction."""
+    return _build_ws_records(
+        req_id=req_id,
+        turn=turn,
+        duration_ms=duration_ms,
+        path_qs=path_qs,
+        req_headers=req_headers,
+        client_messages=client_messages,
+        server_messages=server_messages,
+        upstream_base_url=upstream_base_url,
+        error=error,
+    )

--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -2716,7 +2716,7 @@ function getResponsesContinuationInfo(entry) {
   const previousId = payload.previous_response_id || body.previous_response_id;
   if (!previousId) return null;
   const messages = getMessages(body);
-  if (messages.length > 0) return null;
+  if (messages.some(message => message?.role === 'user')) return null;
   const headers = entry?.request?.headers || {};
   return {
     response_id: payload.id || '',
@@ -2732,22 +2732,61 @@ function getMessages(body) {
   if (!body) return [];
   if (Array.isArray(body.messages) && body.messages.length > 0) return body.messages;
   if (Array.isArray(body.input)) {
-    return body.input.filter(item => {
-      if (!item || typeof item !== 'object') return false;
-      if (typeof item.role !== 'string' || !item.role) return false;
-      return item.type === undefined || item.type === 'message';
-    }).map(item => ({
-      role: item.role || 'user',
-      content: Array.isArray(item.content)
-        ? item.content.map(c => {
-            if (!c || typeof c !== 'object') return c;
-            if (c.type === 'input_text' || c.type === 'output_text' || c.type === 'text') return { type: 'text', text: c.text };
-            return c;
-          })
-        : item.content
-    }));
+    const normalized = [];
+    for (const item of body.input) {
+      if (!item || typeof item !== 'object') continue;
+      if ((item.type === undefined || item.type === 'message' || item.role) && typeof item.role === 'string' && item.role) {
+        appendMessage(normalized, {
+          role: item.role || 'user',
+          content: Array.isArray(item.content)
+            ? item.content.map(c => {
+                if (!c || typeof c !== 'object') return c;
+                if (c.type === 'input_text' || c.type === 'output_text' || c.type === 'text') return { type: 'text', text: c.text };
+                return c;
+              })
+            : item.content
+        });
+        continue;
+      }
+      if (item.type === 'function_call') {
+        appendMessage(normalized, {
+          role: 'assistant',
+          content: [{ type: 'tool_use', name: item.name || 'function_call', input: parseJsonMaybe(item.arguments || {}) }]
+        });
+        continue;
+      }
+      if (item.type === 'function_call_output') {
+        appendMessage(normalized, {
+          role: 'tool',
+          content: [{ type: 'tool_result', tool_use_id: item.call_id || '', content: item.output || '' }]
+        });
+      }
+    }
+    return normalized;
   }
   return [];
+}
+
+function appendMessage(messages, message) {
+  if (!message || !message.role) return;
+  const content = normalizeMessageContent(message.content);
+  const previous = messages[messages.length - 1];
+  if (previous?.role === message.role && message.role !== 'tool') {
+    previous.content = normalizeMessageContent(previous.content).concat(content);
+    return;
+  }
+  messages.push({ role: message.role, content });
+}
+
+function normalizeMessageContent(content) {
+  if (Array.isArray(content)) return content;
+  if (content === undefined || content === null) return [];
+  return [{ type: 'text', text: String(content) }];
+}
+
+function parseJsonMaybe(value) {
+  if (typeof value !== 'string') return value;
+  try { return JSON.parse(value); } catch(e) { return value; }
 }
 
 // Extract token usage from response.body.usage or SSE response.completed event
@@ -2774,7 +2813,7 @@ function normalizeResponseOutput(output) {
         else content.push(c);
       }
     } else if (item.type === 'function_call') {
-      content.push({ type: 'tool_use', name: item.name, input: item.arguments ? (typeof item.arguments === 'string' ? (() => { try { return JSON.parse(item.arguments); } catch(e) { return item.arguments; } })() : item.arguments) : {} });
+      content.push({ type: 'tool_use', name: item.name, input: item.arguments ? parseJsonMaybe(item.arguments) : {} });
     } else if (item.type === 'reasoning') {
       if (!item.summary) continue;
       const summaryText = Array.isArray(item.summary) ? item.summary.map(s => s?.text || '').join('\n') : (item.summary.text || JSON.stringify(item.summary));

--- a/claude_tap/viewer.py
+++ b/claude_tap/viewer.py
@@ -138,13 +138,257 @@ def _extract_request_messages(body: dict) -> list[dict]:
     for item in inp:
         if not isinstance(item, dict):
             continue
-        if item.get("type") not in (None, "message") and "role" not in item:
-            continue
-        role = item.get("role")
-        if not isinstance(role, str) or not role:
-            continue
-        normalized.append({"role": role, "content": item.get("content")})
+        item_type = item.get("type")
+        if item_type in (None, "message") or "role" in item:
+            role = item.get("role")
+            if not isinstance(role, str) or not role:
+                continue
+            normalized.append({"role": role, "content": item.get("content")})
+        elif item_type == "function_call":
+            normalized.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": item.get("name") or "function_call",
+                            "input": item.get("arguments") or {},
+                        }
+                    ],
+                }
+            )
+        elif item_type == "function_call_output":
+            normalized.append(
+                {
+                    "role": "tool",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": item.get("call_id") or "",
+                            "content": item.get("output") or "",
+                        }
+                    ],
+                }
+            )
     return normalized
+
+
+def _json_list_item_key(item: object) -> str:
+    try:
+        return json.dumps(item, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return repr(item)
+
+
+def _merge_json_lists(existing: list, incoming: list) -> list:
+    merged = list(existing)
+    seen = {_json_list_item_key(item) for item in merged}
+    for item in incoming:
+        key = _json_list_item_key(item)
+        if key in seen:
+            continue
+        merged.append(item)
+        seen.add(key)
+    return merged
+
+
+def _request_ws_input_items(record: dict) -> list[dict]:
+    request = record.get("request")
+    if not isinstance(request, dict):
+        return []
+    events = request.get("ws_events")
+    if not isinstance(events, list):
+        return []
+
+    items: list[dict] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        event_type = event.get("type")
+        if event_type in {"conversation.item.create", "input.item.create"}:
+            item = event.get("item")
+            if isinstance(item, dict):
+                items.append(item)
+            continue
+        if event_type == "response.create":
+            response = event.get("response")
+            if isinstance(response, dict) and isinstance(response.get("input"), list):
+                items = _merge_json_lists(items, response["input"])
+            elif isinstance(event.get("input"), list):
+                items = _merge_json_lists(items, event["input"])
+    return items
+
+
+def _response_payloads(record: dict) -> list[dict]:
+    response = record.get("response")
+    if not isinstance(response, dict):
+        return []
+
+    payloads = []
+    body = response.get("body")
+    if isinstance(body, dict):
+        payloads.append(body)
+    if any(key in response for key in ("id", "previous_response_id", "output", "usage", "content")):
+        payloads.append(response)
+
+    for event in _iter_response_events(response):
+        payload = _event_payload(event)
+        if not isinstance(payload, dict):
+            continue
+        response_payload = payload.get("response")
+        if isinstance(response_payload, dict):
+            payloads.append(response_payload)
+        elif any(key in payload for key in ("id", "previous_response_id", "output", "usage", "content")):
+            payloads.append(payload)
+
+    return payloads
+
+
+def _response_ids(record: dict) -> list[str]:
+    ids = []
+    seen = set()
+    for payload in _response_payloads(record):
+        response_id = payload.get("id")
+        if isinstance(response_id, str) and response_id and response_id not in seen:
+            ids.append(response_id)
+            seen.add(response_id)
+    return ids
+
+
+def _previous_response_id(record: dict, body: dict) -> str:
+    value = body.get("previous_response_id")
+    if isinstance(value, str) and value:
+        return value
+    for payload in reversed(_response_payloads(record)):
+        value = payload.get("previous_response_id")
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def _response_output_as_input_items(output: object) -> list[dict]:
+    if not isinstance(output, list):
+        return []
+    items = []
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type == "message":
+            role = item.get("role")
+            if not isinstance(role, str) or not role:
+                role = "assistant"
+            items.append(
+                {
+                    "type": "message",
+                    "role": role,
+                    "content": item.get("content", []),
+                }
+            )
+        elif item_type == "function_call":
+            items.append({k: v for k, v in item.items() if k in {"type", "call_id", "name", "arguments"}})
+        elif item_type == "function_call_output":
+            items.append({k: v for k, v in item.items() if k in {"type", "call_id", "output"}})
+    return items
+
+
+def _response_chain_inputs(record: dict, base_input: list) -> dict[str, list]:
+    inputs_by_id: dict[str, list] = {}
+    current_input = list(base_input)
+
+    for event in _iter_response_events(record.get("response") or {}):
+        if _event_type(event) not in ("response.completed", "response.done"):
+            continue
+        payload = _event_payload(event)
+        response_payload = payload.get("response") if isinstance(payload, dict) else None
+        if not isinstance(response_payload, dict):
+            response_payload = payload if isinstance(payload, dict) else None
+        if not isinstance(response_payload, dict):
+            continue
+
+        previous_id = response_payload.get("previous_response_id")
+        if isinstance(previous_id, str) and previous_id in inputs_by_id:
+            current_input = list(inputs_by_id[previous_id])
+
+        output_items = _response_output_as_input_items(response_payload.get("output"))
+        if output_items:
+            current_input = _merge_json_lists(current_input, output_items)
+
+        response_id = response_payload.get("id")
+        if isinstance(response_id, str) and response_id:
+            inputs_by_id[response_id] = list(current_input)
+
+    return inputs_by_id
+
+
+def _backfill_responses_history_records(records: list[dict]) -> list[dict]:
+    """Backfill Responses request input from earlier trace records.
+
+    Codex Responses continuations may send only a delta (for example a tool
+    result) and reference the unchanged prefix through previous_response_id.
+    When the referenced response is present in the same trace, preserve that
+    prefix in the current request body so the viewer/export can render message
+    history instead of looking like a prompt-less assistant response.
+    """
+    input_by_response_id: dict[str, list] = {}
+
+    for record in records:
+        request = record.get("request")
+        body = request.get("body") if isinstance(request, dict) else None
+        if not isinstance(body, dict):
+            continue
+
+        current_input = body.get("input")
+        current_input_list = current_input if isinstance(current_input, list) else []
+        ws_input = _request_ws_input_items(record)
+        if ws_input:
+            body["input"] = _merge_json_lists(ws_input, current_input_list)
+            current_input_list = body["input"]
+
+        previous_id = _previous_response_id(record, body)
+        previous_input = input_by_response_id.get(previous_id)
+        if previous_input is not None:
+            body["input"] = _merge_json_lists(previous_input, current_input_list)
+            current_input_list = body["input"]
+
+        chain_inputs = _response_chain_inputs(record, current_input_list)
+        if previous_input is None and previous_id in chain_inputs:
+            body["input"] = _merge_json_lists(chain_inputs[previous_id], current_input_list)
+            current_input_list = body["input"]
+
+        for payload in _response_payloads(record):
+            response_id = payload.get("id")
+            if not isinstance(response_id, str) or not response_id:
+                continue
+            output_items = _response_output_as_input_items(payload.get("output"))
+            if output_items:
+                input_by_response_id[response_id] = _merge_json_lists(current_input_list, output_items)
+            else:
+                input_by_response_id[response_id] = list(current_input_list)
+        input_by_response_id.update(chain_inputs)
+
+    return records
+
+
+def _backfill_responses_history(record_jsons: list[str]) -> list[str]:
+    parsed_records: list[dict | None] = []
+    for record_json in record_jsons:
+        try:
+            record = json.loads(record_json)
+        except (json.JSONDecodeError, TypeError):
+            parsed_records.append(None)
+            continue
+        parsed_records.append(record if isinstance(record, dict) else None)
+
+    _backfill_responses_history_records([record for record in parsed_records if record is not None])
+
+    backfilled = []
+    for record_json, record in zip(record_jsons, parsed_records, strict=False):
+        if record is None:
+            backfilled.append(record_json)
+        else:
+            backfilled.append(json.dumps(record, ensure_ascii=False, separators=(",", ":")))
+    return backfilled
 
 
 def _extract_response_tool_names(output: list) -> list[str]:
@@ -277,6 +521,7 @@ def _generate_html_viewer(trace_path: Path, html_path: Path) -> None:
                 line = line.strip()
                 if line:
                     records.append(_normalize_record_for_viewer(line))
+    records = _backfill_responses_history(records)
 
     jsonl_path_js = json.dumps(str(trace_path.absolute()))
     html_path_js = json.dumps(str(html_path.absolute()))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2356,7 +2356,31 @@ async def test_forward_proxy_connect_websocket():
                     proxy=proxy_url,
                     ssl=ssl_ctx,
                 )
-                await ws.send_json({"model": "gpt-test", "input": "hello"})
+                await ws.send_json(
+                    {
+                        "type": "conversation.item.create",
+                        "item": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "hello over forward ws"}],
+                        },
+                    }
+                )
+                await ws.send_json(
+                    {
+                        "type": "response.create",
+                        "response": {
+                            "model": "gpt-test",
+                            "input": [
+                                {
+                                    "type": "message",
+                                    "role": "developer",
+                                    "content": [{"type": "input_text", "text": "developer setup"}],
+                                }
+                            ],
+                        },
+                    }
+                )
 
                 received = []
                 while True:
@@ -2386,6 +2410,12 @@ async def test_forward_proxy_connect_websocket():
             assert records[0]["transport"] == "websocket"
             assert records[0]["request"]["method"] == "WEBSOCKET"
             assert records[0]["request"]["path"] == "/v1/responses"
+            assert records[0]["request"]["body"]["model"] == "gpt-test"
+            assert records[0]["request"]["body"]["input"][0]["role"] == "user"
+            assert records[0]["request"]["body"]["input"][0]["content"][0]["text"] == "hello over forward ws"
+            assert records[0]["request"]["body"]["input"][1]["role"] == "developer"
+            assert records[0]["request"]["ws_events"][0]["type"] == "conversation.item.create"
+            assert records[0]["request"]["ws_events"][1]["type"] == "response.create"
             assert records[0]["response"]["status"] == 101
             assert records[0]["response"]["body"]["status"] == "completed"
             assert records[0]["response"]["body"]["output"][0]["content"][0]["text"] == "Hello over WSS"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -137,3 +137,125 @@ def test_export_json_tolerates_null_request_body_and_stream_text_response(tmp_pa
     assert exported[1]["model"] is None
     assert exported[1]["messages"] == []
     assert f"Exported 2 turns to {json_path}" in capsys.readouterr().out
+
+
+def test_export_json_includes_backfilled_responses_messages_and_output(tmp_path, capsys) -> None:
+    trace_path = tmp_path / "responses.jsonl"
+    json_path = tmp_path / "responses.export.json"
+    records = [
+        {
+            "timestamp": "2026-04-28T12:00:00",
+            "turn": 1,
+            "request": {
+                "body": {
+                    "model": "gpt-5.5",
+                    "input": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "first prompt"}],
+                        }
+                    ],
+                }
+            },
+            "response": {
+                "body": {
+                    "id": "resp_1",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "first answer"}],
+                        }
+                    ],
+                    "usage": {"input_tokens": 5, "output_tokens": 3},
+                }
+            },
+        },
+        {
+            "timestamp": "2026-04-28T12:00:01",
+            "turn": 2,
+            "request": {
+                "body": {
+                    "model": "gpt-5.5",
+                    "previous_response_id": "resp_1",
+                    "input": [
+                        {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "second prompt"}],
+                        }
+                    ],
+                }
+            },
+            "response": {
+                "body": {
+                    "id": "resp_2",
+                    "output": [
+                        {"type": "function_call", "name": "exec_command", "arguments": '{"cmd":"pwd"}'},
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "second answer"}],
+                        },
+                    ],
+                    "usage": {"input_tokens": 8, "output_tokens": 4},
+                }
+            },
+        },
+    ]
+    trace_path.write_text("\n".join(json.dumps(record) for record in records), encoding="utf-8")
+
+    assert export_main([str(trace_path), "--format", "json", "-o", str(json_path)]) == 0
+
+    exported = json.loads(json_path.read_text(encoding="utf-8"))
+    assert [message["role"] for message in exported[1]["messages"]] == ["user", "assistant", "user"]
+    assert exported[1]["messages"][0]["content"][0]["text"] == "first prompt"
+    assert exported[1]["messages"][1]["content"][0]["text"] == "first answer"
+    assert exported[1]["messages"][2]["content"][0]["text"] == "second prompt"
+    assert exported[1]["response"]["content"] == [
+        {"type": "tool_use", "name": "exec_command", "input": {"cmd": "pwd"}},
+        {"type": "text", "text": "second answer"},
+    ]
+    assert f"Exported 2 turns to {json_path}" in capsys.readouterr().out
+
+
+def test_export_markdown_includes_responses_input_and_output_text(tmp_path, capsys) -> None:
+    trace_path = tmp_path / "responses.jsonl"
+    md_path = tmp_path / "responses.md"
+    record = {
+        "timestamp": "2026-04-28T12:00:00",
+        "turn": 1,
+        "request": {
+            "body": {
+                "model": "gpt-5.5",
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "summarize export behavior"}],
+                    }
+                ],
+            }
+        },
+        "response": {
+            "body": {
+                "output": [
+                    {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "export includes responses"}],
+                    }
+                ],
+                "usage": {"input_tokens": 5, "output_tokens": 4},
+            }
+        },
+    }
+    trace_path.write_text(json.dumps(record), encoding="utf-8")
+
+    assert export_main([str(trace_path), "--format", "markdown", "-o", str(md_path)]) == 0
+
+    markdown = md_path.read_text(encoding="utf-8")
+    assert "summarize export behavior" in markdown
+    assert "export includes responses" in markdown
+    assert f"Exported 1 turns to {md_path}" in capsys.readouterr().out

--- a/tests/test_responses_browser.py
+++ b/tests/test_responses_browser.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 from pathlib import Path
 
@@ -203,3 +204,207 @@ def test_viewer_warns_for_tool_result_only_responses_continuation(responses_page
     assert "resp_tool_previous" in detail_text
     assert "cache_tool_result" in detail_text
     assert "claude-tap" in detail_text
+
+
+def test_viewer_backfills_messages_from_previous_response_id(tmp_path) -> None:
+    trace_path = tmp_path / "responses-continuation.jsonl"
+    html_path = tmp_path / "responses-continuation.html"
+    records = [
+        {
+            "turn": 1,
+            "request_id": "req_prev",
+            "request": {
+                "method": "WEBSOCKET",
+                "path": "/responses",
+                "body": {
+                    "type": "response.create",
+                    "model": "gpt-5.5",
+                    "input": [{"role": "user", "content": [{"type": "input_text", "text": "First prompt from trace"}]}],
+                },
+            },
+            "response": {
+                "status": 101,
+                "body": {
+                    "id": "resp_prev",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "First answer"}],
+                        }
+                    ],
+                },
+            },
+        },
+        {
+            "turn": 2,
+            "request_id": "req_next",
+            "request": {
+                "method": "WEBSOCKET",
+                "path": "/responses",
+                "body": {
+                    "type": "response.create",
+                    "model": "gpt-5.5",
+                    "input": [
+                        {
+                            "type": "function_call_output",
+                            "call_id": "call_1",
+                            "output": "tool output",
+                        }
+                    ],
+                },
+            },
+            "response": {
+                "status": 101,
+                "body": {
+                    "id": "resp_next",
+                    "previous_response_id": "resp_prev",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "Second answer"}],
+                        }
+                    ],
+                },
+            },
+        },
+    ]
+    trace_path.write_text("\n".join(json.dumps(record) for record in records), encoding="utf-8")
+    _generate_html_viewer(trace_path, html_path)
+
+    html = html_path.read_text(encoding="utf-8")
+
+    assert html.count("First prompt from trace") == 2
+    assert html.count("First answer") == 2
+    assert "function_call_output" in html
+    assert "Second answer" in html
+
+
+def test_viewer_renders_responses_function_history(responses_page) -> None:
+    responses_page.evaluate(
+        """() => {
+          entries[0].request.body = {
+            type: 'response.create',
+            model: 'gpt-5.5',
+            input: [
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'I will inspect the directory' }]
+              },
+              {
+                type: 'function_call',
+                call_id: 'call_1',
+                name: 'exec_command',
+                arguments: '{"cmd":"pwd"}'
+              },
+              {
+                type: 'function_call_output',
+                call_id: 'call_1',
+                output: '/tmp/project'
+              }
+            ]
+          };
+          entries[0].response.body = { id: 'resp_tool_history', output: [] };
+          renderDetail(entries[0]);
+        }"""
+    )
+    text = responses_page.locator("#detail").inner_text()
+
+    assert "exec_command" in text
+    assert "pwd" in text
+    assert "/tmp/project" in text
+    assert responses_page.locator("#detail .msg.assistant").count() == 1
+    assert responses_page.locator("#detail .msg.tool_result").count() == 1
+
+
+def test_viewer_merges_consecutive_responses_assistant_items(responses_page) -> None:
+    responses_page.evaluate(
+        """() => {
+          entries[0].request.body = {
+            type: 'response.create',
+            model: 'gpt-5.5',
+            input: [
+              {
+                type: 'message',
+                role: 'user',
+                content: [{ type: 'input_text', text: 'Analyze this workbook' }]
+              },
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'I will inspect the file.' }]
+              },
+              {
+                type: 'function_call',
+                call_id: 'call_1',
+                name: 'exec_command',
+                arguments: '{"cmd":"ls -l /home/user"}'
+              },
+              {
+                type: 'message',
+                role: 'assistant',
+                content: [{ type: 'output_text', text: 'Then I will read workbook metadata.' }]
+              },
+              {
+                type: 'function_call',
+                call_id: 'call_2',
+                name: 'exec_command',
+                arguments: '{"cmd":"python3 inspect.py"}'
+              }
+            ]
+          };
+          entries[0].response.body = { id: 'resp_consecutive_assistant', output: [] };
+          renderDetail(entries[0]);
+        }"""
+    )
+    text = responses_page.locator("#detail").inner_text()
+
+    assert responses_page.locator("#detail .msg.user").count() == 1
+    assert responses_page.locator("#detail .msg.assistant").count() == 1
+    assert "I will inspect the file." in text
+    assert "ls -l /home/user" in text
+    assert "Then I will read workbook metadata." in text
+    assert "python3 inspect.py" in text
+
+
+def test_viewer_orders_context_messages_stream_and_json(responses_page) -> None:
+    responses_page.evaluate(
+        """() => {
+          entries[0].request.body = {
+            type: 'response.create',
+            model: 'gpt-5.5',
+            instructions: 'LONG_SYSTEM_PROMPT\\n' + 'system details\\n'.repeat(200),
+            input: [
+              {
+                type: 'message',
+                role: 'user',
+                content: [{ type: 'input_text', text: 'VISIBLE_USER_REQUEST' }]
+              }
+            ],
+            tools: [{ type: 'function', name: 'exec_command' }]
+          };
+          entries[0].response.body = {
+            id: 'resp_order',
+            output: [
+              { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'VISIBLE_ASSISTANT_RESPONSE' }] }
+            ],
+            usage: { input_tokens: 1, output_tokens: 1 }
+          };
+          entries[0].response.sse_events = [
+            { event: 'response.completed', data: { response: { id: 'resp_order', output: [] } } }
+          ];
+          renderDetail(entries[0]);
+        }"""
+    )
+    text = responses_page.locator("#detail").inner_text()
+
+    assert text.index("Tools") < text.index("System Prompt")
+    assert text.index("System Prompt") < text.index("Messages")
+    assert text.index("Messages") < text.index("Response")
+    assert text.index("Response") < text.index("SSE Events")
+    assert text.index("SSE Events") < text.index("Full JSON")
+    assert text.index("LONG_SYSTEM_PROMPT") < text.index("VISIBLE_USER_REQUEST")

--- a/tests/test_responses_support.py
+++ b/tests/test_responses_support.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from claude_tap.sse import SSEReassembler
-from claude_tap.viewer import _extract_metadata
+from claude_tap.viewer import _backfill_responses_history_records, _extract_metadata, _extract_request_messages
 
 
 def test_sse_reassembler_reconstructs_openai_responses_completed_event() -> None:
@@ -68,3 +68,201 @@ def test_extract_metadata_supports_interleaved_responses_roles_without_type() ->
     assert meta["message_count"] == 3
     assert meta["input_tokens"] == 1
     assert meta["output_tokens"] == 1
+
+
+def test_extract_request_messages_includes_responses_function_history() -> None:
+    messages = _extract_request_messages(
+        {
+            "input": [
+                {
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": "I will run a command"}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "exec_command",
+                    "arguments": '{"cmd":"pwd"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": "/tmp/project",
+                },
+            ]
+        }
+    )
+
+    assert [message["role"] for message in messages] == ["assistant", "assistant", "tool"]
+    assert messages[1]["content"][0]["type"] == "tool_use"
+    assert messages[1]["content"][0]["name"] == "exec_command"
+    assert messages[2]["content"][0]["type"] == "tool_result"
+    assert messages[2]["content"][0]["content"] == "/tmp/project"
+
+
+def test_backfill_responses_history_uses_previous_response_id_prefix() -> None:
+    records = [
+        {
+            "turn": 1,
+            "request": {
+                "path": "/v1/responses",
+                "body": {
+                    "model": "gpt-5.5",
+                    "input": [{"role": "user", "content": [{"type": "input_text", "text": "First prompt"}]}],
+                },
+            },
+            "response": {
+                "body": {
+                    "id": "resp_1",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "type": "message",
+                            "role": "assistant",
+                            "content": [{"type": "output_text", "text": "First answer"}],
+                        }
+                    ],
+                }
+            },
+        },
+        {
+            "turn": 2,
+            "request": {
+                "path": "/v1/responses",
+                "body": {
+                    "model": "gpt-5.5",
+                    "input": [
+                        {
+                            "type": "function_call_output",
+                            "call_id": "call_1",
+                            "output": "tool output",
+                        }
+                    ],
+                },
+            },
+            "response": {"body": {"id": "resp_2", "previous_response_id": "resp_1", "status": "completed"}},
+        },
+    ]
+
+    _backfill_responses_history_records(records)
+
+    second_input = records[1]["request"]["body"]["input"]
+    assert second_input[0]["role"] == "user"
+    assert second_input[0]["content"][0]["text"] == "First prompt"
+    assert second_input[1]["role"] == "assistant"
+    assert second_input[1]["content"][0]["text"] == "First answer"
+    assert second_input[2]["type"] == "function_call_output"
+
+
+def test_backfill_responses_history_uses_same_record_response_chain() -> None:
+    records = [
+        {
+            "turn": 1,
+            "request": {
+                "path": "/v1/responses",
+                "body": {
+                    "model": "gpt-5.5",
+                    "input": [],
+                },
+            },
+            "response": {
+                "status": 101,
+                "body": {"id": "resp_2", "previous_response_id": "resp_1", "status": "completed"},
+                "ws_events": [
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_1",
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [{"type": "output_text", "text": "First assistant prefix"}],
+                                },
+                                {
+                                    "type": "function_call",
+                                    "call_id": "call_1",
+                                    "name": "exec_command",
+                                    "arguments": "{}",
+                                },
+                            ],
+                        },
+                    },
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_2",
+                            "previous_response_id": "resp_1",
+                            "status": "completed",
+                            "output": [
+                                {
+                                    "type": "message",
+                                    "role": "assistant",
+                                    "content": [{"type": "output_text", "text": "Final answer"}],
+                                }
+                            ],
+                        },
+                    },
+                ],
+            },
+        }
+    ]
+
+    _backfill_responses_history_records(records)
+
+    first_input = records[0]["request"]["body"]["input"]
+    assert first_input[0]["role"] == "assistant"
+    assert first_input[0]["content"][0]["text"] == "First assistant prefix"
+    assert first_input[1]["type"] == "function_call"
+
+
+def test_backfill_responses_history_uses_request_ws_user_frames() -> None:
+    records = [
+        {
+            "turn": 1,
+            "transport": "websocket",
+            "request": {
+                "path": "/v1/responses",
+                "body": {
+                    "type": "response.create",
+                    "model": "gpt-5.5",
+                    "input": [],
+                    "previous_response_id": "resp_prev",
+                },
+                "ws_events": [
+                    {
+                        "type": "conversation.item.create",
+                        "item": {
+                            "type": "message",
+                            "role": "user",
+                            "content": [{"type": "input_text", "text": "Captured user frame"}],
+                        },
+                    },
+                    {
+                        "type": "response.create",
+                        "response": {
+                            "model": "gpt-5.5",
+                            "previous_response_id": "resp_prev",
+                            "input": [
+                                {
+                                    "type": "function_call_output",
+                                    "call_id": "call_1",
+                                    "output": "tool output",
+                                }
+                            ],
+                        },
+                    },
+                ],
+            },
+            "response": {"body": {"id": "resp_2", "previous_response_id": "resp_prev"}},
+        }
+    ]
+
+    _backfill_responses_history_records(records)
+
+    request_input = records[0]["request"]["body"]["input"]
+    assert request_input[0]["role"] == "user"
+    assert request_input[0]["content"][0]["text"] == "Captured user frame"
+    assert request_input[1]["type"] == "function_call_output"

--- a/tests/test_ws_proxy.py
+++ b/tests/test_ws_proxy.py
@@ -11,7 +11,7 @@ import pytest
 from aiohttp import web
 from yarl import URL
 
-from claude_tap.proxy import _build_ws_record, _get_ws_proxy_settings, proxy_handler
+from claude_tap.proxy import _build_ws_record, _build_ws_records, _get_ws_proxy_settings, proxy_handler
 from claude_tap.trace import TraceWriter
 
 
@@ -271,8 +271,33 @@ def test_build_ws_record_merges_incremental_request_and_output_items() -> None:
             ),
             json.dumps(
                 {
+                    "type": "conversation.item.create",
+                    "item": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "hello"}]},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "input.item.create",
+                    "item": {
+                        "type": "message",
+                        "role": "developer",
+                        "content": [{"type": "input_text", "text": "follow instructions"}],
+                    },
+                }
+            ),
+            json.dumps(
+                {
                     "type": "response.create",
-                    "input": [{"role": "user", "content": [{"type": "input_text", "text": "hello"}]}],
+                    "response": {
+                        "previous_response_id": "resp_previous",
+                        "input": [
+                            {
+                                "type": "function_call_output",
+                                "call_id": "call_1",
+                                "output": "tool output",
+                            }
+                        ],
+                    },
                 }
             ),
             json.dumps(
@@ -329,11 +354,99 @@ def test_build_ws_record_merges_incremental_request_and_output_items() -> None:
     )
 
     assert record["request"]["body"]["input"][0]["content"][0]["text"] == "hello"
-    assert record["request"]["body"]["input"][1]["type"] == "function_call_output"
+    assert record["request"]["body"]["input"][1]["role"] == "developer"
+    assert record["request"]["body"]["input"][2]["type"] == "function_call_output"
     assert record["request"]["body"]["previous_response_id"] == "resp_previous"
     assert record["request"]["body"]["tools"][0]["name"] == "exec_command"
+    assert record["request"]["ws_events"][1]["type"] == "conversation.item.create"
     assert record["response"]["body"]["usage"] == {"input_tokens": 10, "output_tokens": 2}
     assert record["response"]["body"]["output"][0]["content"][0]["text"] == "HELLO_FROM_WS"
+
+
+def test_build_ws_records_splits_multiplexed_responses_turns() -> None:
+    records = _build_ws_records(
+        req_id="req_ws",
+        turn=4,
+        duration_ms=50,
+        path_qs="/v1/responses",
+        req_headers={"Authorization": "Bearer test-token"},
+        client_messages=[
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "model": "gpt-5.5",
+                    "input": [
+                        {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "first"}]}
+                    ],
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.create",
+                    "model": "gpt-5.5",
+                    "previous_response_id": "resp_1",
+                    "input": [{"type": "function_call_output", "call_id": "call_1", "output": "tool output"}],
+                }
+            ),
+        ],
+        server_messages=[
+            json.dumps(
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {
+                        "type": "function_call",
+                        "call_id": "call_1",
+                        "name": "exec_command",
+                        "arguments": "{}",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {"id": "resp_1", "status": "completed", "output": [], "usage": {"input_tokens": 1}},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.output_item.done",
+                    "output_index": 0,
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [{"type": "output_text", "text": "second answer"}],
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "response.completed",
+                    "response": {
+                        "id": "resp_2",
+                        "previous_response_id": "resp_1",
+                        "status": "completed",
+                        "output": [],
+                        "usage": {"input_tokens": 2},
+                    },
+                }
+            ),
+        ],
+        upstream_base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert len(records) == 2
+    assert records[0]["request_id"] == "req_ws_1"
+    assert records[0]["turn"] == 4
+    assert records[0]["request"]["body"]["input"][0]["content"][0]["text"] == "first"
+    assert records[0]["response"]["body"]["id"] == "resp_1"
+    assert records[0]["response"]["body"]["output"][0]["type"] == "function_call"
+    assert records[1]["request_id"] == "req_ws_2"
+    assert records[1]["turn"] == 5
+    assert records[1]["request"]["body"]["previous_response_id"] == "resp_1"
+    assert records[1]["request"]["body"]["input"][0]["type"] == "function_call_output"
+    assert records[1]["response"]["body"]["id"] == "resp_2"
+    assert records[1]["response"]["body"]["output"][0]["content"][0]["text"] == "second answer"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- backfill Responses history from `previous_response_id` by indexing response outputs, not only request inputs
- render Responses `function_call` and `function_call_output` items in the Messages panel as tool use/result history
- apply the same history backfill for JSON/Markdown exports

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -x --timeout=60`
- verified real trace HTML: `/Users/liaohch3/src/github.com/SoTALab-ai/sotalab-platform/logs/skill-task-610-tap/stage1-combined.stage1.previous-id-backfilled.html`

## Screenshot
![Responses history](https://raw.githubusercontent.com/liaohch3/claude-tap/main/docs/evidence/issue87/codex-sdk-real-ws-message-history.png)

Fixes #87