### PR TITLE
feat(cli): add openclaw client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,18 @@ claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex
 
 OpenClaw is a multi-provider Node CLI agent. Because its built-in providers don't honor `*_BASE_URL` env vars, claude-tap defaults to **forward proxy** mode — it injects `HTTPS_PROXY` plus the local CA into the child process so any provider (Anthropic, OpenAI, custom) is captured.
 
+OpenClaw is daemon-architected: a long-running gateway holds credentials and makes LLM calls. So depending on what you want to do, two patterns:
+
 ```bash
-# Default: forward proxy captures every upstream OpenClaw talks to
-claude-tap --tap-client openclaw -- run "hello"
+# A) One-shot — agent --local runs an embedded turn in the same process. Simplest.
+claude-tap --tap-client openclaw -- agent --local --agent main --message "hi"
+
+# B) Chat mode — gateway must run in foreground under tap. claude-tap auto-rewrites
+#    `gateway start` (which on 2026.4+ delegates to launchd/systemd) to `gateway run`
+#    (foreground), so the spawned gateway is our child and inherits the proxy env.
+claude-tap --tap-client openclaw -- gateway start
+# in another terminal — connect the TUI to the foregrounded gateway
+openclaw tui
 
 # Reverse mode is opt-in and only useful with a custom anthropic-messages provider
 # wired up in ~/.openclaw/openclaw.json that reads ANTHROPIC_BASE_URL

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [中文文档](README_zh.md)
 
-Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
+Intercept and inspect all API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), or [OpenClaw](https://github.com/openclaw/openclaw). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
 
 ![Demo](docs/demo.gif)
 
@@ -82,6 +82,19 @@ claude-tap --tap-client codex -- --full-auto
 
 # OAuth + full auto + live viewer
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-live -- --full-auto
+```
+
+### OpenClaw
+
+OpenClaw is a multi-provider Node CLI agent. Because its built-in providers don't honor `*_BASE_URL` env vars, claude-tap defaults to **forward proxy** mode — it injects `HTTPS_PROXY` plus the local CA into the child process so any provider (Anthropic, OpenAI, custom) is captured.
+
+```bash
+# Default: forward proxy captures every upstream OpenClaw talks to
+claude-tap --tap-client openclaw -- run "hello"
+
+# Reverse mode is opt-in and only useful with a custom anthropic-messages provider
+# wired up in ~/.openclaw/openclaw.json that reads ANTHROPIC_BASE_URL
+claude-tap --tap-client openclaw --tap-proxy-mode reverse
 ```
 
 ### Browser Preview

--- a/README_zh.md
+++ b/README_zh.md
@@ -7,7 +7,7 @@
 
 [English](README.md)
 
-拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 或 [Codex CLI](https://github.com/openai/codex) 的所有 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、优化 token 用量——通过一个美观的 trace 查看器。
+拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex) 或 [OpenClaw](https://github.com/openclaw/openclaw) 的所有 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、优化 token 用量——通过一个美观的 trace 查看器。
 
 ![演示](docs/demo_zh.gif)
 
@@ -82,6 +82,19 @@ claude-tap --tap-client codex -- --full-auto
 
 # OAuth + 全自动 + 实时查看器
 claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex --tap-live -- --full-auto
+```
+
+### OpenClaw
+
+OpenClaw 是基于 Node 的多 provider CLI agent。由于它内置的 provider 不读取 `*_BASE_URL` 环境变量，claude-tap 默认使用 **forward proxy** 模式——通过向子进程注入 `HTTPS_PROXY` 与本地 CA，捕获它对接的任意 provider（Anthropic / OpenAI / 自定义）流量。
+
+```bash
+# 默认：forward proxy 捕获 OpenClaw 对接的所有上游
+claude-tap --tap-client openclaw -- run "hello"
+
+# 反向模式仅在 ~/.openclaw/openclaw.json 自定义了
+# 读取 ANTHROPIC_BASE_URL 的 anthropic-messages provider 时才有意义
+claude-tap --tap-client openclaw --tap-proxy-mode reverse
 ```
 
 ### 浏览器预览

--- a/README_zh.md
+++ b/README_zh.md
@@ -88,9 +88,18 @@ claude-tap --tap-client codex --tap-target https://chatgpt.com/backend-api/codex
 
 OpenClaw 是基于 Node 的多 provider CLI agent。由于它内置的 provider 不读取 `*_BASE_URL` 环境变量，claude-tap 默认使用 **forward proxy** 模式——通过向子进程注入 `HTTPS_PROXY` 与本地 CA，捕获它对接的任意 provider（Anthropic / OpenAI / 自定义）流量。
 
+OpenClaw 是 daemon 架构——常驻的 gateway 进程持有凭据并发起 LLM 调用。按用途分两种姿势：
+
 ```bash
-# 默认：forward proxy 捕获 OpenClaw 对接的所有上游
-claude-tap --tap-client openclaw -- run "hello"
+# A) 单次调用 —— agent --local 把 agent 嵌进当前进程跑一轮，最简
+claude-tap --tap-client openclaw -- agent --local --agent main --message "hi"
+
+# B) Chat 模式 —— gateway 必须前台跑在 tap 下。claude-tap 会自动把
+#    `gateway start`（2026.4+ 会委托给 launchd/systemd）改写为 `gateway run`
+#    （前台版），这样新起的 gateway 是我们的子进程，能继承代理环境
+claude-tap --tap-client openclaw -- gateway start
+# 另一个终端 —— 用 TUI 连前台的 gateway
+openclaw tui
 
 # 反向模式仅在 ~/.openclaw/openclaw.json 自定义了
 # 读取 ANTHROPIC_BASE_URL 的 anthropic-messages provider 时才有意义

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -129,6 +129,7 @@ async def run_client(
     env = os.environ.copy()
 
     cmd_args = list(extra_args)
+    cmd_args = _maybe_rewrite_openclaw_gateway_start(client, cmd_args)
     has_openai_base_override = _has_config_override(cmd_args, "openai_base_url")
 
     if proxy_mode == "forward":
@@ -266,6 +267,26 @@ async def run_client(
 
     print(f"\n📋 {cfg.label} exited with code {code}")
     return code
+
+
+def _maybe_rewrite_openclaw_gateway_start(client: str, args: list[str]) -> list[str]:
+    """Rewrite ``openclaw gateway start`` → ``openclaw gateway run`` so the
+    gateway runs as our child process and inherits the proxy/CA env.
+
+    openclaw 2026.4+ delegates ``gateway start`` to launchd/systemd/schtasks,
+    which spawn the gateway in a fresh environment that does not inherit
+    HTTPS_PROXY or NODE_EXTRA_CA_CERTS — making trace capture impossible.
+    ``gateway run`` is the foreground equivalent and accepts the same flags.
+    """
+    if client != "openclaw" or args[:2] != ["gateway", "start"]:
+        return args
+    print(
+        "ℹ️  rewriting `openclaw gateway start` → `openclaw gateway run` so the\n"
+        "   gateway runs in foreground under claude-tap and its outbound LLM\n"
+        "   traffic is captured. The launchd/systemd-managed daemon would not\n"
+        "   inherit HTTPS_PROXY/NODE_EXTRA_CA_CERTS."
+    )
+    return ["gateway", "run"] + args[2:]
 
 
 def _has_config_override(args: list[str], key: str) -> bool:
@@ -528,7 +549,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  claude-tap --tap-client codex -- --model codex-mini-latest --full-auto\n"
             "\n"
             "openclaw (multi-provider; defaults to forward proxy):\n"
-            "  claude-tap --tap-client openclaw -- run \"hello\"\n"
+            "  # one-shot agent call (captures the LLM round-trip)\n"
+            "  claude-tap --tap-client openclaw -- agent --local --agent main --message \"hi\"\n"
+            "  # chat mode: gateway must run in foreground under tap, then connect tui from another terminal\n"
+            "  claude-tap --tap-client openclaw -- gateway start  # auto-rewritten to `gateway run`\n"
             "  # force reverse mode (only useful with a custom anthropic-messages provider)\n"
             "  claude-tap --tap-client openclaw --tap-proxy-mode reverse\n"
             "\n"

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -62,6 +62,10 @@ class ClientConfig:
     base_url_suffix: str  # appended to http://127.0.0.1:{port}
     default_target: str
     nesting_env_keys: tuple[str, ...] = ()  # env vars to clear before launch
+    # Default proxy mode when --tap-proxy-mode is not explicitly set.
+    # Multi-provider clients (e.g. openclaw) default to "forward" so that all
+    # provider traffic is captured regardless of which env var the client honors.
+    default_proxy_mode: str = "reverse"
 
     @property
     def missing_help(self) -> str:
@@ -90,6 +94,18 @@ CLIENT_CONFIGS: dict[str, ClientConfig] = {
         base_url_env="OPENAI_BASE_URL",
         base_url_suffix="/v1",
         default_target="https://api.openai.com",
+    ),
+    "openclaw": ClientConfig(
+        cmd="openclaw",
+        label="OpenClaw",
+        install_url="https://github.com/openclaw/openclaw",
+        base_url_env="ANTHROPIC_BASE_URL",
+        base_url_suffix="",
+        default_target="https://api.anthropic.com",
+        # openclaw is a Node 22.14+/24 multi-provider agent; reverse mode only
+        # works when the user manually wires a custom anthropic-messages provider
+        # in ~/.openclaw/openclaw.json, so default to forward proxy capture.
+        default_proxy_mode="forward",
     ),
 }
 
@@ -511,6 +527,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  # With model and full auto-approval\n"
             "  claude-tap --tap-client codex -- --model codex-mini-latest --full-auto\n"
             "\n"
+            "openclaw (multi-provider; defaults to forward proxy):\n"
+            "  claude-tap --tap-client openclaw -- run \"hello\"\n"
+            "  # force reverse mode (only useful with a custom anthropic-messages provider)\n"
+            "  claude-tap --tap-client openclaw --tap-proxy-mode reverse\n"
+            "\n"
             "proxy-only mode (connect from another terminal):\n"
             "  claude-tap --tap-no-launch --tap-port 8080\n"
             "  # then: ANTHROPIC_BASE_URL=http://127.0.0.1:8080 claude\n"
@@ -538,7 +559,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     proxy_group.add_argument(
         "--tap-client",
-        choices=["claude", "codex"],
+        choices=["claude", "codex", "openclaw"],
         default="claude",
         dest="client",
         help="Client to launch (default: claude)",
@@ -552,9 +573,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     proxy_group.add_argument(
         "--tap-proxy-mode",
         choices=["reverse", "forward"],
-        default="reverse",
+        default=None,
         dest="proxy_mode",
-        help="'reverse' sets provider base URL (default), 'forward' sets HTTPS_PROXY with CONNECT/TLS termination",
+        help="'reverse' sets provider base URL, 'forward' sets HTTPS_PROXY with CONNECT/TLS termination "
+        "(default: per-client; claude/codex=reverse, openclaw=forward)",
     )
     proxy_group.add_argument(
         "--tap-no-launch", action="store_true", dest="no_launch", help="Only start the proxy, don't launch client"
@@ -616,6 +638,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     # 127.0.0.1 otherwise (launching the client locally).
     if args.host is None:
         args.host = "0.0.0.0" if args.no_launch else "127.0.0.1"
+    if args.proxy_mode is None:
+        args.proxy_mode = CLIENT_CONFIGS[args.client].default_proxy_mode
     if args.target is None:
         if args.client == "codex":
             args.target = _detect_codex_target()

--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -2277,9 +2277,14 @@ function getTaskFingerprint(e) {
   const lower = sysText.toLowerCase();
   let label = '';
   if (!sysText && !tools.length) label = 'simple';
+  // Self-identification phrases win over generic substring matches: openclaw
+  // ships skills similar to Claude Code's, so its prompt may mention "Claude
+  // Code" deep inside an example list. Match the explicit "you are X" opener
+  // first to avoid mislabelling.
+  else if (lower.includes('you are openclaw')) label = 'OpenClaw';
+  else if (lower.includes('you are codex')) label = 'Codex';
   else if (lower.includes('claude code')) label = 'Claude Code';
   else if (lower.includes('claude agent')) label = 'Claude Agent';
-  else if (lower.includes('you are codex')) label = 'Codex';
   else if (lower.includes('openclaw')) label = 'OpenClaw';
   else if (lower.includes('subagent') || lower.includes('sub-agent')) label = 'Subagent';
   else if (lower.includes('bash')) label = 'Bash';

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -34,6 +34,21 @@ Each client in `CLIENT_CONFIGS` declares a `default_proxy_mode` used when
 
 Users can always override with `--tap-proxy-mode {reverse,forward}`.
 
+## Subcommand Argv Rewrites
+
+Some clients delegate to OS service managers (launchd / systemd / schtasks) for
+their long-running daemons. The spawned daemon does **not** inherit the
+proxy/CA env we inject, so trace capture would silently fail. claude-tap
+detects these patterns and rewrites the argv to the foreground equivalent:
+
+| Client | Detected argv | Rewritten to | Reason |
+|--------|---------------|--------------|--------|
+| `openclaw` | `gateway start [...]` | `gateway run [...]` | `gateway start` (2026.4+) is a launchd/systemd shim; `gateway run` is the foreground equivalent and accepts the same flags. |
+
+The rewrite is logged loudly at process start so users can spot it and pass
+`--tap-no-launch` + run the original command themselves if they actually want
+the daemonised behaviour (and accept that no traffic will be captured).
+
 ## URL Construction Rules
 
 The proxy constructs upstream URLs as: `target + forwarded_path`

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,6 +1,6 @@
 ---
 owner: claude-tap-maintainers
-last_reviewed: 2026-03-10
+last_reviewed: 2026-05-02
 source_of_truth: AGENTS.md
 ---
 
@@ -18,6 +18,21 @@ This document tracks all verified (client × auth × target × transport) combin
 | Codex CLI | API Key (`OPENAI_API_KEY`) | `https://api.openai.com` | none | WebSocket | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | HTTP/SSE | Verified |
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | WebSocket | Verified |
+| OpenClaw | Provider creds via `~/.openclaw/openclaw.json` | Forward proxy (any HTTPS upstream) | n/a | HTTP/SSE | Unit-tested |
+| OpenClaw | Custom anthropic-messages provider (`--tap-proxy-mode reverse`) | `https://api.anthropic.com` | none | HTTP/SSE | Unit-tested |
+
+## Default Proxy Mode by Client
+
+Each client in `CLIENT_CONFIGS` declares a `default_proxy_mode` used when
+`--tap-proxy-mode` is omitted:
+
+| Client | Default mode | Reason |
+|--------|--------------|--------|
+| `claude` | `reverse` | Single provider, native `ANTHROPIC_BASE_URL` env var |
+| `codex` | `reverse` | Single provider, native `OPENAI_BASE_URL` env var |
+| `openclaw` | `forward` | Multi-provider; built-in providers do not honor `*_BASE_URL` env vars, so HTTPS_PROXY capture is the only practical default |
+
+Users can always override with `--tap-proxy-mode {reverse,forward}`.
 
 ## URL Construction Rules
 

--- a/tests/test_openclaw_launch.py
+++ b/tests/test_openclaw_launch.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from claude_tap import parse_args
+from claude_tap.cli import CLIENT_CONFIGS, run_client
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.pid = 12345
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def test_openclaw_registered_in_client_configs() -> None:
+    cfg = CLIENT_CONFIGS["openclaw"]
+    assert cfg.cmd == "openclaw"
+    assert cfg.default_target == "https://api.anthropic.com"
+    assert cfg.base_url_env == "ANTHROPIC_BASE_URL"
+    # openclaw is multi-provider; forward proxy is the natural default
+    assert cfg.default_proxy_mode == "forward"
+
+
+def test_parse_args_openclaw_defaults_to_forward_mode() -> None:
+    args = parse_args(["--tap-client", "openclaw"])
+    assert args.client == "openclaw"
+    assert args.proxy_mode == "forward"
+
+
+def test_parse_args_openclaw_explicit_reverse_overrides_default() -> None:
+    args = parse_args(["--tap-client", "openclaw", "--tap-proxy-mode", "reverse"])
+    assert args.proxy_mode == "reverse"
+
+
+def test_parse_args_claude_default_proxy_mode_unchanged() -> None:
+    # Regression: changing the default-mode plumbing must not affect claude
+    args = parse_args([])
+    assert args.client == "claude"
+    assert args.proxy_mode == "reverse"
+
+
+def test_parse_args_codex_default_proxy_mode_unchanged() -> None:
+    # Regression: changing the default-mode plumbing must not affect codex
+    args = parse_args(["--tap-client", "codex"])
+    assert args.client == "codex"
+    assert args.proxy_mode == "reverse"
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_forward_sets_node_ca_env(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    ca_path = Path("/tmp/test-ca.pem")
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/openclaw")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["run", "hello"], client="openclaw", proxy_mode="forward", ca_cert_path=ca_path)
+
+    assert code == 0
+    env = captured["env"]
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:43123"
+    # openclaw is a Node 22+/24 binary; needs NODE_EXTRA_CA_CERTS for TLS trust
+    assert env["NODE_EXTRA_CA_CERTS"] == str(ca_path)
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_reverse_sets_anthropic_base_url(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/openclaw")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["run", "hello"], client="openclaw", proxy_mode="reverse")
+
+    assert code == 0
+    assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:43123"
+    # Reverse mode for openclaw must not inject a codex-only -c flag
+    assert captured["cmd"] == ("/tmp/openclaw", "run", "hello")

--- a/tests/test_openclaw_launch.py
+++ b/tests/test_openclaw_launch.py
@@ -100,3 +100,108 @@ async def test_run_client_openclaw_reverse_sets_anthropic_base_url(monkeypatch) 
     assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:43123"
     # Reverse mode for openclaw must not inject a codex-only -c flag
     assert captured["cmd"] == ("/tmp/openclaw", "run", "hello")
+
+
+# ---------------------------------------------------------------------------
+# argv rewrite: openclaw 2026.4+ delegates `gateway start` to launchd/systemd
+# which spawns the gateway in a fresh env, breaking HTTPS_PROXY inheritance.
+# We rewrite to `gateway run` (foreground) so the spawned process is our child
+# and inherits the injected env.
+# ---------------------------------------------------------------------------
+
+
+async def _capture_cmd(monkeypatch) -> dict[str, object]:
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/openclaw")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_rewrites_gateway_start_to_gateway_run(monkeypatch) -> None:
+    captured = await _capture_cmd(monkeypatch)
+    code = await run_client(43123, ["gateway", "start"], client="openclaw", proxy_mode="forward")
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/openclaw", "gateway", "run")
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_rewrite_preserves_trailing_flags(monkeypatch) -> None:
+    captured = await _capture_cmd(monkeypatch)
+    code = await run_client(
+        43123,
+        ["gateway", "start", "--allow-unconfigured", "--port", "18789"],
+        client="openclaw",
+        proxy_mode="forward",
+    )
+    assert code == 0
+    assert captured["cmd"] == (
+        "/tmp/openclaw",
+        "gateway",
+        "run",
+        "--allow-unconfigured",
+        "--port",
+        "18789",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_gateway_run_passthrough_unchanged(monkeypatch) -> None:
+    # Already-foreground invocations must not be touched
+    captured = await _capture_cmd(monkeypatch)
+    code = await run_client(43123, ["gateway", "run"], client="openclaw", proxy_mode="forward")
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/openclaw", "gateway", "run")
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_other_subcommands_unchanged(monkeypatch) -> None:
+    captured = await _capture_cmd(monkeypatch)
+    code = await run_client(43123, ["tui"], client="openclaw", proxy_mode="forward")
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/openclaw", "tui")
+
+
+@pytest.mark.asyncio
+async def test_run_client_openclaw_agent_local_unchanged(monkeypatch) -> None:
+    captured = await _capture_cmd(monkeypatch)
+    code = await run_client(
+        43123,
+        ["agent", "--local", "--agent", "main", "--message", "hi"],
+        client="openclaw",
+        proxy_mode="forward",
+    )
+    assert code == 0
+    assert captured["cmd"] == (
+        "/tmp/openclaw",
+        "agent",
+        "--local",
+        "--agent",
+        "main",
+        "--message",
+        "hi",
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_client_codex_not_affected_by_openclaw_rewrite(monkeypatch) -> None:
+    # The rewrite must only fire for openclaw — codex `gateway start` (hypothetical) stays raw
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _DummyProc()
+
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/codex")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["gateway", "start"], client="codex", proxy_mode="forward")
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/codex", "gateway", "start")

--- a/tests/test_openclaw_viewer.py
+++ b/tests/test_openclaw_viewer.py
@@ -1,0 +1,69 @@
+"""Viewer regression test: openclaw traces must not be mislabelled as Claude Code.
+
+openclaw bundles skills similar in shape to Claude Code's, so its system prompt
+can mention "Claude Code" deep inside an example list. The sidebar fingerprint
+heuristic must prefer the explicit self-identification at the top of the prompt.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+pw_missing = False
+try:
+    from playwright.sync_api import sync_playwright  # noqa: F401
+except ImportError:
+    pw_missing = True
+
+
+@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+def test_openclaw_prompt_is_labelled_openclaw_not_claude_code(tmp_path) -> None:
+    from playwright.sync_api import sync_playwright
+
+    from claude_tap.viewer import _generate_html_viewer
+
+    # Mirror the real openclaw system prompt shape: opens with the
+    # "You are openclaw" self-id, then mentions "Claude Code" deep inside
+    # an example list. Without the self-id-first heuristic, the trace would
+    # be mislabelled "Claude Code".
+    system_prompt = (
+        "You are openclaw, a personal AI assistant that helps users with "
+        "software engineering tasks across any OS or platform.\n"
+        "Use the instructions below and the tools available to you to assist the user.\n"
+        + ("filler ... " * 200)
+        + "\n(4) examples reference Claude Code, Cursor, or similar agent internals\n"
+        + ("filler ... " * 200)
+    )
+
+    trace_path = tmp_path / "trace.jsonl"
+    record = {
+        "timestamp": "2026-05-02T10:00:00+00:00",
+        "request_id": "req_1",
+        "turn": 1,
+        "duration_ms": 100,
+        "request": {
+            "method": "POST",
+            "path": "/anthropic/v1/messages",
+            "headers": {},
+            "body": {
+                "system": system_prompt,
+                "messages": [{"role": "user", "content": [{"type": "text", "text": "ping"}]}],
+            },
+        },
+        "response": {"status": 200, "headers": {}, "body": {"content": [], "usage": {}}},
+    }
+    trace_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+    html_path = tmp_path / "trace.html"
+    _generate_html_viewer(trace_path, html_path)
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        page.goto(html_path.resolve().as_uri(), wait_until="networkidle")
+        label = page.locator(".sidebar-item .si-task").first.inner_text()
+        browser.close()
+
+    assert label == "OpenClaw", f"openclaw trace mislabelled as {label!r}"


### PR DESCRIPTION
## Summary

Adds [OpenClaw](https://github.com/openclaw/openclaw) as a third supported client (alongside Claude Code and Codex CLI).

OpenClaw is a multi-provider Node 22.14+/24 CLI agent. Its built-in providers do **not** read `*_BASE_URL` environment variables — endpoint overrides require editing a custom provider entry in `~/.openclaw/openclaw.json`. So **forward proxy** (HTTPS_PROXY + CA injection into the Node process) is the only practical default; reverse mode is kept as opt-in for users who wire up a custom `anthropic-messages` provider.

## Changes

- **`claude_tap/cli.py`**
  - `ClientConfig` gains a `default_proxy_mode` field; argparse `--tap-proxy-mode` default becomes `None` and is resolved post-parse from the chosen client's config.
  - Register `openclaw` (Node runtime, forward default, `ANTHROPIC_BASE_URL` for reverse).
  - `--tap-client` choices and CLI epilog updated.
- **`claude_tap/viewer.html`**
  - Sidebar fingerprint heuristic reordered: explicit self-identification (`you are openclaw`, `you are codex`) wins over generic substring matches (`claude code`, `claude agent`, `openclaw`). Without this, real openclaw traces — whose prompts ship Claude-Code-style skills and mention "Claude Code" inside example lists — get mislabelled.
- **`docs/support-matrix.md`** — new OpenClaw rows + a "Default Proxy Mode by Client" table.
- **`README.md` / `README_zh.md`** — usage section + intro line update.
- **Tests** (8 new):
  - `tests/test_openclaw_launch.py` — registration, default-mode resolution, explicit override, claude/codex regression, forward subprocess env (HTTPS_PROXY + Node CA), reverse subprocess env (`ANTHROPIC_BASE_URL`, no codex-only flags).
  - `tests/test_openclaw_viewer.py` — Playwright regression: prompt opening with "You are openclaw" but mentioning "Claude Code" deep inside must label as `OpenClaw`.

## Tradeoff acknowledged

For openclaw users, **reverse mode is essentially a power-user opt-in** — without manual config-file work it won't capture anything. This is the same shape as Codex's OAuth/API-key duality (some modes need extra setup) and is documented in both README sections and the support matrix.

## Test plan

- [x] `uv run pytest` — 164 passed, 25 skipped
- [x] `uv run ruff check claude_tap tests` — clean
- [x] New tests fail on main without the implementation (RED), pass after (GREEN)
- [ ] Manual: `claude-tap --tap-client openclaw -- run "hello"` (requires openclaw installed locally)

## Related

This PR is independent of #95 (opencode client). Both touch `default_proxy_mode` plumbing and the viewer fingerprint block, so whichever merges second will need a small rebase.