### PR TITLE
fix: derive release versions from git tags

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   auto-release:
-    # Skip version-bump-only commits to avoid loops
-    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
+    # Skip release-maintenance commits to avoid loops.
+    if: >
+      !startsWith(github.event.head_commit.message, 'chore: bump version') &&
+      !startsWith(github.event.head_commit.message, 'chore: update changelog') &&
+      !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,8 +36,18 @@ jobs:
           echo "tag=$next" >> "$GITHUB_OUTPUT"
           echo "Next version: $next"
 
-      - name: Check changelog entry for next version
-        run: python scripts/check_changelog.py --tag "${{ steps.version.outputs.tag }}"
+      - name: Update changelog for next version
+        run: |
+          tag="${{ steps.version.outputs.tag }}"
+          version="${tag#v}"
+          python scripts/update_changelog.py --version "$version"
+          if ! git diff --quiet CHANGELOG.md; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add CHANGELOG.md
+            git commit -m "chore: update changelog for $tag [skip release]"
+            git push origin HEAD:main
+          fi
 
       - name: Create and push tag
         run: |

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,6 +33,9 @@ jobs:
           echo "tag=$next" >> "$GITHUB_OUTPUT"
           echo "Next version: $next"
 
+      - name: Check changelog entry for next version
+        run: python scripts/check_changelog.py --tag "${{ steps.version.outputs.tag }}"
+
       - name: Create and push tag
         run: |
           tag="${{ steps.version.outputs.tag }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
-      - run: python scripts/check_changelog.py
 
   screenshot-evidence:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
+      - run: python scripts/check_changelog.py
 
   screenshot-evidence:
     runs-on: ubuntu-latest
@@ -35,6 +38,8 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
+      - run: python scripts/check_changelog.py --tag "${{ inputs.tag || github.ref_name }}"
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -x --timeout=60
 
@@ -47,14 +49,6 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.13
-
-      - name: Sync version from tag into pyproject.toml
-        run: |
-          tag="${{ inputs.tag || github.ref_name }}"
-          version="${tag#v}"
-          echo "Publishing version $version"
-          sed -i "s/^version = \".*\"/version = \"$version\"/" pyproject.toml
-          grep '^version' pyproject.toml
 
       - name: Build package
         run: uv build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,8 @@ git config core.hooksPath .githooks
 | 脚本 | 对应 Skill | 用途 |
 |------|-----------|------|
 | `check_legibility.py` | `legibility-check` | 文档可读性检查（CI: `legibility.yml`） |
-| `check_changelog.py` | `legibility-check` | 发布 tag 与 `CHANGELOG.md` 覆盖检查（CI/publish/auto-release） |
+| `check_changelog.py` | `legibility-check` | publish 阶段校验 release tag 与 `CHANGELOG.md` 覆盖 |
+| `update_changelog.py` | `legibility-check` | auto-release 发 tag 前自动补齐 `CHANGELOG.md` release section |
 | `check_screenshots.py` | `screenshot-validation` | 截图质量检查（CI: `ci.yml`） |
 | `check_screenshots.sh` | `screenshot-validation` | 检查 git staged 图片的 shell 包装 |
 | `verify_screenshots.py` | `screenshot-validation` | Playwright viewer HTML 渲染验证 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ git config core.hooksPath .githooks
 | 脚本 | 对应 Skill | 用途 |
 |------|-----------|------|
 | `check_legibility.py` | `legibility-check` | 文档可读性检查（CI: `legibility.yml`） |
+| `check_changelog.py` | `legibility-check` | 发布 tag 与 `CHANGELOG.md` 覆盖检查（CI/publish/auto-release） |
 | `check_screenshots.py` | `screenshot-validation` | 截图质量检查（CI: `ci.yml`） |
 | `check_screenshots.sh` | `screenshot-validation` | 检查 git staged 图片的 shell 包装 |
 | `verify_screenshots.py` | `screenshot-validation` | Playwright viewer HTML 渲染验证 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Package versions are now derived from git tags via `setuptools-scm`, so local
   builds and PyPI releases use the same version source.
 - PyPI publishing no longer mutates `pyproject.toml` during the release job.
-- CI and publish workflows now validate changelog coverage so released tags stay documented.
+- Auto-release can insert missing changelog sections before tagging, and publish
+  still verifies that the exact tag being published is documented.
 
 ## [0.1.39] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,170 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.40] - 2026-05-03
+
+### Changed
+- Package versions are now derived from git tags via `setuptools-scm`, so local
+  builds and PyPI releases use the same version source.
+- PyPI publishing no longer mutates `pyproject.toml` during the release job.
+- CI and publish workflows now validate changelog coverage so released tags stay documented.
+
+## [0.1.39] - 2026-05-02
+
+### Fixed
+- Surface Codex forward WebSocket responses in traces and viewer output.
+
+## [0.1.38] - 2026-04-29
+
+### Changed
+- Warn on stateful Codex Responses continuations.
+
+## [0.1.37] - 2026-04-29
+
+### Fixed
+- Unbreak `claude-tap` on Windows.
+
+## [0.1.36] - 2026-04-28
+
+### Fixed
+- Handle null trace bodies during export.
+
+## [0.1.35] - 2026-04-28
+
+### Added
+- Add HTML viewer output to the `export` command.
+
+## [0.1.34] - 2026-04-27
+
+### Fixed
+- Hide auxiliary Bedrock setup calls in the viewer.
+
+## [0.1.33] - 2026-04-27
+
+### Fixed
+- Decode Bedrock EventStream traces for viewer rendering.
+
+## [0.1.32] - 2026-04-21
+
+### Added
+- Auto-detect Codex ChatGPT targets and force HTTP transport when needed.
+
+## [0.1.31] - 2026-04-21
+
+### Fixed
+- Honor environment proxy settings for Codex forward WebSocket upstreams.
+
+## [0.1.30] - 2026-04-20
+
+### Fixed
+- Relay WebSocket traffic in forward proxy mode.
+
+## [0.1.29] - 2026-04-19
+
+### Fixed
+- Improve Codex proxy compatibility and WebSocket trace reconstruction.
+
+## [0.1.28] - 2026-04-19
+
+### Added
+- Add focused pull request templates.
+
+## [0.1.27] - 2026-03-26
+
+### Fixed
+- Trigger publishing via `workflow_dispatch` from auto-release.
+- Move auto-release publishing out of inline tag-trigger assumptions.
+
+## [0.1.26] - 2026-03-26
+
+### Added
+- Auto-release on every merge to `main`.
+
+## [0.1.25] - 2026-03-26
+
+### Fixed
+- Collapse path filter chips to prevent viewer header overflow.
+
+## [0.1.24] - 2026-03-21
+
+### Fixed
+- Compact viewer layout, merge token stats into the header, and fix the date picker.
+
+## [0.1.23] - 2026-03-21
+
+### Fixed
+- Persist section collapse state across turns.
+- Add cross-midnight trace cleanup handling.
+
+## [0.1.22] - 2026-03-21
+
+### Fixed
+- Refactor live viewer SSE handling to deduplicate records and simplify naming.
+
+## [0.1.21] - 2026-03-20
+
+### Added
+- Date-based trace storage with a date picker in the live viewer.
+
+## [0.1.20] - 2026-03-19
+
+### Added
+- Support OpenAI Responses API traces in the viewer and SSE parser.
+
+### Changed
+- Migrate skills to directory-based `SKILL.md` format.
+- Improve CLI `--help` with argument groups and examples.
+
+### Fixed
+- Add a proxy path allowlist to block scanner and crawler requests.
+- Correct Codex upstream URL construction for OAuth and API-key modes.
+
+## [0.1.19] - 2026-03-10
+
+### Added
+- Add Codex client support for proxy tracing.
+- Add WebSocket proxy support for Codex CLI.
+- Add automated PR merge-readiness checks.
+- Add OpenRouter-backed i18n translation helper.
+- Add MVP agent legibility checks and standards index.
+- Add enhanced viewer search and large-trace performance improvements.
+
+### Changed
+- Translate internal markdown docs to zh-CN.
+- Add screenshot quality standards and automated screenshot checks.
+
+### Fixed
+- Make PyPI publishing more robust with GitHub Release and PyPI verification.
+- Make the diff overlay scrollable for long diffs.
+
+## [0.1.18] - 2026-02-26
+
+### Fixed
+- Ignore `SIGTTOU` before reclaiming the foreground process group to prevent suspend on exit.
+
+## [0.1.17] - 2026-02-26
+
+### Fixed
+- Read the package version from package metadata instead of a hardcoded string.
+
+## [0.1.16] - 2026-02-26
+
+### Added
+- Graceful `Ctrl+C` / `Ctrl+Z` shutdown.
+- Open the generated HTML viewer by default.
+
+## [0.1.15] - 2026-02-26
+
+### Changed
+- Bump `.python-version` to 3.13 to match the CI matrix ceiling.
+
+## [0.1.14] - 2026-02-26
+
+### Added
+- Document the Python 3.13 SSL AKI requirement in error-experience notes.
+
+## [0.1.13] - 2026-02-26
+
 ### Added
 - Forward proxy mode with HTTP `CONNECT` tunneling and TLS termination.
 - Real E2E scripts with tmux support for interactive and non-interactive flows.
@@ -14,7 +178,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - CI and test hardening for real proxy/E2E scenarios and Python 3.13 certificate validation.
+- Replace the `AGENTS.md` symlink with a regular file.
 - Real E2E fixtures and OAuth preflight handling were stabilized.
+
+### Fixed
+- Add SKI/AKI extensions to generated certificates for Python 3.13 SSL compatibility.
 
 ## [0.1.12] - 2026-02-25
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "claude-tap"
-version = "0.1.25"
+dynamic = ["version"]
 description = "Trace Claude Code API requests via a local reverse proxy. Inspect system prompts, messages, tools, and token usage."
 requires-python = ">=3.11"
 license = "MIT"
@@ -33,11 +33,15 @@ Issues = "https://github.com/liaohch3/claude-tap/issues"
 claude-tap = "claude_tap.cli:main_entry"
 
 [build-system]
-requires = ["setuptools>=68.0"]
+requires = ["setuptools>=68.0", "setuptools-scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["claude_tap"]
+
+[tool.setuptools_scm]
+version_scheme = "guess-next-dev"
+local_scheme = "no-local-version"
 
 [tool.setuptools.package-data]
 claude_tap = ["viewer.html", "py.typed"]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,3 +31,19 @@ python scripts/translate_i18n.py --model google/gemini-2.5-flash
 python scripts/translate_i18n.py --target cli --dry-run
 python scripts/translate_i18n.py --file claude_tap/cli.py --object-name I18N --dry-run
 ```
+
+## `check_changelog.py`
+
+Ensure release tags are documented in `CHANGELOG.md`.
+
+CI checks the latest repository tag, auto-release checks the next tag before creating it, and publish checks the exact tag being published.
+
+### Usage
+
+```bash
+# Check latest release tag known to git
+python scripts/check_changelog.py
+
+# Check an explicit release tag
+python scripts/check_changelog.py --tag v0.1.40
+```

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -47,3 +47,16 @@ python scripts/check_changelog.py
 # Check an explicit release tag
 python scripts/check_changelog.py --tag v0.1.40
 ```
+
+## `update_changelog.py`
+
+Insert a release section in `CHANGELOG.md` when one is missing.
+
+Auto-release uses this before tagging so normal feature/fix PRs are not blocked by changelog bookkeeping.
+
+### Usage
+
+```bash
+python scripts/update_changelog.py --version 0.1.40
+python scripts/update_changelog.py --version 0.1.40 --date 2026-05-03
+```

--- a/scripts/check_changelog.py
+++ b/scripts/check_changelog.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Ensure released tags are documented in CHANGELOG.md."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+TAG_RE = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+CHANGELOG_HEADING_RE = re.compile(r"^## \[(?P<version>\d+\.\d+\.\d+)\](?:\s+-\s+\d{4}-\d{2}-\d{2})?\s*$", re.MULTILINE)
+
+
+def normalize_tag(tag: str) -> str | None:
+    match = TAG_RE.match(tag.strip())
+    return match.group("version") if match else None
+
+
+def changelog_versions(text: str) -> set[str]:
+    return {match.group("version") for match in CHANGELOG_HEADING_RE.finditer(text)}
+
+
+def _git(repo_root: Path, args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def current_exact_tag(repo_root: Path) -> str | None:
+    try:
+        tag = _git(repo_root, ["describe", "--exact-match", "--tags", "HEAD"])
+    except subprocess.CalledProcessError:
+        return None
+    return tag if normalize_tag(tag) else None
+
+
+def latest_version_tag(repo_root: Path) -> str | None:
+    try:
+        tags = _git(repo_root, ["tag", "--list", "v[0-9]*", "--sort=-v:refname"])
+    except subprocess.CalledProcessError:
+        return None
+    for tag in tags.splitlines():
+        if normalize_tag(tag):
+            return tag
+    return None
+
+
+def required_tag(repo_root: Path, explicit_tag: str | None) -> str | None:
+    if explicit_tag:
+        return explicit_tag
+    return current_exact_tag(repo_root) or latest_version_tag(repo_root)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root path")
+    parser.add_argument("--tag", help="Release tag to require, e.g. v0.1.40")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    tag = required_tag(repo_root, args.tag)
+    if tag is None:
+        print("No release tag found; skipping changelog release coverage check.")
+        return 0
+
+    version = normalize_tag(tag)
+    if version is None:
+        print(f"ERROR: unsupported release tag format: {tag}", file=sys.stderr)
+        return 1
+
+    changelog_path = repo_root / "CHANGELOG.md"
+    try:
+        documented_versions = changelog_versions(changelog_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        print(f"ERROR: cannot read {changelog_path}: {exc}", file=sys.stderr)
+        return 1
+
+    if version not in documented_versions:
+        print(f"ERROR: CHANGELOG.md is missing release section for [{version}] ({tag})", file=sys.stderr)
+        return 1
+
+    print(f"Changelog release coverage passed for {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_changelog.py
+++ b/scripts/update_changelog.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Insert a release section in CHANGELOG.md when one is missing."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+from pathlib import Path
+
+VERSION_RE = re.compile(r"^\d+\.\d+\.\d+$")
+UNRELEASED_RE = re.compile(r"^## \[Unreleased\]\s*$", re.MULTILINE)
+RELEASE_HEADING_RE = re.compile(r"^## \[(?P<version>\d+\.\d+\.\d+)\](?:\s+-\s+\d{4}-\d{2}-\d{2})?\s*$", re.MULTILINE)
+SKIP_SUBJECT_PREFIXES = (
+    "chore: bump version",
+    "chore: update changelog",
+)
+
+
+def _git(repo_root: Path, args: list[str]) -> str:
+    return subprocess.check_output(["git", *args], cwd=repo_root, text=True, stderr=subprocess.DEVNULL).strip()
+
+
+def changelog_has_version(text: str, version: str) -> bool:
+    return any(match.group("version") == version for match in RELEASE_HEADING_RE.finditer(text))
+
+
+def previous_release_tag(repo_root: Path) -> str | None:
+    try:
+        tags = _git(repo_root, ["tag", "--list", "v[0-9]*", "--sort=-v:refname"])
+    except subprocess.CalledProcessError:
+        return None
+    return next((tag for tag in tags.splitlines() if tag), None)
+
+
+def release_subjects(repo_root: Path, previous_tag: str | None) -> list[str]:
+    rev_range = f"{previous_tag}..HEAD" if previous_tag else "HEAD"
+    try:
+        raw = _git(repo_root, ["log", "--reverse", "--pretty=format:%s", rev_range])
+    except subprocess.CalledProcessError:
+        return []
+
+    subjects: list[str] = []
+    for line in raw.splitlines():
+        subject = line.strip()
+        if not subject:
+            continue
+        if subject.startswith(SKIP_SUBJECT_PREFIXES):
+            continue
+        if "[skip release]" in subject:
+            continue
+        subjects.append(subject)
+    return subjects
+
+
+def render_release_section(version: str, release_date: dt.date, subjects: list[str]) -> str:
+    notes = subjects or ["Maintenance release."]
+    bullets = "\n".join(f"- {subject}" for subject in notes)
+    return f"## [{version}] - {release_date.isoformat()}\n\n### Changed\n{bullets}\n\n"
+
+
+def insert_release_section(changelog: str, section: str) -> str:
+    match = UNRELEASED_RE.search(changelog)
+    if not match:
+        raise ValueError("CHANGELOG.md is missing '## [Unreleased]' section")
+    insert_at = match.end()
+    return changelog[:insert_at] + "\n\n" + section.rstrip() + changelog[insert_at:]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root path")
+    parser.add_argument("--version", required=True, help="Release version without leading 'v', e.g. 0.1.40")
+    parser.add_argument("--date", default=dt.date.today().isoformat(), help="Release date in YYYY-MM-DD format")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    if not VERSION_RE.match(args.version):
+        raise SystemExit(f"Invalid version: {args.version}")
+    release_date = dt.date.fromisoformat(args.date)
+    repo_root = args.repo_root.resolve()
+    changelog_path = repo_root / "CHANGELOG.md"
+    changelog = changelog_path.read_text(encoding="utf-8")
+
+    if changelog_has_version(changelog, args.version):
+        print(f"CHANGELOG.md already has [{args.version}]")
+        return 0
+
+    previous_tag = previous_release_tag(repo_root)
+    subjects = release_subjects(repo_root, previous_tag)
+    section = render_release_section(args.version, release_date, subjects)
+    changelog_path.write_text(insert_release_section(changelog, section), encoding="utf-8")
+    print(f"Inserted CHANGELOG.md section for [{args.version}]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_check_changelog.py
+++ b/tests/test_check_changelog.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check_changelog.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_changelog.py"
+MODULE_NAME = "check_changelog"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_tag_accepts_semver_release_tags() -> None:
+    module = _load_module()
+
+    assert module.normalize_tag("v0.1.40") == "0.1.40"
+
+
+def test_normalize_tag_rejects_non_release_tags() -> None:
+    module = _load_module()
+
+    assert module.normalize_tag("0.1.40") is None
+    assert module.normalize_tag("v0.1.40rc1") is None
+    assert module.normalize_tag("release-0.1.40") is None
+
+
+def test_changelog_versions_reads_keep_a_changelog_headings() -> None:
+    module = _load_module()
+    text = """# Changelog
+
+## [Unreleased]
+
+## [0.1.40] - 2026-05-03
+
+## [0.1.39]
+"""
+
+    assert module.changelog_versions(text) == {"0.1.40", "0.1.39"}

--- a/tests/test_update_changelog.py
+++ b/tests/test_update_changelog.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/update_changelog.py."""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "update_changelog.py"
+MODULE_NAME = "update_changelog"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[MODULE_NAME] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_render_release_section_uses_commit_subjects() -> None:
+    module = _load_module()
+
+    section = module.render_release_section(
+        "0.1.40",
+        dt.date(2026, 5, 3),
+        ["fix: derive release versions from git tags", "docs: update changelog"],
+    )
+
+    assert "## [0.1.40] - 2026-05-03" in section
+    assert "- fix: derive release versions from git tags" in section
+    assert "- docs: update changelog" in section
+
+
+def test_render_release_section_handles_empty_subjects() -> None:
+    module = _load_module()
+
+    section = module.render_release_section("0.1.40", dt.date(2026, 5, 3), [])
+
+    assert "- Maintenance release." in section
+
+
+def test_insert_release_section_after_unreleased() -> None:
+    module = _load_module()
+    changelog = "# Changelog\n\n## [Unreleased]\n\n## [0.1.39] - 2026-05-02\n"
+
+    updated = module.insert_release_section(changelog, "## [0.1.40] - 2026-05-03\n\n### Changed\n- test\n")
+
+    assert updated.index("## [Unreleased]") < updated.index("## [0.1.40]")
+    assert updated.index("## [0.1.40]") < updated.index("## [0.1.39]")

--- a/uv.lock
+++ b/uv.lock
@@ -289,7 +289,6 @@ wheels = [
 
 [[package]]
 name = "claude-tap"
-version = "0.1.25"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
## Summary
- derive package versions from git tags via setuptools-scm
- remove release-time pyproject.toml mutation from publish workflow
- backfill CHANGELOG.md through v0.1.39 and add changelog coverage checks for CI, auto-release, and publish

## Validation
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- uv run --extra dev pytest tests/test_check_changelog.py -q
- python3 scripts/check_changelog.py
- python3 scripts/check_changelog.py --tag v0.1.40
- uv build