### PR TITLE
Add missing skill names to local skill metadata

### DIFF
--- a/.agents/skills/codex-e2e-test/SKILL.md
+++ b/.agents/skills/codex-e2e-test/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: codex-e2e-test
 description: Run real E2E tests against Codex CLI (OpenAI Responses API) through claude-tap proxy
 tags: testing, e2e, codex, responses-api
 ---

--- a/.agents/skills/real-e2e-test/SKILL.md
+++ b/.agents/skills/real-e2e-test/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: real-e2e-test
 description: Run real E2E tests against Claude CLI in pytest and tmux modes
 tags: testing, e2e, integration, tmux
 ---


### PR DESCRIPTION
补齐两个本地 skill 缺失的 name 字段