### PR TITLE
Add claude-internal tap client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [中文文档](README_zh.md)
 
-Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
+Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code), Claude Internal, or [Codex CLI](https://github.com/openai/codex). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
 
 ![Demo](docs/demo.gif)
 
@@ -24,7 +24,7 @@ Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.
 
 ## Install
 
-Requires Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (or [Codex CLI](https://github.com/openai/codex) for `--tap-client codex`).
+Requires Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (or [Codex CLI](https://github.com/openai/codex) for `--tap-client codex`; or an internal `claude-internal` binary for `--tap-client claude-internal`).
 
 ```bash
 # Recommended
@@ -56,6 +56,18 @@ claude-tap -- --dangerously-skip-permissions
 
 # Full-power combo: live viewer + skip permissions + specific model
 claude-tap --tap-live -- --dangerously-skip-permissions --model claude-sonnet-4-6
+```
+
+### Claude Internal
+
+If your environment provides the internal Claude client as `claude-internal`, select it explicitly:
+
+```bash
+# Launch Claude Internal with tracing
+claude-tap --tap-client claude-internal
+
+# Pass any flags through to Claude Internal
+claude-tap --tap-client claude-internal -- --model claude-sonnet-4-6
 ```
 
 ### Codex CLI
@@ -119,6 +131,11 @@ claude-tap --tap-no-launch --tap-port 8080
 # In another terminal:
 ANTHROPIC_BASE_URL=http://127.0.0.1:8080 claude
 
+# Claude Internal
+claude-tap --tap-client claude-internal --tap-no-launch --tap-port 8080
+# In another terminal:
+ANTHROPIC_BASE_URL=http://127.0.0.1:8080 claude-internal
+
 # Codex CLI (OAuth)
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-no-launch --tap-port 8080
 # In another terminal:
@@ -151,7 +168,7 @@ claude-tap --tap-max-traces 10
 All flags are forwarded to the selected client, except these `--tap-*` ones:
 
 ```
---tap-client CLIENT      Client to launch: claude (default) or codex
+--tap-client CLIENT      Client to launch: claude (default), claude-internal, or codex
 --tap-target URL         Upstream API URL (default: auto per client)
 --tap-live               Start real-time viewer (auto-opens browser)
 --tap-live-port PORT     Port for live viewer server (default: auto)
@@ -187,7 +204,7 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 
 **How it works:**
 
-1. `claude-tap` starts a reverse proxy and spawns the selected client (`claude` or `codex`) with the provider-specific base URL pointing to it
+1. `claude-tap` starts a reverse proxy and spawns the selected client (`claude`, `claude-internal`, or `codex`) with the provider-specific base URL pointing to it
 2. All API requests flow through the proxy → upstream API → back through proxy
 3. SSE streaming responses are forwarded in real-time (zero added latency)
 4. Each request-response pair is recorded to `trace.jsonl`

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,7 +7,7 @@
 
 [English](README.md)
 
-拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 或 [Codex CLI](https://github.com/openai/codex) 的所有 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、优化 token 用量——通过一个美观的 trace 查看器。
+拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、Claude Internal 或 [Codex CLI](https://github.com/openai/codex) 的所有 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、优化 token 用量——通过一个美观的 trace 查看器。
 
 ![演示](docs/demo_zh.gif)
 
@@ -24,7 +24,7 @@
 
 ## 安装
 
-需要 Python 3.11+ 和 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)（使用 `--tap-client codex` 时需要 [Codex CLI](https://github.com/openai/codex)）。
+需要 Python 3.11+ 和 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)（使用 `--tap-client codex` 时需要 [Codex CLI](https://github.com/openai/codex)；使用 `--tap-client claude-internal` 时需要内部 `claude-internal` 可执行文件）。
 
 ```bash
 # 推荐
@@ -56,6 +56,18 @@ claude-tap -- --dangerously-skip-permissions
 
 # 全功能组合：实时查看器 + 跳过权限确认 + 指定模型
 claude-tap --tap-live -- --dangerously-skip-permissions --model claude-sonnet-4-6
+```
+
+### Claude Internal
+
+如果你的环境提供名为 `claude-internal` 的内部 Claude 客户端，可以显式选择它：
+
+```bash
+# 启动带 trace 的 Claude Internal
+claude-tap --tap-client claude-internal
+
+# 透传参数给 Claude Internal
+claude-tap --tap-client claude-internal -- --model claude-sonnet-4-6
 ```
 
 ### Codex CLI
@@ -111,6 +123,11 @@ claude-tap --tap-no-launch --tap-port 8080
 # 在另一个终端:
 ANTHROPIC_BASE_URL=http://127.0.0.1:8080 claude
 
+# Claude Internal
+claude-tap --tap-client claude-internal --tap-no-launch --tap-port 8080
+# 在另一个终端:
+ANTHROPIC_BASE_URL=http://127.0.0.1:8080 claude-internal
+
 # Codex CLI（OAuth）
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-no-launch --tap-port 8080
 # 在另一个终端:
@@ -143,7 +160,7 @@ claude-tap --tap-max-traces 10
 除以下 `--tap-*` 参数外，所有参数均透传给所选客户端：
 
 ```
---tap-client CLIENT      启动的客户端: claude（默认）或 codex
+--tap-client CLIENT      启动的客户端: claude（默认）、claude-internal 或 codex
 --tap-target URL         上游 API 地址（默认: 根据客户端自动选择）
 --tap-live               启动实时查看器（自动打开浏览器）
 --tap-live-port PORT     实时查看器端口（默认: 自动分配）
@@ -179,7 +196,7 @@ claude-tap --tap-max-traces 10
 
 **工作原理:**
 
-1. `claude-tap` 启动反向代理，并以对应服务商的 base URL 指向代理来启动所选客户端（`claude` 或 `codex`）
+1. `claude-tap` 启动反向代理，并以对应服务商的 base URL 指向代理来启动所选客户端（`claude`、`claude-internal` 或 `codex`）
 2. 所有 API 请求流经: 代理 → 上游 API → 代理返回
 3. SSE 流式响应实时转发（零额外延迟）
 4. 每个请求-响应对记录到 `trace.jsonl`

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -62,6 +62,11 @@ class ClientConfig:
     base_url_suffix: str  # appended to http://127.0.0.1:{port}
     default_target: str
     nesting_env_keys: tuple[str, ...] = ()  # env vars to clear before launch
+    inject_forward_proxy_settings: bool = False
+    config_base_url_key: str | None = None
+    strip_path_prefix: str = ""
+    strip_path_prefix_skip_target_contains: str | None = None
+    force_http: bool = False
 
     @property
     def missing_help(self) -> str:
@@ -71,6 +76,13 @@ class ClientConfig:
 
     def reverse_base_url(self, port: int) -> str:
         return f"http://127.0.0.1:{port}{self.base_url_suffix}"
+
+    def strip_path_prefix_for_target(self, target: str) -> str:
+        if not self.strip_path_prefix:
+            return ""
+        if self.strip_path_prefix_skip_target_contains and self.strip_path_prefix_skip_target_contains in target:
+            return ""
+        return self.strip_path_prefix
 
 
 CLIENT_CONFIGS: dict[str, ClientConfig] = {
@@ -82,6 +94,17 @@ CLIENT_CONFIGS: dict[str, ClientConfig] = {
         base_url_suffix="",
         default_target="https://api.anthropic.com",
         nesting_env_keys=("CLAUDECODE", "CLAUDE_CODE_SSE_PORT"),
+        inject_forward_proxy_settings=True,
+    ),
+    "claude-internal": ClientConfig(
+        cmd="claude-internal",
+        label="Claude Internal",
+        install_url="your internal Claude Code distribution channel",
+        base_url_env="ANTHROPIC_BASE_URL",
+        base_url_suffix="",
+        default_target="https://api.anthropic.com",
+        nesting_env_keys=("CLAUDECODE", "CLAUDE_CODE_SSE_PORT"),
+        inject_forward_proxy_settings=True,
     ),
     "codex": ClientConfig(
         cmd="codex",
@@ -90,6 +113,10 @@ CLIENT_CONFIGS: dict[str, ClientConfig] = {
         base_url_env="OPENAI_BASE_URL",
         base_url_suffix="/v1",
         default_target="https://api.openai.com",
+        config_base_url_key="openai_base_url",
+        strip_path_prefix="/v1",
+        strip_path_prefix_skip_target_contains="api.openai.com",
+        force_http=True,
     ),
 }
 
@@ -113,7 +140,9 @@ async def run_client(
     env = os.environ.copy()
 
     cmd_args = list(extra_args)
-    has_openai_base_override = _has_config_override(cmd_args, "openai_base_url")
+    has_config_base_override = cfg.config_base_url_key is not None and _has_config_override(
+        cmd_args, cfg.config_base_url_key
+    )
 
     if proxy_mode == "forward":
         proxy_url = f"http://127.0.0.1:{port}"
@@ -130,7 +159,7 @@ async def run_client(
             env["SSL_CERT_FILE"] = str(ca_cert_path)
             env["CODEX_CA_CERTIFICATE"] = str(ca_cert_path)
 
-        if client == "claude":
+        if cfg.inject_forward_proxy_settings:
             # Claude Code may source proxy env from settings rather than process env.
             # Inject equivalent settings unless user already provided --settings.
             has_settings_arg = any(arg == "--settings" or arg.startswith("--settings=") for arg in cmd_args)
@@ -153,10 +182,10 @@ async def run_client(
         base_url = cfg.reverse_base_url(port)
         env[cfg.base_url_env] = base_url
         env["NO_PROXY"] = "127.0.0.1"
-        if client == "codex" and not has_openai_base_override:
+        if cfg.config_base_url_key and not has_config_base_override:
             # Newer Codex builds may ignore OPENAI_BASE_URL in OAuth/WebSocket mode
             # unless the same value is also supplied as a config override.
-            cmd_args = ["-c", f'openai_base_url="{base_url}"'] + cmd_args
+            cmd_args = ["-c", f'{cfg.config_base_url_key}="{base_url}"'] + cmd_args
 
     for key in cfg.nesting_env_keys:
         env.pop(key, None)
@@ -337,13 +366,14 @@ async def async_main(args: argparse.Namespace):
         print(f"   CA cert: {ca_cert_path}")
     else:
         app = web.Application(client_max_size=0)  # No body size limit (proxy must forward everything)
+        cfg = CLIENT_CONFIGS[args.client]
         app["trace_ctx"] = {
             "target_url": args.target,
             "writer": writer,
             "session": session,
             "turn_counter": 0,
-            "strip_path_prefix": "/v1" if args.client == "codex" and "api.openai.com" not in args.target else "",
-            "force_http": args.client == "codex",
+            "strip_path_prefix": cfg.strip_path_prefix_for_target(args.target),
+            "force_http": cfg.force_http,
         }
         app.router.add_route("*", "/{path_info:.*}", proxy_handler)
 
@@ -492,7 +522,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     tap_parser = argparse.ArgumentParser(
         prog="claude-tap",
-        description="Trace Claude Code or Codex API requests via a local proxy. "
+        description="Trace Claude Code, Claude Internal, or Codex API requests via a local proxy. "
         "All flags not listed below are forwarded to the selected client.",
         epilog=(
             "claude code:\n"
@@ -502,6 +532,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  claude-tap -- -c                      Continue last conversation\n"
             "  claude-tap -- --dangerously-skip-permissions  Auto-accept tool calls\n"
             "  claude-tap --tap-live -- --dangerously-skip-permissions --model claude-sonnet-4-6\n"
+            "  claude-tap --tap-client claude-internal  Trace Claude Internal\n"
             "\n"
             "codex cli:\n"
             "  # API Key users (OPENAI_API_KEY) — default target works out of the box\n"
@@ -538,10 +569,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     proxy_group.add_argument(
         "--tap-client",
-        choices=["claude", "codex"],
+        choices=tuple(CLIENT_CONFIGS),
         default="claude",
         dest="client",
-        help="Client to launch (default: claude)",
+        help=f"Client to launch (default: claude; choices: {', '.join(CLIENT_CONFIGS)})",
     )
     proxy_group.add_argument(
         "--tap-target",

--- a/claude_tap/forward_proxy.py
+++ b/claude_tap/forward_proxy.py
@@ -672,16 +672,19 @@ class ForwardProxyServer:
                 if msg.type == WSMsgType.TEXT:
                     server_messages.append(msg.data)
                     await ws_writer.send_frame(msg.data.encode("utf-8"), WSMsgType.TEXT)
+                    await writer.drain()
                 elif msg.type == WSMsgType.BINARY:
                     await ws_writer.send_frame(msg.data, WSMsgType.BINARY)
+                    await writer.drain()
                 elif msg.type == WSMsgType.PING:
                     payload = msg.data if isinstance(msg.data, (bytes, bytearray)) else b""
                     await ws_writer.send_frame(bytes(payload), WSMsgType.PING)
+                    await writer.drain()
                 elif msg.type == WSMsgType.PONG:
                     payload = msg.data if isinstance(msg.data, (bytes, bytearray)) else b""
                     await ws_writer.send_frame(bytes(payload), WSMsgType.PONG)
+                    await writer.drain()
                 elif msg.type == WSMsgType.CLOSE:
-                    await ws_writer.close(code=msg.data or 1000, message=msg.extra)
                     break
                 elif msg.type in (WSMsgType.CLOSING, WSMsgType.CLOSED, WSMsgType.ERROR):
                     break
@@ -691,14 +694,17 @@ class ForwardProxyServer:
             asyncio.create_task(_relay_client_to_upstream()),
             asyncio.create_task(_relay_upstream_to_client()),
         ]
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        for task in pending:
-            task.cancel()
+        _pump_task, client_task, server_task = tasks
+        await asyncio.wait((client_task, server_task), return_when=asyncio.FIRST_COMPLETED)
+        if client_task.done() and not server_task.done():
             try:
-                await task
-            except (asyncio.CancelledError, Exception):
+                await asyncio.wait_for(server_task, timeout=5)
+            except (TimeoutError, asyncio.CancelledError, Exception):
                 pass
-        for task in done:
+
+        for task in tasks:
+            if not task.done():
+                task.cancel()
             try:
                 await task
             except (asyncio.CancelledError, Exception):
@@ -707,7 +713,12 @@ class ForwardProxyServer:
         if not upstream_ws.closed:
             await upstream_ws.close()
         try:
+            if server_messages:
+                # Let queued data frames reach aiohttp clients before the close frame.
+                await writer.drain()
+                await asyncio.sleep(0.01)
             await ws_writer.close()
+            await writer.drain()
         except Exception:
             pass
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -14,6 +14,7 @@ This document tracks all verified (client × auth × target × transport) combin
 | Client | Auth Mode | Target | strip_path_prefix | Transport | Status |
 |--------|-----------|--------|-------------------|-----------|--------|
 | Claude Code | API Key | `https://api.anthropic.com` | none | HTTP/SSE | Verified |
+| Claude Internal | Internal auth | `https://api.anthropic.com` | none | HTTP/SSE | Verified with fake upstream |
 | Codex CLI | API Key (`OPENAI_API_KEY`) | `https://api.openai.com` | none | HTTP/SSE | Verified |
 | Codex CLI | API Key (`OPENAI_API_KEY`) | `https://api.openai.com` | none | WebSocket | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | HTTP/SSE | Verified |
@@ -35,7 +36,7 @@ upstream: {target}/responses
 ### Decision Logic
 
 ```python
-strip = "/v1" if client == "codex" and "api.openai.com" not in target else ""
+strip = CLIENT_CONFIGS[client].strip_path_prefix_for_target(target)
 ```
 
 | Target contains `api.openai.com` | strip | Example |
@@ -47,8 +48,9 @@ strip = "/v1" if client == "codex" and "api.openai.com" not in target else ""
 
 ### Automated (CI)
 
-- `test_codex_upstream_url_construction` — verifies URL construction for all 5 matrix combinations
+- `test_codex_upstream_url_construction` — verifies URL construction for all configured client rows
 - `test_codex_client_reverse_proxy` — e2e with fake upstream (OAuth-like, with strip)
+- `test_claude_internal_client_reverse_proxy` — e2e with fake upstream (Claude-like, no strip)
 - `test_websocket_proxy_basic` — WS relay and trace recording
 
 ### Manual (pre-merge for proxy changes)
@@ -56,6 +58,10 @@ strip = "/v1" if client == "codex" and "api.openai.com" not in target else ""
 ```bash
 # API Key mode
 uv run python -m claude_tap --tap-client codex --tap-no-launch --tap-port 0
+# Verify log shows correct upstream URL
+
+# Claude Internal mode
+uv run python -m claude_tap --tap-client claude-internal --tap-no-launch --tap-port 0
 # Verify log shows correct upstream URL
 
 # OAuth mode

--- a/tests/test_codex_launch.py
+++ b/tests/test_codex_launch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
@@ -22,6 +23,46 @@ class _DummyProc:
 
     def kill(self) -> None:
         self.returncode = -9
+
+
+@pytest.mark.asyncio
+async def test_run_client_claude_internal_reverse_injects_anthropic_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/claude-internal")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["--version"], client="claude-internal", proxy_mode="reverse")
+
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/claude-internal", "--version")
+    assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:43123"
+
+
+@pytest.mark.asyncio
+async def test_run_client_claude_internal_forward_injects_proxy_settings(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/claude-internal")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["--version"], client="claude-internal", proxy_mode="forward")
+
+    assert code == 0
+    assert captured["cmd"][:2] == ("/tmp/claude-internal", "--settings")
+    settings = captured["cmd"][2]
+    assert json.loads(settings)["env"]["HTTPS_PROXY"] == "http://127.0.0.1:43123"
 
 
 @pytest.mark.asyncio

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -417,6 +417,9 @@ def _run_claude_tap(project_dir, trace_dir, fake_bin_dir, upstream_port, timeout
     Returns the CompletedProcess."""
     env = os.environ.copy()
     env["PATH"] = fake_bin_dir + ":" + env.get("PATH", "")
+    repo_root = Path(__file__).resolve().parent.parent
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = str(repo_root) if not existing_pythonpath else f"{repo_root}{os.pathsep}{existing_pythonpath}"
 
     cmd = [
         sys.executable,
@@ -1185,6 +1188,13 @@ def test_parse_args(monkeypatch, tmp_path):
     assert a.claude_args == []
     print("  OK: codex defaults")
 
+    # Claude Internal defaults
+    a = parse_args(["--tap-client", "claude-internal"])
+    assert a.client == "claude-internal"
+    assert a.target == "https://api.anthropic.com"
+    assert a.claude_args == []
+    print("  OK: claude-internal defaults")
+
     # Claude flags pass through
     a = parse_args(["-c"])
     assert a.claude_args == ["-c"]
@@ -1302,6 +1312,39 @@ def test_codex_client_reverse_proxy():
     finally:
         stop()
         _cleanup(trace_dir, fake_bin_dir, "codex")
+
+
+def test_claude_internal_client_reverse_proxy():
+    """Test --tap-client claude-internal in reverse mode using ANTHROPIC_BASE_URL."""
+    stop_upstream, upstream_port = run_fake_upstream_in_thread()
+    trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_claude_internal_")
+    fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_claude_internal_")
+    fake_claude_internal = Path(fake_bin_dir) / "claude-internal"
+    fake_claude_internal.write_text(FAKE_CLAUDE_SCRIPT)
+    fake_claude_internal.chmod(fake_claude_internal.stat().st_mode | stat.S_IEXEC)
+
+    try:
+        proc = _run_claude_tap(
+            Path(__file__).parent,
+            trace_dir,
+            fake_bin_dir,
+            upstream_port,
+            tap_client="claude-internal",
+        )
+
+        assert proc.returncode == 0, f"claude-internal mode failed: stdout={proc.stdout} stderr={proc.stderr}"
+        trace_files = list(Path(trace_dir).glob("**/*.jsonl"))
+        assert len(trace_files) == 1
+        records = [json.loads(line) for line in trace_files[0].read_text().splitlines() if line.strip()]
+        assert len(records) == 2
+        assert records[0]["request"]["path"] == "/v1/messages"
+        assert records[0]["upstream_base_url"] == f"http://127.0.0.1:{upstream_port}"
+        assert records[0]["request"]["body"]["model"] == "claude-test-model"
+        assert "ANTHROPIC_BASE_URL=http://127.0.0.1:" in proc.stdout
+        assert "Starting Claude Internal" in proc.stdout
+    finally:
+        stop_upstream()
+        _cleanup(trace_dir, fake_bin_dir, "claude-internal")
 
 
 ## ---------------------------------------------------------------------------
@@ -2155,6 +2198,7 @@ def test_codex_upstream_url_construction(monkeypatch, tmp_path):
     See: docs/error-experience/entries/2026-03-10-codex-strip-prefix-url-mismatch.md
     """
     from claude_tap import parse_args
+    from claude_tap.cli import CLIENT_CONFIGS
 
     monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
 
@@ -2166,37 +2210,43 @@ def test_codex_upstream_url_construction(monkeypatch, tmp_path):
 
     # Case 1: API Key mode — target=api.openai.com, should NOT strip /v1
     args = parse_args(["--tap-client", "codex"])
-    strip = "/v1" if args.client == "codex" and "api.openai.com" not in args.target else ""
+    strip = CLIENT_CONFIGS[args.client].strip_path_prefix_for_target(args.target)
     url = _build_upstream(args.target, strip, "/v1/responses")
     assert url == "https://api.openai.com/v1/responses", f"API Key mode URL wrong: {url}"
     print("  OK: api.openai.com + /v1/responses → correct")
 
     # Case 2: OAuth mode — target=chatgpt.com, should strip /v1
     args = parse_args(["--tap-client", "codex", "--tap-target", "https://chatgpt.com/backend-api/codex"])
-    strip = "/v1" if args.client == "codex" and "api.openai.com" not in args.target else ""
+    strip = CLIENT_CONFIGS[args.client].strip_path_prefix_for_target(args.target)
     url = _build_upstream(args.target, strip, "/v1/responses")
     assert url == "https://chatgpt.com/backend-api/codex/responses", f"OAuth mode URL wrong: {url}"
     print("  OK: chatgpt.com + /v1/responses → correct")
 
     # Case 3: API Key mode with /v1/models path
     args = parse_args(["--tap-client", "codex"])
-    strip = "/v1" if args.client == "codex" and "api.openai.com" not in args.target else ""
+    strip = CLIENT_CONFIGS[args.client].strip_path_prefix_for_target(args.target)
     url = _build_upstream(args.target, strip, "/v1/models")
     assert url == "https://api.openai.com/v1/models", f"API Key models URL wrong: {url}"
     print("  OK: api.openai.com + /v1/models → correct")
 
     # Case 4: OAuth mode with /v1/models path
     args = parse_args(["--tap-client", "codex", "--tap-target", "https://chatgpt.com/backend-api/codex"])
-    strip = "/v1" if args.client == "codex" and "api.openai.com" not in args.target else ""
+    strip = CLIENT_CONFIGS[args.client].strip_path_prefix_for_target(args.target)
     url = _build_upstream(args.target, strip, "/v1/models")
     assert url == "https://chatgpt.com/backend-api/codex/models", f"OAuth models URL wrong: {url}"
     print("  OK: chatgpt.com + /v1/models → correct")
 
     # Case 5: Claude client should never strip
     args = parse_args(["--tap-client", "claude"])
-    strip = "/v1" if args.client == "codex" and "api.openai.com" not in args.target else ""
+    strip = CLIENT_CONFIGS[args.client].strip_path_prefix_for_target(args.target)
     assert strip == "", "Claude client should never strip path prefix"
     print("  OK: claude client has no strip prefix")
+
+    # Case 6: Claude Internal client should never strip
+    args = parse_args(["--tap-client", "claude-internal"])
+    strip = CLIENT_CONFIGS[args.client].strip_path_prefix_for_target(args.target)
+    assert strip == "", "Claude Internal client should never strip path prefix"
+    print("  OK: claude-internal client has no strip prefix")
 
     print("  test_codex_upstream_url_construction PASSED")
 


### PR DESCRIPTION
## Summary
- Add `--tap-client claude-internal` as a Claude-compatible client that launches `claude-internal` and injects `ANTHROPIC_BASE_URL`.
- Move client-specific reverse proxy behavior into `ClientConfig` so `claude`, `claude-internal`, and `codex` share one configuration path.
- Document Claude Internal usage and update the support matrix.
- Fix forward-proxy WebSocket close handling so queued upstream frames flush before the close frame.

## Tests
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -x --timeout=60`
- `uv run python scripts/check_legibility.py`

No UI changes; screenshot evidence is not applicable.