### PR TITLE
docs: add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our Standard
+
+This project should be a respectful, practical place to discuss `claude-tap`, local proxying, trace inspection, and related developer tooling.
+
+Examples of constructive behavior:
+
+- Be direct and specific about technical problems.
+- Assume good intent while still asking for evidence.
+- Keep criticism focused on code, docs, behavior, and user impact.
+- Respect privacy when discussing traces, prompts, logs, screenshots, and recordings.
+- Help make issues and pull requests actionable.
+
+Examples of unacceptable behavior:
+
+- Harassment, insults, threats, or sustained personal attacks
+- Sexualized language or imagery
+- Publishing someone else's private information
+- Sharing unredacted credentials, private traces, or sensitive local data
+- Repeated off-topic disruption after maintainers ask for a change
+
+## Enforcement
+
+Maintainers may edit, hide, or remove comments, issues, pull requests, or other contributions that violate this code of conduct. Maintainers may also temporarily or permanently restrict participation when needed to protect the project and its contributors.
+
+## Reporting
+
+Report conduct concerns privately to the maintainers. Do not include sensitive personal data, credentials, or private trace files in public issues.
+
+Security vulnerabilities should be reported through the security reporting process, not through public conduct reports.
+
+## Scope
+
+This code of conduct applies to project spaces, including GitHub issues, pull requests, discussions, reviews, and any project-managed communication channel.


### PR DESCRIPTION
## Summary
- add a concise Code of Conduct for project spaces
- include privacy expectations around traces, prompts, logs, and credentials

## Validation
- git diff --check