### PR TITLE
docs: add security policy and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,86 @@
+name: Bug report
+description: Report a reproducible problem with claude-tap.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Do not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers unless they are fully redacted.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and pull requests.
+          required: true
+        - label: I removed secrets and private trace data from this report.
+          required: true
+  - type: input
+    id: version
+    attributes:
+      label: claude-tap version
+      description: Output of `claude-tap --version` or package version.
+      placeholder: "0.1.39"
+    validations:
+      required: true
+  - type: dropdown
+    id: client
+    attributes:
+      label: Client
+      options:
+        - Claude Code
+        - Codex CLI
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: proxy-mode
+    attributes:
+      label: Proxy mode
+      options:
+        - reverse
+        - forward
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: Use sanitized commands and data.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. See ...
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Sanitized logs or trace summary
+      description: Paste only redacted excerpts. Do not attach private trace files.
+      render: text
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, Python version, install method, Claude Code/Codex version, relevant proxy/VPN setup.
+      placeholder: |
+        OS:
+        Python:
+        Install method:
+        Client version:
+        Network/proxy setup:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security report
+    url: https://github.com/liaohch3/claude-tap/security/advisories/new
+    about: Please report vulnerabilities privately. Do not include secrets or private traces in public issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,56 @@
+name: Feature request
+description: Propose an improvement or new capability.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the user problem first. Avoid including private prompts, raw traces, or generated viewer files.
+  - type: checkboxes
+    id: preflight
+    attributes:
+      label: Preflight
+      options:
+        - label: I searched existing issues and pull requests.
+          required: true
+        - label: This request does not include secrets or private trace data.
+          required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow is blocked or painful today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or interface you want.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Proxy routing
+        - Trace format
+        - Viewer
+        - Export
+        - Documentation
+        - Release/CI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Sanitized evidence
+      description: Link to redacted screenshots, recordings, or sample traces if useful.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+`claude-tap` intercepts and records API traffic from local AI coding clients. Security reports may involve credentials, proxy routing, generated certificates, trace files, or private prompt data.
+
+## Supported Versions
+
+Security fixes target the latest published PyPI release and the `main` branch.
+
+## Reporting a Vulnerability
+
+Please do not open a public GitHub issue for security-sensitive reports.
+
+Use GitHub private vulnerability reporting if it is available on this repository. If private reporting is not available, contact the maintainer privately before sharing exploit details, credentials, private traces, or reproduction data.
+
+Include:
+
+- A concise description of the issue
+- Affected versions or commits
+- Steps to reproduce with sanitized data
+- Whether credentials, traces, local files, or generated certificates may be exposed
+- Any known mitigation or workaround
+
+## Trace Data
+
+Do not attach raw `.traces/*.jsonl`, generated HTML viewers, screenshots, or recordings unless you have reviewed and redacted them. Trace files can contain prompts, tool schemas, file paths, response bodies, and other private context even when API keys are redacted.
+
+## Scope
+
+Security-sensitive areas include:
+
+- API key, auth token, cookie, or header handling
+- Trace redaction and export behavior
+- Reverse proxy and forward proxy routing
+- `--tap-host`, `--tap-no-launch`, and remote binding behavior
+- Generated CA certificates and per-host TLS certificates
+- Generated viewer HTML that may contain private trace data
+
+## Public Disclosure
+
+Please allow maintainers time to investigate and prepare a fix before public disclosure.


### PR DESCRIPTION
## Summary
- add SECURITY.md with private reporting and trace-data guidance
- add bug report and feature request issue forms
- disable blank issues and route security reports to private advisories

## Validation
- parsed issue template YAML with PyYAML
- git diff --check