### PR TITLE
feat(cli): add opencode client support

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -62,6 +62,10 @@ class ClientConfig:
     base_url_suffix: str  # appended to http://127.0.0.1:{port}
     default_target: str
     nesting_env_keys: tuple[str, ...] = ()  # env vars to clear before launch
+    # Default proxy mode when --tap-proxy-mode is not explicitly set.
+    # Multi-provider clients (e.g. opencode) default to "forward" so that all
+    # provider traffic is captured regardless of which env var the client honors.
+    default_proxy_mode: str = "reverse"
 
     @property
     def missing_help(self) -> str:
@@ -90,6 +94,18 @@ CLIENT_CONFIGS: dict[str, ClientConfig] = {
         base_url_env="OPENAI_BASE_URL",
         base_url_suffix="/v1",
         default_target="https://api.openai.com",
+    ),
+    "opencode": ClientConfig(
+        cmd="opencode",
+        label="OpenCode",
+        install_url="https://opencode.ai/docs/",
+        # opencode is multi-provider; ANTHROPIC_BASE_URL is what reverse mode
+        # patches when the user explicitly opts out of forward mode. Forward
+        # proxy is the default and captures every provider transparently.
+        base_url_env="ANTHROPIC_BASE_URL",
+        base_url_suffix="",
+        default_target="https://api.anthropic.com",
+        default_proxy_mode="forward",
     ),
 }
 
@@ -522,6 +538,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  # With model and full auto-approval\n"
             "  claude-tap --tap-client codex -- --model codex-mini-latest --full-auto\n"
             "\n"
+            "opencode (multi-provider; defaults to forward proxy mode):\n"
+            "  # Forward proxy captures every provider opencode talks to\n"
+            "  claude-tap --tap-client opencode\n"
+            "  # Force reverse mode (single ANTHROPIC_BASE_URL provider only)\n"
+            "  claude-tap --tap-client opencode --tap-proxy-mode reverse\n"
+            "\n"
             "proxy-only mode (connect from another terminal):\n"
             "  claude-tap --tap-no-launch --tap-port 8080\n"
             "  # then: ANTHROPIC_BASE_URL=http://127.0.0.1:8080 claude\n"
@@ -553,7 +575,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     proxy_group.add_argument(
         "--tap-client",
-        choices=["claude", "codex"],
+        choices=["claude", "codex", "opencode"],
         default="claude",
         dest="client",
         help="Client to launch (default: claude)",
@@ -567,9 +589,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     proxy_group.add_argument(
         "--tap-proxy-mode",
         choices=["reverse", "forward"],
-        default="reverse",
+        default=None,
         dest="proxy_mode",
-        help="'reverse' sets provider base URL (default), 'forward' sets HTTPS_PROXY with CONNECT/TLS termination",
+        help=(
+            "'reverse' sets provider base URL, 'forward' sets HTTPS_PROXY with CONNECT/TLS termination. "
+            "Default depends on the client: 'reverse' for claude/codex, 'forward' for opencode."
+        ),
     )
     proxy_group.add_argument(
         "--tap-no-launch", action="store_true", dest="no_launch", help="Only start the proxy, don't launch client"
@@ -636,6 +661,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             args.target = _detect_codex_target()
         else:
             args.target = CLIENT_CONFIGS[args.client].default_target
+    if args.proxy_mode is None:
+        args.proxy_mode = CLIENT_CONFIGS[args.client].default_proxy_mode
     return args
 
 

--- a/claude_tap/sse.py
+++ b/claude_tap/sse.py
@@ -31,13 +31,27 @@ class SSEReassembler:
         elif line.startswith("data:"):
             self._current_data_lines.append(line[len("data:") :].strip())
         elif line == "":
-            if self._current_event is not None:
+            # Emit on blank line if we have an explicit event: header (Anthropic /
+            # OpenAI Responses) OR accumulated data: lines without a header
+            # (OpenAI Chat Completions uses bare "data: {...}" frames).
+            if self._current_event is not None or self._current_data_lines:
                 raw_data = "\n".join(self._current_data_lines)
+                # Skip OpenAI Chat Completions terminator "[DONE]" — it's a
+                # protocol sentinel, not a payload, and would otherwise show up
+                # as a noisy non-JSON event in the trace.
+                if raw_data == "[DONE]" and self._current_event is None:
+                    self._current_event = None
+                    self._current_data_lines = []
+                    return
                 try:
                     data = json.loads(raw_data)
                 except (json.JSONDecodeError, ValueError):
                     data = raw_data
-                self.add_event(self._current_event, data)
+                # Default event type for bare data: frames (OpenAI Chat
+                # Completions). Snapshot reconstruction stays a no-op for
+                # these — the events themselves are preserved in the trace.
+                event_type = self._current_event or "message"
+                self.add_event(event_type, data)
                 self._current_event = None
                 self._current_data_lines = []
 
@@ -63,6 +77,11 @@ class SSEReassembler:
                     self._snapshot = copy.deepcopy(response)
                 elif event_type in ("response.completed", "response.done"):
                     self._snapshot = copy.deepcopy(data)
+            elif event_type == "message" and "choices" in data:
+                # OpenAI Chat Completions chunk — must run before the
+                # `_snapshot is None` guard below, since the accumulator
+                # initializes its own snapshot on the first chunk.
+                self._accumulate_chat_completion_chunk(data)
             elif self._snapshot is None:
                 return
             elif event_type == "content_block_start":
@@ -106,6 +125,77 @@ class SSEReassembler:
                     self._snapshot["usage"].update(usage)
         except Exception:
             pass
+
+    def _accumulate_chat_completion_chunk(self, data: dict) -> None:
+        choices = data.get("choices") or []
+        if not isinstance(choices, list) or not choices:
+            return
+        choice = choices[0] if isinstance(choices[0], dict) else {}
+        delta = choice.get("delta") or {}
+        finish_reason = choice.get("finish_reason")
+
+        if self._snapshot is None:
+            self._snapshot = {
+                "id": data.get("id", ""),
+                "object": "chat.completion",
+                "model": data.get("model", ""),
+                "choices": [
+                    {
+                        "index": 0,
+                        "message": {"role": delta.get("role") or "assistant", "content": ""},
+                        "finish_reason": None,
+                    }
+                ],
+                # Anthropic-shape mirror so the viewer's renderResponseContent
+                # picks it up without schema-specific code.
+                "content": [{"type": "text", "text": ""}],
+            }
+
+        msg = self._snapshot["choices"][0]["message"]
+        text_block = self._snapshot["content"][0]
+
+        if isinstance(delta.get("role"), str) and delta["role"]:
+            msg["role"] = delta["role"]
+        if isinstance(delta.get("content"), str) and delta["content"]:
+            msg["content"] = (msg.get("content") or "") + delta["content"]
+            text_block["text"] = (text_block.get("text") or "") + delta["content"]
+
+        # Tool calls arrive as indexed deltas: {"index": 0, "id":?, "type":?,
+        # "function": {"name":?, "arguments":?}}. Each field accumulates by
+        # concatenation — most providers stream `arguments` token by token.
+        for tc_delta in delta.get("tool_calls") or []:
+            if not isinstance(tc_delta, dict):
+                continue
+            idx = tc_delta.get("index", 0)
+            tool_calls = msg.setdefault("tool_calls", [])
+            while len(tool_calls) <= idx:
+                tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
+            existing = tool_calls[idx]
+            if isinstance(tc_delta.get("id"), str):
+                existing["id"] = tc_delta["id"]
+            if isinstance(tc_delta.get("type"), str):
+                existing["type"] = tc_delta["type"]
+            fn_delta = tc_delta.get("function") or {}
+            if isinstance(fn_delta, dict):
+                fn = existing.setdefault("function", {"name": "", "arguments": ""})
+                if isinstance(fn_delta.get("name"), str):
+                    fn["name"] = (fn.get("name") or "") + fn_delta["name"]
+                if isinstance(fn_delta.get("arguments"), str):
+                    fn["arguments"] = (fn.get("arguments") or "") + fn_delta["arguments"]
+
+        if finish_reason:
+            self._snapshot["choices"][0]["finish_reason"] = finish_reason
+
+        # Usage typically arrives only on the final chunk. Keep both naming
+        # schemes so existing Anthropic-oriented stat code still works.
+        usage = data.get("usage")
+        if isinstance(usage, dict):
+            merged = dict(usage)
+            if "prompt_tokens" in usage and "input_tokens" not in usage:
+                merged["input_tokens"] = usage["prompt_tokens"]
+            if "completion_tokens" in usage and "output_tokens" not in usage:
+                merged["output_tokens"] = usage["completion_tokens"]
+            self._snapshot["usage"] = merged
 
     def reconstruct(self) -> dict | None:
         if self._snapshot is None:

--- a/claude_tap/sse.py
+++ b/claude_tap/sse.py
@@ -128,8 +128,16 @@ class SSEReassembler:
 
     def _accumulate_chat_completion_chunk(self, data: dict) -> None:
         choices = data.get("choices") or []
+        usage = data.get("usage")
+
+        # Some providers send a final usage-only chunk: {"choices": [],
+        # "usage": {...}}. Process the usage and bail out — there is no
+        # delta body to apply.
         if not isinstance(choices, list) or not choices:
+            if isinstance(usage, dict) and self._snapshot is not None:
+                self._merge_chat_completion_usage(usage)
             return
+
         choice = choices[0] if isinstance(choices[0], dict) else {}
         delta = choice.get("delta") or {}
         finish_reason = choice.get("finish_reason")
@@ -147,7 +155,9 @@ class SSEReassembler:
                     }
                 ],
                 # Anthropic-shape mirror so the viewer's renderResponseContent
-                # picks it up without schema-specific code.
+                # picks it up without schema-specific code. content[0] is the
+                # leading text block; tool_use blocks (mirrored from
+                # msg.tool_calls) follow.
                 "content": [{"type": "text", "text": ""}],
             }
 
@@ -182,20 +192,50 @@ class SSEReassembler:
                     fn["name"] = (fn.get("name") or "") + fn_delta["name"]
                 if isinstance(fn_delta.get("arguments"), str):
                     fn["arguments"] = (fn.get("arguments") or "") + fn_delta["arguments"]
+            # Mirror this tool call into the Anthropic-shape `content` array
+            # so the viewer (which only reads body.content) can render
+            # tool-only responses, and so the sidebar's response_tool_names
+            # extractor sees the call.
+            self._mirror_tool_call_to_content(idx, existing)
 
         if finish_reason:
             self._snapshot["choices"][0]["finish_reason"] = finish_reason
 
-        # Usage typically arrives only on the final chunk. Keep both naming
-        # schemes so existing Anthropic-oriented stat code still works.
-        usage = data.get("usage")
         if isinstance(usage, dict):
-            merged = dict(usage)
-            if "prompt_tokens" in usage and "input_tokens" not in usage:
-                merged["input_tokens"] = usage["prompt_tokens"]
-            if "completion_tokens" in usage and "output_tokens" not in usage:
-                merged["output_tokens"] = usage["completion_tokens"]
-            self._snapshot["usage"] = merged
+            self._merge_chat_completion_usage(usage)
+
+    def _mirror_tool_call_to_content(self, idx: int, tc: dict) -> None:
+        """Sync one accumulated tool_call into the `content` array as a
+        tool_use block. content[0] is the leading text block, so tool_use
+        blocks live at content[idx + 1]."""
+        content = self._snapshot["content"]
+        target = idx + 1
+        while len(content) <= target:
+            content.append({"type": "tool_use", "id": "", "name": "", "input": {}})
+        block = content[target]
+        if tc.get("id"):
+            block["id"] = tc["id"]
+        fn = tc.get("function") or {}
+        if fn.get("name"):
+            block["name"] = fn["name"]
+        args_str = fn.get("arguments", "")
+        if args_str:
+            try:
+                block["input"] = json.loads(args_str)
+            except (json.JSONDecodeError, ValueError):
+                # Arguments are still streaming; leave the previously parsed
+                # input (or {}) until a complete JSON arrives.
+                pass
+
+    def _merge_chat_completion_usage(self, usage: dict) -> None:
+        """Merge an OpenAI-shape usage dict into the snapshot, exposing both
+        prompt/completion and input/output token names for downstream code."""
+        merged = dict(usage)
+        if "prompt_tokens" in usage and "input_tokens" not in usage:
+            merged["input_tokens"] = usage["prompt_tokens"]
+        if "completion_tokens" in usage and "output_tokens" not in usage:
+            merged["output_tokens"] = usage["completion_tokens"]
+        self._snapshot["usage"] = merged
 
     def reconstruct(self) -> dict | None:
         if self._snapshot is None:

--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -2555,9 +2555,12 @@ function getTaskFingerprint(e) {
   const lower = sysText.toLowerCase();
   let label = '';
   if (!sysText && !tools.length) label = 'simple';
+  // Self-identification phrases ("You are X") win over generic substring matches,
+  // since other agents may mention "Claude Code" inside their own prompt body.
+  else if (lower.includes('you are opencode')) label = 'OpenCode';
+  else if (lower.includes('you are codex')) label = 'Codex';
   else if (lower.includes('claude code')) label = 'Claude Code';
   else if (lower.includes('claude agent')) label = 'Claude Agent';
-  else if (lower.includes('you are codex')) label = 'Codex';
   else if (lower.includes('openclaw')) label = 'OpenClaw';
   else if (lower.includes('subagent') || lower.includes('sub-agent')) label = 'Subagent';
   else if (lower.includes('bash')) label = 'Bash';

--- a/claude_tap/viewer.py
+++ b/claude_tap/viewer.py
@@ -294,6 +294,14 @@ def _generate_html_viewer(trace_path: Path, html_path: Path) -> None:
                 if line:
                     records.append(_normalize_record_for_viewer(line))
 
+    # Escape </ sequences so embedded record JSON cannot prematurely close the
+    # surrounding <script> / <script type="text/plain"> blocks. Forward-proxy
+    # mode can capture arbitrary HTTPS upstreams whose bodies legitimately
+    # contain </script>; without this, the browser closes the data block early
+    # and renders the captured HTML as page content. JSON's \/ is a valid
+    # escape for /, so the parsed JSON value is unchanged.
+    records = [rec.replace("</", "<\\/") for rec in records]
+
     jsonl_path_js = json.dumps(str(trace_path.absolute()))
     html_path_js = json.dumps(str(html_path.absolute()))
     version_js = json.dumps(CLAUDE_TAP_VERSION)
@@ -310,9 +318,7 @@ def _generate_html_viewer(trace_path: Path, html_path: Path) -> None:
 
         meta_js = json.dumps(meta_list, separators=(",", ":"))
 
-        # Escape </ sequences in raw JSONL to prevent premature </script> close.
-        # In JSON, \/ is a valid escape for /, so replacing </ with <\/ is safe.
-        raw_lines = "\n".join(rec.replace("</", "<\\/") for rec in records)
+        raw_lines = "\n".join(records)
 
         data_js = (
             f"const EMBEDDED_TRACE_META = {meta_js};\n"

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,6 +1,6 @@
 ---
 owner: claude-tap-maintainers
-last_reviewed: 2026-03-10
+last_reviewed: 2026-05-01
 source_of_truth: AGENTS.md
 ---
 
@@ -18,6 +18,21 @@ This document tracks all verified (client × auth × target × transport) combin
 | Codex CLI | API Key (`OPENAI_API_KEY`) | `https://api.openai.com` | none | WebSocket | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | HTTP/SSE | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | WebSocket | Verified |
+| OpenCode | Provider creds via `opencode providers` | Forward proxy (any HTTPS upstream) | n/a | HTTP/SSE | Unit-tested |
+| OpenCode | Anthropic provider only (`--tap-proxy-mode reverse`) | `https://api.anthropic.com` | none | HTTP/SSE | Unit-tested |
+
+## Default Proxy Mode by Client
+
+Each client in `CLIENT_CONFIGS` declares a `default_proxy_mode` used when
+`--tap-proxy-mode` is omitted:
+
+| Client | Default mode | Reason |
+|--------|--------------|--------|
+| `claude` | `reverse` | Single provider, native `ANTHROPIC_BASE_URL` env var |
+| `codex` | `reverse` | Single provider, native `OPENAI_BASE_URL` env var |
+| `opencode` | `forward` | Multi-provider; forward proxy captures every upstream regardless of which env var the client honors |
+
+Users can always override with `--tap-proxy-mode {reverse,forward}`.
 
 ## URL Construction Rules
 

--- a/tests/test_chat_completions_sse.py
+++ b/tests/test_chat_completions_sse.py
@@ -85,6 +85,86 @@ def test_chat_completions_tool_call_accumulation() -> None:
     assert msg["tool_calls"][0]["function"]["arguments"] == '{"city":"SF"}'
     assert snap["choices"][0]["finish_reason"] == "tool_calls"
 
+    # Tool call must also be mirrored into Anthropic-shape `content` so the
+    # viewer (which only reads body.content) can render the tool call.
+    tool_use_blocks = [b for b in snap["content"] if b.get("type") == "tool_use"]
+    assert len(tool_use_blocks) == 1
+    assert tool_use_blocks[0]["id"] == "call_1"
+    assert tool_use_blocks[0]["name"] == "get_weather"
+    assert tool_use_blocks[0]["input"] == {"city": "SF"}
+
+
+def test_chat_completions_tool_only_response_renders_via_content() -> None:
+    """Pure tool-call responses (no text) must still surface the tool call
+    through `content`, otherwise the viewer's Response section is blank and
+    the sidebar's response_tool_names extractor sees nothing."""
+    r = SSEReassembler()
+    r.feed_bytes(
+        b'data: {"id":"c2","choices":[{"delta":{"role":"assistant","tool_calls":'
+        b'[{"index":0,"id":"call_a","type":"function","function":'
+        b'{"name":"search","arguments":"{\\"q\\":\\"go\\"}"}}]}}]}\n\n'
+        b'data: {"id":"c2","choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    snap = r.reconstruct()
+    assert snap is not None
+    # Text mirror is empty (no delta.content was sent).
+    text_blocks = [b for b in snap["content"] if b.get("type") == "text"]
+    assert text_blocks and text_blocks[0]["text"] == ""
+    # tool_use block carries the call so viewer/export can render it.
+    tool_use = [b for b in snap["content"] if b.get("type") == "tool_use"]
+    assert len(tool_use) == 1
+    assert tool_use[0]["name"] == "search"
+    assert tool_use[0]["input"] == {"q": "go"}
+
+
+def test_chat_completions_parallel_tool_calls_each_mirror() -> None:
+    """When a single delta carries multiple tool_calls (parallel calls),
+    every entry must end up as its own tool_use block in `content`."""
+    r = SSEReassembler()
+    r.feed_bytes(
+        b'data: {"id":"c3","choices":[{"delta":{"role":"assistant","tool_calls":['
+        b'{"index":0,"id":"a","type":"function","function":{"name":"f1","arguments":"{}"}},'
+        b'{"index":1,"id":"b","type":"function","function":{"name":"f2","arguments":"{}"}}'
+        b"]}}]}\n\n"
+        b'data: {"id":"c3","choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    snap = r.reconstruct()
+    assert snap is not None
+    tool_use = [b for b in snap["content"] if b.get("type") == "tool_use"]
+    names = [b["name"] for b in tool_use]
+    assert names == ["f1", "f2"]
+    ids = [b["id"] for b in tool_use]
+    assert ids == ["a", "b"]
+
+
+def test_chat_completions_usage_only_final_chunk_is_captured() -> None:
+    """Some providers send a final chunk with empty `choices` and only
+    `usage` populated; that token info must still land in the snapshot."""
+    r = SSEReassembler()
+    r.feed_bytes(
+        b'data: {"id":"c4","model":"hy3","choices":[{"delta":{"role":"assistant","content":"hi"}}]}\n\n'
+        b'data: {"id":"c4","choices":[{"delta":{},"finish_reason":"stop"}]}\n\n'
+        b'data: {"id":"c4","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":2,"total_tokens":12}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    snap = r.reconstruct()
+    assert snap is not None
+    assert snap["usage"]["prompt_tokens"] == 10
+    assert snap["usage"]["completion_tokens"] == 2
+    # Dual naming applied so Anthropic-oriented stat code keeps working.
+    assert snap["usage"]["input_tokens"] == 10
+    assert snap["usage"]["output_tokens"] == 2
+
+
+def test_chat_completions_usage_only_chunk_without_prior_snapshot_is_skipped() -> None:
+    """Edge case: if a usage-only chunk arrives before any choices have set
+    up the snapshot, it is dropped (no body context to attach to)."""
+    r = SSEReassembler()
+    r.feed_bytes(b'data: {"choices":[],"usage":{"prompt_tokens":1}}\n\n')
+    assert r.reconstruct() is None
+
 
 def test_chat_completions_done_sentinel_is_filtered() -> None:
     r = SSEReassembler()

--- a/tests/test_chat_completions_sse.py
+++ b/tests/test_chat_completions_sse.py
@@ -1,0 +1,135 @@
+"""Regression: SSEReassembler must capture OpenAI Chat Completions streams.
+
+opencode in forward-proxy mode talks to providers that expose the OpenAI
+Chat Completions API (e.g. opencode.ai's `/zen/v1/chat/completions`). Those
+streams use bare `data: {...}` frames with no `event:` headers, terminated
+by `data: [DONE]`. The pre-fix reassembler required an explicit `event:`
+line and silently dropped every Chat Completions response — opencode traces
+showed `resp.body=None` and `sse_events=[]` for any non-Anthropic provider.
+"""
+
+from __future__ import annotations
+
+from claude_tap.sse import SSEReassembler
+
+
+def test_chat_completions_stream_events_are_captured() -> None:
+    r = SSEReassembler()
+    r.feed_bytes(
+        b'data: {"id":"c1","choices":[{"delta":{"role":"assistant"}}]}\n\n'
+        b'data: {"id":"c1","choices":[{"delta":{"content":"OK"}}]}\n\n'
+        b'data: {"id":"c1","choices":[{"finish_reason":"stop","delta":{}}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+
+    # All three real frames captured; [DONE] is filtered as protocol noise.
+    assert len(r.events) == 3
+    for ev in r.events:
+        assert ev["event"] == "message"
+    assert r.events[0]["data"]["choices"][0]["delta"] == {"role": "assistant"}
+    assert r.events[1]["data"]["choices"][0]["delta"] == {"content": "OK"}
+    assert r.events[2]["data"]["choices"][0]["finish_reason"] == "stop"
+
+    # Snapshot is reconstructed so the viewer's Response section can render.
+    snap = r.reconstruct()
+    assert snap is not None
+    # True OpenAI Chat Completions shape preserved for fidelity.
+    assert snap["choices"][0]["message"]["role"] == "assistant"
+    assert snap["choices"][0]["message"]["content"] == "OK"
+    assert snap["choices"][0]["finish_reason"] == "stop"
+    # Anthropic-shape mirror so the existing renderer picks it up unchanged.
+    assert snap["content"] == [{"type": "text", "text": "OK"}]
+
+
+def test_chat_completions_usage_dual_naming() -> None:
+    """Final chunk's `usage` must be exposed under both Anthropic and OpenAI
+    keys so token displays that only know one schema still work."""
+    r = SSEReassembler()
+    r.feed_bytes(
+        b'data: {"id":"c1","model":"hy3","choices":[{"delta":{"role":"assistant","content":"hi"}}]}\n\n'
+        b'data: {"id":"c1","choices":[{"delta":{},"finish_reason":"stop"}],'
+        b'"usage":{"prompt_tokens":12,"completion_tokens":3,"total_tokens":15}}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    snap = r.reconstruct()
+    assert snap is not None
+    usage = snap["usage"]
+    # OpenAI naming preserved
+    assert usage["prompt_tokens"] == 12
+    assert usage["completion_tokens"] == 3
+    # Anthropic-aliased copies added so existing stat extractors pick them up
+    assert usage["input_tokens"] == 12
+    assert usage["output_tokens"] == 3
+    assert snap["model"] == "hy3"
+
+
+def test_chat_completions_tool_call_accumulation() -> None:
+    """Tool calls stream as indexed deltas with name/arguments concatenated
+    across multiple chunks. Final snapshot must have the assembled call."""
+    r = SSEReassembler()
+    r.feed_bytes(
+        b'data: {"id":"c1","choices":[{"delta":{"role":"assistant","tool_calls":'
+        b'[{"index":0,"id":"call_1","type":"function","function":{"name":"get_weather","arguments":""}}]}}]}\n\n'
+        b'data: {"id":"c1","choices":[{"delta":{"tool_calls":'
+        b'[{"index":0,"function":{"arguments":"{\\"city\\":"}}]}}]}\n\n'
+        b'data: {"id":"c1","choices":[{"delta":{"tool_calls":'
+        b'[{"index":0,"function":{"arguments":"\\"SF\\"}"}}]}}]}\n\n'
+        b'data: {"id":"c1","choices":[{"delta":{},"finish_reason":"tool_calls"}]}\n\n'
+        b"data: [DONE]\n\n"
+    )
+    snap = r.reconstruct()
+    assert snap is not None
+    msg = snap["choices"][0]["message"]
+    assert msg["tool_calls"][0]["id"] == "call_1"
+    assert msg["tool_calls"][0]["function"]["name"] == "get_weather"
+    assert msg["tool_calls"][0]["function"]["arguments"] == '{"city":"SF"}'
+    assert snap["choices"][0]["finish_reason"] == "tool_calls"
+
+
+def test_chat_completions_done_sentinel_is_filtered() -> None:
+    r = SSEReassembler()
+    r.feed_bytes(b"data: [DONE]\n\n")
+    assert r.events == []
+
+
+def test_chat_completions_chunked_across_feeds() -> None:
+    """Bytes split mid-frame must still produce one coherent event."""
+    r = SSEReassembler()
+    r.feed_bytes(b'data: {"id":"c1","choices":[{"de')
+    r.feed_bytes(b'lta":{"content":"hel')
+    r.feed_bytes(b'lo"}}]}\n\n')
+    assert len(r.events) == 1
+    assert r.events[0]["data"]["choices"][0]["delta"]["content"] == "hello"
+
+
+def test_anthropic_stream_unchanged() -> None:
+    """The Chat Completions support must not regress Anthropic snapshot
+    reconstruction — it's the path claude/codex rely on."""
+    r = SSEReassembler()
+    r.feed_bytes(
+        b"event: message_start\n"
+        b'data: {"type":"message_start","message":{"id":"m1","role":"assistant",'
+        b'"content":[],"model":"claude-x","usage":{"input_tokens":3,"output_tokens":0}}}\n\n'
+        b"event: content_block_start\n"
+        b'data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n'
+        b"event: content_block_delta\n"
+        b'data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hi"}}\n\n'
+        b"event: content_block_stop\n"
+        b'data: {"type":"content_block_stop","index":0}\n\n'
+        b"event: message_delta\n"
+        b'data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":1}}\n\n'
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n'
+    )
+    snap = r.reconstruct()
+    assert snap is not None
+    assert snap["content"][0]["text"] == "hi"
+    assert snap["usage"]["output_tokens"] == 1
+
+
+def test_mixed_event_and_bare_data_in_one_stream() -> None:
+    """Defensive: a stream that mixes both shapes shouldn't crash. The bare
+    frames emit as default-type events; the named ones use their declared name."""
+    r = SSEReassembler()
+    r.feed_bytes(b'data: {"bare":1}\n\nevent: ping\ndata: {"named":2}\n\ndata: {"bare":3}\n\n')
+    assert [e["event"] for e in r.events] == ["message", "ping", "message"]
+    assert [e["data"] for e in r.events] == [{"bare": 1}, {"named": 2}, {"bare": 3}]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1450,12 +1450,20 @@ def test_sse_reassembler():
     assert len(r.events) == 6
     print("  OK: basic SSE parsing")
 
-    # Orphan data line (no event: prefix) — should be ignored
+    # Bare data line (no event: prefix) — must be emitted as a default-type
+    # event so OpenAI Chat Completions streams (which never send event: headers)
+    # don't get silently dropped.
     r2 = SSEReassembler()
     r2.feed_bytes(b'data: {"orphan": true}\n\n')
-    assert len(r2.events) == 0
+    # Bare data lines (no event: prefix) are emitted as default-type events.
+    # OpenAI Chat Completions streams use exactly this shape — the previous
+    # "ignored" behavior silently dropped every such response body.
+    assert len(r2.events) == 1
+    assert r2.events[0]["event"] == "message"
+    assert r2.events[0]["data"] == {"orphan": True}
+    # Snapshot reconstruction stays a no-op for non-Anthropic/Responses schemas.
     assert r2.reconstruct() is None
-    print("  OK: orphan data ignored")
+    print("  OK: bare data emitted as default-type event")
 
     # Partial chunks (data split across feed_bytes calls)
     r3 = SSEReassembler()

--- a/tests/test_opencode_launch.py
+++ b/tests/test_opencode_launch.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from claude_tap import parse_args
+from claude_tap.cli import CLIENT_CONFIGS, run_client
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.pid = 12345
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def test_opencode_registered_in_client_configs() -> None:
+    cfg = CLIENT_CONFIGS["opencode"]
+    assert cfg.cmd == "opencode"
+    assert cfg.default_target == "https://api.anthropic.com"
+    assert cfg.base_url_env == "ANTHROPIC_BASE_URL"
+    # opencode is multi-provider; forward proxy is the natural default
+    assert cfg.default_proxy_mode == "forward"
+
+
+def test_parse_args_opencode_defaults_to_forward_mode() -> None:
+    args = parse_args(["--tap-client", "opencode"])
+    assert args.client == "opencode"
+    assert args.proxy_mode == "forward"
+
+
+def test_parse_args_opencode_explicit_reverse_overrides_default() -> None:
+    args = parse_args(["--tap-client", "opencode", "--tap-proxy-mode", "reverse"])
+    assert args.proxy_mode == "reverse"
+
+
+def test_parse_args_claude_default_proxy_mode_unchanged() -> None:
+    # Regression: changing the default-mode plumbing must not affect claude
+    args = parse_args([])
+    assert args.client == "claude"
+    assert args.proxy_mode == "reverse"
+
+
+def test_parse_args_codex_default_proxy_mode_unchanged() -> None:
+    # Regression: changing the default-mode plumbing must not affect codex
+    args = parse_args(["--tap-client", "codex"])
+    assert args.client == "codex"
+    assert args.proxy_mode == "reverse"
+
+
+@pytest.mark.asyncio
+async def test_run_client_opencode_forward_sets_node_ca_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    ca_path = Path("/tmp/test-ca.pem")
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/opencode")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["run", "hello"], client="opencode", proxy_mode="forward", ca_cert_path=ca_path)
+
+    assert code == 0
+    env = captured["env"]
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:43123"
+    assert env["NODE_EXTRA_CA_CERTS"] == str(ca_path)
+    assert env["SSL_CERT_FILE"] == str(ca_path)
+
+
+@pytest.mark.asyncio
+async def test_run_client_opencode_reverse_sets_anthropic_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/opencode")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["run", "hello"], client="opencode", proxy_mode="reverse")
+
+    assert code == 0
+    assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:43123"
+    # Reverse mode for opencode must not inject a codex-only -c flag
+    assert captured["cmd"] == ("/tmp/opencode", "run", "hello")

--- a/tests/test_opencode_viewer.py
+++ b/tests/test_opencode_viewer.py
@@ -1,0 +1,69 @@
+"""Viewer regression test: opencode traces must not be mislabelled as Claude Code.
+
+opencode's system prompt begins with "You are opencode, ..." but may also
+mention "Claude Code" later (e.g. in agent-builder examples). The sidebar
+fingerprint heuristic must prefer the explicit self-identification.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pw_missing = False
+try:
+    from playwright.sync_api import sync_playwright  # noqa: F401
+except ImportError:
+    pw_missing = True
+
+
+@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+def test_opencode_prompt_is_labelled_opencode_not_claude_code(tmp_path) -> None:
+    from playwright.sync_api import sync_playwright
+
+    from claude_tap.viewer import _generate_html_viewer
+
+    # Mirror the real opencode system prompt shape: opens with the
+    # "You are opencode" self-id, then mentions "Claude Code" deep inside
+    # an example list. The pre-fix heuristic stopped at the first match
+    # and labelled the trace "Claude Code".
+    system_prompt = (
+        "You are opencode, an interactive CLI tool that helps users with "
+        "software engineering tasks.\n"
+        "Use the instructions below and the tools available to you to assist the user.\n"
+        + ("filler ... " * 200)
+        + "\n(4) ask about Claude Code, Cursor, or similar agent internals\n"
+        + ("filler ... " * 200)
+    )
+
+    trace_path = tmp_path / "trace.jsonl"
+    record = {
+        "timestamp": "2026-05-01T23:46:43+00:00",
+        "request_id": "req_1",
+        "turn": 1,
+        "duration_ms": 100,
+        "request": {
+            "method": "POST",
+            "path": "/anthropic/v1/messages",
+            "headers": {},
+            "body": {
+                "system": system_prompt,
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "ping"}]}],
+            },
+        },
+        "response": {"status": 200, "headers": {}, "body": {"content": [], "usage": {}}},
+    }
+    trace_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    html_path = tmp_path / "trace.html"
+    _generate_html_viewer(trace_path, html_path)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(html_path.resolve().as_uri(), wait_until="networkidle")
+        label = page.locator(".sidebar-item .si-task").first.inner_text()
+        browser.close()
+
+    assert label == "OpenCode", f"opencode trace mislabelled as {label!r}"

--- a/tests/test_viewer_non_dict_body.py
+++ b/tests/test_viewer_non_dict_body.py
@@ -1,0 +1,173 @@
+"""Regression: viewer must tolerate non-dict request/response bodies.
+
+opencode in forward-proxy mode (the new default in this PR) captures every
+HTTPS upstream the client talks to — not just LLM endpoints. First-run
+bootstraps proxy npm registry traffic (security advisory POSTs, .tgz
+downloads, HTML error pages) whose `request.body` / `response.body` end up
+as strings instead of JSON objects. The pre-fix viewer extractor assumed
+dict and crashed with `AttributeError: 'str' object has no attribute 'get'`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_tap.viewer import LAZY_THRESHOLD, _extract_metadata, _generate_html_viewer
+
+
+def _record(req_body, resp_body, *, request_id: str = "req_1", turn: int = 1) -> dict:
+    return {
+        "timestamp": "2026-05-04T03:00:00+00:00",
+        "request_id": request_id,
+        "turn": turn,
+        "duration_ms": 50,
+        "request": {
+            "method": "POST",
+            "path": "/-/npm/v1/security/advisories/bulk",
+            "headers": {},
+            "body": req_body,
+        },
+        "response": {
+            "status": 200,
+            "headers": {},
+            "body": resp_body,
+        },
+    }
+
+
+def test_extract_metadata_handles_string_request_body() -> None:
+    rec = _record("raw-string-payload-not-json", {"usage": {"input_tokens": 0}})
+    meta = _extract_metadata(json.dumps(rec))
+    assert meta is not None
+    assert meta["request_id"] == "req_1"
+    # Non-dict body should degrade gracefully — no model, no system hint.
+    assert meta["model"] == ""
+    assert meta["has_system"] is False
+    assert meta["message_count"] == 0
+    assert meta["tool_names"] == []
+
+
+def test_extract_metadata_handles_string_response_body() -> None:
+    rec = _record({"model": "claude-x", "messages": []}, "<!doctype html>...")
+    meta = _extract_metadata(json.dumps(rec))
+    assert meta is not None
+    assert meta["model"] == "claude-x"
+    # Non-dict response body must not block extraction of request-side fields.
+    assert meta["input_tokens"] == 0
+    assert meta["output_tokens"] == 0
+    assert meta["response_tool_names"] == []
+    assert meta["error_message"] == ""
+
+
+def test_extract_metadata_handles_both_bodies_as_strings() -> None:
+    rec = _record("npm-tgz-binary-blob", "gateway timeout html")
+    meta = _extract_metadata(json.dumps(rec))
+    assert meta is not None
+    assert meta["status"] == 200
+    assert meta["path"] == "/-/npm/v1/security/advisories/bulk"
+
+
+def test_generate_html_viewer_does_not_crash_on_mixed_bodies(tmp_path: Path) -> None:
+    """End-to-end: lazy path (>LAZY_THRESHOLD records) calls _extract_metadata
+    on every line. A single string-body record must not abort generation."""
+    trace_path = tmp_path / "trace.jsonl"
+    lines: list[str] = []
+    # Fill above the lazy threshold so _extract_metadata is exercised.
+    for i in range(LAZY_THRESHOLD + 5):
+        if i % 7 == 0:
+            # Non-LLM npm/tgz traffic — string bodies.
+            rec = _record("opaque-binary", "<html></html>", request_id=f"req_{i}", turn=i)
+        else:
+            rec = _record(
+                {"model": "claude-x", "messages": [{"role": "user", "content": "hi"}]},
+                {"usage": {"input_tokens": 1, "output_tokens": 1}, "content": []},
+                request_id=f"req_{i}",
+                turn=i,
+            )
+        lines.append(json.dumps(rec))
+    trace_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    html_path = tmp_path / "trace.html"
+    _generate_html_viewer(trace_path, html_path)
+
+    assert html_path.exists()
+    assert html_path.stat().st_size > 0
+
+
+def _opencode_homepage_payload() -> str:
+    """A minimal stand-in for the kind of HTML body the forward proxy captures
+    when opencode hits a non-LLM upstream (e.g. opencode.ai homepage). The two
+    pieces that matter are the </script> close-tag and a nested <script>."""
+    return (
+        '<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">'
+        "<style>body{margin:0}</style>"
+        "<script>window.__OC=1;</script>"
+        "</head><body><h1>The open source AI coding agent</h1>"
+        "<script>console.log('boot')</script></body></html>"
+    )
+
+
+def test_html_viewer_inline_path_escapes_script_close_in_string_body(tmp_path: Path) -> None:
+    """Regression: small traces (<= LAZY_THRESHOLD) inline records as a JS
+    array literal inside <script>...</script>. If a captured response.body is
+    a string containing </script> (e.g. opencode.ai homepage HTML), the
+    surrounding script tag would close prematurely and the HTML would render
+    as page content. The inline path must escape </ -> <\\/ before embedding.
+    """
+    trace_path = tmp_path / "trace.jsonl"
+    rec = _record(None, _opencode_homepage_payload(), request_id="req_oc_home", turn=5)
+    trace_path.write_text(json.dumps(rec) + "\n", encoding="utf-8")
+
+    html_path = tmp_path / "trace.html"
+    _generate_html_viewer(trace_path, html_path)
+    html = html_path.read_text(encoding="utf-8")
+
+    # Locate the inlined data block.
+    anchor = "const EMBEDDED_TRACE_DATA = ["
+    start = html.find(anchor)
+    assert start >= 0, "EMBEDDED_TRACE_DATA block not found in inline path"
+    # Find where the JS data block is meant to end. It is followed by the
+    # surrounding `</script>` that closes the data <script> block. Between
+    # `start` and that close there must be NO unescaped </script>.
+    data_close = html.find("</script>", start)
+    assert data_close >= 0
+    data_block = html[start:data_close]
+    assert "</script>" not in data_block, (
+        "captured </script> leaked into the inline data block — would close "
+        "the wrapping <script> tag and render captured HTML as page content"
+    )
+    # And the escaped form must be present (proves the body did make it in).
+    assert "<\\/script>" in data_block
+
+
+def test_html_viewer_lazy_path_still_escapes_script_close(tmp_path: Path) -> None:
+    """Regression: lazy path (> LAZY_THRESHOLD) embeds records in a
+    <script type="text/plain" id="trace-raw"> block. Same </script> hazard."""
+    trace_path = tmp_path / "trace.jsonl"
+    lines: list[str] = []
+    for i in range(LAZY_THRESHOLD + 5):
+        if i == 3:
+            rec = _record(None, _opencode_homepage_payload(), request_id=f"req_{i}", turn=i)
+        else:
+            rec = _record(
+                {"model": "claude-x", "messages": []},
+                {"usage": {}, "content": []},
+                request_id=f"req_{i}",
+                turn=i,
+            )
+        lines.append(json.dumps(rec))
+    trace_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    html_path = tmp_path / "trace.html"
+    _generate_html_viewer(trace_path, html_path)
+    html = html_path.read_text(encoding="utf-8")
+
+    anchor = '<script type="text/plain" id="trace-raw">'
+    start = html.find(anchor)
+    assert start >= 0, "trace-raw block not found in lazy path"
+    block_close = html.find("</script>", start)
+    assert block_close >= 0
+    raw_block = html[start + len(anchor) : block_close]
+    assert "</script>" not in raw_block
+    assert "<\\/script>" in raw_block

--- a/tests/test_viewer_non_dict_body.py
+++ b/tests/test_viewer_non_dict_body.py
@@ -141,6 +141,36 @@ def test_html_viewer_inline_path_escapes_script_close_in_string_body(tmp_path: P
     assert "<\\/script>" in data_block
 
 
+def test_extract_metadata_recognizes_openai_function_tool_shape() -> None:
+    """opencode (Chat Completions) sends tools wrapped as
+    {type:"function", function:{name,description,parameters}}. The sidebar
+    metadata extractor must read names from `function.name`, not just `name`."""
+    rec = {
+        "request_id": "req_oc",
+        "turn": 1,
+        "timestamp": "2026-05-04T16:00:00+00:00",
+        "duration_ms": 100,
+        "request": {
+            "method": "POST",
+            "path": "/zen/v1/chat/completions",
+            "body": {
+                "model": "hy3-preview-free",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": [
+                    {"type": "function", "function": {"name": "question", "description": "ask"}},
+                    {"type": "function", "function": {"name": "bash", "description": "run"}},
+                    # Defensive: a flat-Anthropic-shape tool mixed in must still resolve.
+                    {"name": "edit", "description": "edit"},
+                ],
+            },
+        },
+        "response": {"status": 200, "body": {"usage": {}, "content": []}},
+    }
+    meta = _extract_metadata(json.dumps(rec))
+    assert meta is not None
+    assert meta["tool_names"] == ["question", "bash", "edit"]
+
+
 def test_html_viewer_lazy_path_still_escapes_script_close(tmp_path: Path) -> None:
     """Regression: lazy path (> LAZY_THRESHOLD) embeds records in a
     <script type="text/plain" id="trace-raw"> block. Same </script> hazard."""


### PR DESCRIPTION
## Summary
- Add `opencode` to `--tap-client` choices, defaulting to forward proxy mode
- Introduce `default_proxy_mode` field on `ClientConfig` so multi-provider clients can opt into forward MITM by default while claude/codex remain on reverse
- Fix viewer task label so opencode traces are not mislabelled as "Claude Code" when their prompt happens to mention it

## Background
- Current limitation: only single-provider clients (claude, codex) were first-class; opencode talks to multiple providers in one session, which a single base-url env var can't capture.
- Why now: forward proxy already supports arbitrary HTTPS upstreams via TLS MITM; surfacing it as the default for opencode is the smallest correct change.

## Scope
- Areas touched: `claude_tap/cli.py`, `claude_tap/viewer.html`, `docs/support-matrix.md`, two new test files.
- Explicitly not changed: WebSocket / Bedrock / Codex code paths, README, token-stat extraction (still Anthropic-schema only).

## Validation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ --ignore=tests/e2e` — 161 passed, 18 skipped (real-e2e gated)
- [x] Manual smoke: ran `uv run python -m claude_tap --tap-client opencode` against opencode 1.14.31 hitting `api.minimaxi.com/anthropic/v1/messages`; trace captured the multi-provider traffic end-to-end.
- [x] Functional, smoke, or E2E verification listed below
- [ ] UI changes include `raw.githubusercontent.com` screenshot URLs when applicable — viewer change is a label heuristic only; covered by Playwright regression test
- [x] Any screenshots, recordings, or demos use real `.traces/` data — yes, the heuristic regression was triggered by a real opencode trace
- [ ] If any gate or evidence is skipped, explain why and get reviewer approval before merge

## Results
- `claude-tap --tap-client opencode` now starts forward MITM, captures every provider opencode talks to, and labels the trace correctly in the viewer
- claude / codex defaults are unchanged (regression-tested)

## Evidence
- Screenshots / recordings / trace files: real opencode trace under `.traces/2026-05-01/trace_234643.*` exposed the viewer mislabel; new `tests/test_opencode_viewer.py` reproduces it with a synthetic prompt that mirrors the real shape.

## Follow-up
- Token statistics in `TraceWriter._update_stats` still assume Anthropic schema; OpenAI-style `usage.prompt_tokens` / `completion_tokens` are not summed. Trace bodies remain intact; only the end-of-run stats line is affected. Worth a separate small PR.
- Live viewer empty-state copy ("Start using Claude Code...") is hardcoded; could be made client-aware later.

## Risk / Rollback
- Main risk: `--tap-proxy-mode` default changed from `"reverse"` to `None` and is resolved per-client. claude / codex regression is locked in by `test_parse_args_claude_default_proxy_mode_unchanged` and `test_parse_args_codex_default_proxy_mode_unchanged`.
- Rollback: revert the two commits; no schema or on-disk format changes.