### PR TITLE
feat: add copilot tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [中文文档](README_zh.md)
 
-Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
+Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), or [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/getting-started-with-github-copilot-in-the-cli). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
 
 ![Demo](docs/demo.gif)
 
@@ -24,7 +24,7 @@ Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.
 
 ## Install
 
-Requires Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (or [Codex CLI](https://github.com/openai/codex) for `--tap-client codex`).
+Requires Python 3.11+ and one supported client: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), or [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/getting-started-with-github-copilot-in-the-cli).
 
 ```bash
 # Recommended
@@ -84,6 +84,21 @@ claude-tap --tap-client codex -- --full-auto
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-live -- --full-auto
 ```
 
+### GitHub Copilot CLI
+
+GitHub Copilot CLI uses forward proxy mode by default because it does not expose a provider base URL setting.
+
+```bash
+# Basic — launch GitHub Copilot CLI with tracing
+claude-tap --tap-client copilot
+
+# Ask one prompt non-interactively
+claude-tap --tap-client copilot -- -p "Explain this repository"
+
+# Live viewer while Copilot runs
+claude-tap --tap-client copilot --tap-live
+```
+
 ### Browser Preview
 
 ```bash
@@ -128,6 +143,11 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex
 claude-tap --tap-client codex --tap-no-launch --tap-port 8080
 # In another terminal:
 OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex
+
+# GitHub Copilot CLI
+claude-tap --tap-client copilot --tap-no-launch --tap-port 8080
+# In another terminal:
+HTTPS_PROXY=http://127.0.0.1:8080 NODE_EXTRA_CA_CERTS=~/.claude-tap/ca.pem copilot
 ```
 
 ### Common Combos
@@ -138,6 +158,9 @@ claude-tap --tap-live -- --dangerously-skip-permissions
 
 # Trace Codex (OAuth) with live viewer and full auto
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-live -- --full-auto
+
+# Trace GitHub Copilot CLI with live viewer
+claude-tap --tap-client copilot --tap-live
 
 # Save traces to a custom directory
 claude-tap --tap-output-dir ./my-traces
@@ -151,7 +174,7 @@ claude-tap --tap-max-traces 10
 All flags are forwarded to the selected client, except these `--tap-*` ones:
 
 ```
---tap-client CLIENT      Client to launch: claude (default) or codex
+--tap-client CLIENT      Client to launch: claude (default), codex, or copilot
 --tap-target URL         Upstream API URL (default: auto per client)
 --tap-live               Start real-time viewer (auto-opens browser)
 --tap-live-port PORT     Port for live viewer server (default: auto)
@@ -163,7 +186,7 @@ All flags are forwarded to the selected client, except these `--tap-*` ones:
 --tap-max-traces N       Max trace sessions to keep (default: 50, 0 = unlimited)
 --tap-no-update-check    Disable PyPI update check on startup
 --tap-no-auto-update     Check for updates but don't auto-download
---tap-proxy-mode MODE    Proxy mode: reverse (default) or forward
+--tap-proxy-mode MODE    Proxy mode: reverse or forward (default is client-specific)
 ```
 
 ## Viewer Features
@@ -187,7 +210,7 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 
 **How it works:**
 
-1. `claude-tap` starts a reverse proxy and spawns the selected client (`claude` or `codex`) with the provider-specific base URL pointing to it
+1. `claude-tap` starts a reverse proxy for clients with base URL support, or a forward proxy for clients such as Copilot, then spawns the selected client
 2. All API requests flow through the proxy → upstream API → back through proxy
 3. SSE streaming responses are forwarded in real-time (zero added latency)
 4. Each request-response pair is recorded to `trace.jsonl`

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,7 +7,7 @@
 
 [English](README.md)
 
-拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 或 [Codex CLI](https://github.com/openai/codex) 的所有 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、优化 token 用量——通过一个美观的 trace 查看器。
+拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex) 或 [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/getting-started-with-github-copilot-in-the-cli) 的所有 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、优化 token 用量——通过一个美观的 trace 查看器。
 
 ![演示](docs/demo_zh.gif)
 
@@ -24,7 +24,7 @@
 
 ## 安装
 
-需要 Python 3.11+ 和 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)（使用 `--tap-client codex` 时需要 [Codex CLI](https://github.com/openai/codex)）。
+需要 Python 3.11+ 和一个受支持客户端：[Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex) 或 [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli/getting-started-with-github-copilot-in-the-cli)。
 
 ```bash
 # 推荐
@@ -84,6 +84,21 @@ claude-tap --tap-client codex -- --full-auto
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-live -- --full-auto
 ```
 
+### GitHub Copilot CLI
+
+GitHub Copilot CLI 默认使用 forward proxy 模式，因为它不提供类似 `ANTHROPIC_BASE_URL` 或 `OPENAI_BASE_URL` 的上游 base URL 配置。
+
+```bash
+# 基本用法 — 启动带 trace 的 GitHub Copilot CLI
+claude-tap --tap-client copilot
+
+# 非交互式提问
+claude-tap --tap-client copilot -- -p "Explain this repository"
+
+# 实时查看器
+claude-tap --tap-client copilot --tap-live
+```
+
 ### 浏览器预览
 
 ```bash
@@ -120,6 +135,11 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex
 claude-tap --tap-client codex --tap-no-launch --tap-port 8080
 # 在另一个终端:
 OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex
+
+# GitHub Copilot CLI
+claude-tap --tap-client copilot --tap-no-launch --tap-port 8080
+# 在另一个终端:
+HTTPS_PROXY=http://127.0.0.1:8080 NODE_EXTRA_CA_CERTS=~/.claude-tap/ca.pem copilot
 ```
 
 ### 常用组合
@@ -130,6 +150,9 @@ claude-tap --tap-live -- --dangerously-skip-permissions
 
 # 追踪 Codex（OAuth）：实时查看器 + 全自动
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-live -- --full-auto
+
+# 追踪 GitHub Copilot CLI：实时查看器
+claude-tap --tap-client copilot --tap-live
 
 # 自定义 trace 输出目录
 claude-tap --tap-output-dir ./my-traces
@@ -143,7 +166,7 @@ claude-tap --tap-max-traces 10
 除以下 `--tap-*` 参数外，所有参数均透传给所选客户端：
 
 ```
---tap-client CLIENT      启动的客户端: claude（默认）或 codex
+--tap-client CLIENT      启动的客户端: claude（默认）、codex 或 copilot
 --tap-target URL         上游 API 地址（默认: 根据客户端自动选择）
 --tap-live               启动实时查看器（自动打开浏览器）
 --tap-live-port PORT     实时查看器端口（默认: 自动分配）
@@ -155,7 +178,7 @@ claude-tap --tap-max-traces 10
 --tap-max-traces N       最大保留 trace 数量（默认: 50，0 = 不限）
 --tap-no-update-check    禁用启动时的 PyPI 更新检查
 --tap-no-auto-update     仅检查更新，不自动下载
---tap-proxy-mode MODE    代理模式: reverse（默认）或 forward
+--tap-proxy-mode MODE    代理模式: reverse 或 forward（默认根据客户端选择）
 ```
 
 ## 查看器功能
@@ -179,7 +202,7 @@ claude-tap --tap-max-traces 10
 
 **工作原理:**
 
-1. `claude-tap` 启动反向代理，并以对应服务商的 base URL 指向代理来启动所选客户端（`claude` 或 `codex`）
+1. `claude-tap` 对支持 base URL 的客户端启动反向代理，对 Copilot 等客户端启动正向代理，然后启动所选客户端
 2. 所有 API 请求流经: 代理 → 上游 API → 代理返回
 3. SSE 流式响应实时转发（零额外延迟）
 4. 每个请求-响应对记录到 `trace.jsonl`

--- a/claude_tap/__init__.py
+++ b/claude_tap/__init__.py
@@ -1,8 +1,8 @@
-"""claude-tap: Proxy to trace Claude Code API requests.
+"""claude-tap: Proxy to trace AI CLI API requests.
 
-A CLI tool that wraps Claude Code with a local proxy (reverse or forward)
-to intercept and record all API requests. Useful for studying Claude Code's
-Context Engineering.
+A CLI tool that wraps Claude Code, Codex CLI, or GitHub Copilot CLI with a local
+proxy (reverse or forward) to intercept and record all API requests. Useful for
+studying AI CLI Context Engineering.
 """
 
 from __future__ import annotations

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -58,9 +58,10 @@ class ClientConfig:
     cmd: str
     label: str
     install_url: str
-    base_url_env: str
+    base_url_env: str | None
     base_url_suffix: str  # appended to http://127.0.0.1:{port}
     default_target: str
+    default_proxy_mode: str = "reverse"
     nesting_env_keys: tuple[str, ...] = ()  # env vars to clear before launch
 
     @property
@@ -91,6 +92,15 @@ CLIENT_CONFIGS: dict[str, ClientConfig] = {
         base_url_suffix="/v1",
         default_target="https://api.openai.com",
     ),
+    "copilot": ClientConfig(
+        cmd="copilot",
+        label="GitHub Copilot CLI",
+        install_url="https://docs.github.com/en/copilot/github-copilot-in-the-cli/getting-started-with-github-copilot-in-the-cli",
+        base_url_env=None,
+        base_url_suffix="",
+        default_target="https://api.githubcopilot.com",
+        default_proxy_mode="forward",
+    ),
 }
 
 
@@ -102,6 +112,10 @@ async def run_client(
     ca_cert_path: Path | None = None,
 ) -> int:
     cfg = CLIENT_CONFIGS[client]
+
+    if proxy_mode == "reverse" and cfg.base_url_env is None:
+        print(f"\nError: {cfg.label} does not support reverse proxy mode. Use --tap-proxy-mode forward.\n")
+        return 1
 
     # asyncio.create_subprocess_exec uses CreateProcess on Windows, which only
     # auto-appends `.exe`; resolve here so npm `.cmd`/`.bat` shims also work.
@@ -151,7 +165,8 @@ async def run_client(
         # Don't set provider-specific base URL in forward mode
     else:
         base_url = cfg.reverse_base_url(port)
-        env[cfg.base_url_env] = base_url
+        if cfg.base_url_env is not None:
+            env[cfg.base_url_env] = base_url
         env["NO_PROXY"] = "127.0.0.1"
         if client == "codex" and not has_openai_base_override:
             # Newer Codex builds may ignore OPENAI_BASE_URL in OAuth/WebSocket mode
@@ -168,7 +183,8 @@ async def run_client(
         if ca_cert_path:
             print(f"   NODE_EXTRA_CA_CERTS={ca_cert_path}")
     else:
-        print(f"   {cfg.base_url_env}={cfg.reverse_base_url(port)}")
+        if cfg.base_url_env is not None:
+            print(f"   {cfg.base_url_env}={cfg.reverse_base_url(port)}")
     print()
 
     # Give child its own process group and make it the foreground group
@@ -492,7 +508,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     tap_parser = argparse.ArgumentParser(
         prog="claude-tap",
-        description="Trace Claude Code or Codex API requests via a local proxy. "
+        description="Trace Claude Code, Codex, or GitHub Copilot CLI API requests via a local proxy. "
         "All flags not listed below are forwarded to the selected client.",
         epilog=(
             "claude code:\n"
@@ -510,6 +526,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex\n"
             "  # With model and full auto-approval\n"
             "  claude-tap --tap-client codex -- --model codex-mini-latest --full-auto\n"
+            "\n"
+            "github copilot cli:\n"
+            "  claude-tap --tap-client copilot\n"
+            '  claude-tap --tap-client copilot --tap-live -- -p "Explain this repository"\n'
             "\n"
             "proxy-only mode (connect from another terminal):\n"
             "  claude-tap --tap-no-launch --tap-port 8080\n"
@@ -538,7 +558,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     proxy_group.add_argument(
         "--tap-client",
-        choices=["claude", "codex"],
+        choices=sorted(CLIENT_CONFIGS),
         default="claude",
         dest="client",
         help="Client to launch (default: claude)",
@@ -552,9 +572,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     proxy_group.add_argument(
         "--tap-proxy-mode",
         choices=["reverse", "forward"],
-        default="reverse",
+        default=None,
         dest="proxy_mode",
-        help="'reverse' sets provider base URL (default), 'forward' sets HTTPS_PROXY with CONNECT/TLS termination",
+        help="'reverse' sets provider base URL, 'forward' sets HTTPS_PROXY with CONNECT/TLS termination (default: client-specific)",
     )
     proxy_group.add_argument(
         "--tap-no-launch", action="store_true", dest="no_launch", help="Only start the proxy, don't launch client"
@@ -621,6 +641,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             args.target = _detect_codex_target()
         else:
             args.target = CLIENT_CONFIGS[args.client].default_target
+    if args.proxy_mode is None:
+        args.proxy_mode = CLIENT_CONFIGS[args.client].default_proxy_mode
     return args
 
 

--- a/claude_tap/proxy.py
+++ b/claude_tap/proxy.py
@@ -66,6 +66,7 @@ ALLOWED_PATH_PREFIXES: tuple[str, ...] = (
     "/v1/responses",
     "/v1/chat/completions",
     "/v1/completions",
+    "/v1/engines",
     "/v1/models",
     "/v1/embeddings",
     # OpenAI Responses API (after strip_path_prefix removes /v1)

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -18,6 +18,7 @@ This document tracks all verified (client × auth × target × transport) combin
 | Codex CLI | API Key (`OPENAI_API_KEY`) | `https://api.openai.com` | none | WebSocket | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | HTTP/SSE | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | WebSocket | Verified |
+| GitHub Copilot CLI | Copilot auth | `https://api.githubcopilot.com` | n/a | Forward proxy CONNECT/TLS | Supported |
 
 ## URL Construction Rules
 
@@ -37,6 +38,11 @@ upstream: {target}/responses
 ```python
 strip = "/v1" if client == "codex" and "api.openai.com" not in target else ""
 ```
+
+GitHub Copilot CLI does not use reverse proxy URL construction by default. It
+uses forward proxy mode so the client continues to call
+`https://api.githubcopilot.com` while `HTTPS_PROXY` routes traffic through
+`claude-tap`.
 
 | Target contains `api.openai.com` | strip | Example |
 |----------------------------------|-------|---------|
@@ -62,6 +68,10 @@ uv run python -m claude_tap --tap-client codex --tap-no-launch --tap-port 0
 uv run python -m claude_tap --tap-client codex \
   --tap-target https://chatgpt.com/backend-api/codex --tap-no-launch --tap-port 0
 # Verify log shows correct upstream URL
+
+# GitHub Copilot CLI
+uv run python -m claude_tap --tap-client copilot --tap-no-launch --tap-port 0
+# In another terminal, set HTTPS_PROXY and NODE_EXTRA_CA_CERTS from the proxy output.
 ```
 
 ### Real E2E (optional, when auth is available)

--- a/tests/test_codex_launch.py
+++ b/tests/test_codex_launch.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from claude_tap.cli import _has_config_override, run_client
+from claude_tap.cli import _has_config_override, parse_args, run_client
 
 
 class _DummyProc:
@@ -98,6 +98,55 @@ async def test_run_client_codex_forward_sets_rust_tls_ca_env(monkeypatch) -> Non
     assert captured["env"]["HTTPS_PROXY"] == "http://127.0.0.1:43123"
     assert captured["env"]["SSL_CERT_FILE"] == str(ca_path)
     assert captured["env"]["CODEX_CA_CERTIFICATE"] == str(ca_path)
+
+
+@pytest.mark.asyncio
+async def test_run_client_copilot_forward_sets_node_ca_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    ca_path = Path("/tmp/test-ca.pem")
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/copilot")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["-p", "hello"], client="copilot", proxy_mode="forward", ca_cert_path=ca_path)
+
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/copilot", "-p", "hello")
+    assert captured["env"]["HTTPS_PROXY"] == "http://127.0.0.1:43123"
+    assert captured["env"]["NODE_EXTRA_CA_CERTS"] == str(ca_path)
+
+
+@pytest.mark.asyncio
+async def test_run_client_copilot_reverse_is_rejected(monkeypatch) -> None:
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        raise AssertionError("Copilot reverse mode should fail before spawning")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+
+    code = await run_client(43123, [], client="copilot", proxy_mode="reverse")
+
+    assert code == 1
+
+
+def test_parse_args_copilot_defaults_to_forward() -> None:
+    args = parse_args(["--tap-client", "copilot"])
+
+    assert args.client == "copilot"
+    assert args.target == "https://api.githubcopilot.com"
+    assert args.proxy_mode == "forward"
+
+
+def test_parse_args_copilot_respects_explicit_proxy_mode() -> None:
+    args = parse_args(["--tap-client", "copilot", "--tap-proxy-mode", "reverse"])
+
+    assert args.client == "copilot"
+    assert args.proxy_mode == "reverse"
 
 
 def test_has_config_override_detects_cli_forms() -> None:

--- a/tests/test_path_allowlist.py
+++ b/tests/test_path_allowlist.py
@@ -14,6 +14,7 @@ from claude_tap.proxy import _is_allowed_path
         "/v1/responses",
         "/v1/chat/completions",
         "/v1/completions",
+        "/v1/engines/copilot-codex/completions",
         "/v1/models",
         "/v1/models/claude-3",
         "/v1/embeddings",


### PR DESCRIPTION
## Summary

- Add GitHub Copilot CLI as a supported `--tap-client copilot` client.
- Default Copilot tracing to forward proxy mode with `HTTPS_PROXY` and `NODE_EXTRA_CA_CERTS`.
- Document Copilot usage and add support-matrix coverage.

## Validation

- `uv run --extra dev python scripts/check_legibility.py`
- `uv run --extra dev ruff format --check .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev pytest tests/ -x --timeout=60`

## Screenshots

Not applicable: CLI/docs-only change.
