### PR TITLE
fix: respect protected branches in auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   auto-release:
-    # Skip release-maintenance commits to avoid loops.
+    # Skip explicit non-release commits to avoid loops.
     if: >
       !startsWith(github.event.head_commit.message, 'chore: bump version') &&
-      !startsWith(github.event.head_commit.message, 'chore: update changelog') &&
       !contains(github.event.head_commit.message, '[skip release]')
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       actions: write
     steps:
       - uses: actions/checkout@v4
@@ -37,19 +37,48 @@ jobs:
           echo "Next version: $next"
 
       - name: Update changelog for next version
+        id: changelog
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           tag="${{ steps.version.outputs.tag }}"
           version="${tag#v}"
           python scripts/update_changelog.py --version "$version"
-          if ! git diff --quiet CHANGELOG.md; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add CHANGELOG.md
-            git commit -m "chore: update changelog for $tag [skip release]"
-            git push origin HEAD:main
+          if git diff --quiet CHANGELOG.md; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          branch="release/${tag}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add CHANGELOG.md
+          git commit -m "chore: update changelog for $tag"
+          git push --force-with-lease origin "$branch"
+
+          pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // ""')"
+          if [ -n "$pr_number" ]; then
+            echo "Release changelog PR #$pr_number already exists"
+          else
+            pr_url="$(gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "chore: update changelog for $tag" \
+              --body "Auto-generated release changelog for $tag. Auto-merge will continue the release after checks pass.")"
+            pr_number="${pr_url##*/}"
+          fi
+
+          auto_merge_enabled="$(gh pr view "$pr_number" --json autoMergeRequest --jq '.autoMergeRequest != null')"
+          if [ "$auto_merge_enabled" = "true" ]; then
+            echo "Auto-merge is already enabled for release changelog PR #$pr_number"
+          else
+            gh pr merge "$pr_number" --auto --squash --delete-branch
+          fi
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
       - name: Create and push tag
+        if: steps.changelog.outputs.changed == 'false'
         run: |
           tag="${{ steps.version.outputs.tag }}"
           git tag "$tag"
@@ -57,6 +86,7 @@ jobs:
           echo "Created tag $tag"
 
       - name: Trigger publish workflow
+        if: steps.changelog.outputs.changed == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,7 @@ git config core.hooksPath .githooks
 |------|-----------|------|
 | `check_legibility.py` | `legibility-check` | 文档可读性检查（CI: `legibility.yml`） |
 | `check_changelog.py` | `legibility-check` | publish 阶段校验 release tag 与 `CHANGELOG.md` 覆盖 |
-| `update_changelog.py` | `legibility-check` | auto-release 发 tag 前自动补齐 `CHANGELOG.md` release section |
+| `update_changelog.py` | `legibility-check` | auto-release 发 tag 前自动补齐 `CHANGELOG.md` release section，分支保护下会走 auto-merge release PR |
 | `check_screenshots.py` | `screenshot-validation` | 截图质量检查（CI: `ci.yml`） |
 | `check_screenshots.sh` | `screenshot-validation` | 检查 git staged 图片的 shell 包装 |
 | `verify_screenshots.py` | `screenshot-validation` | Playwright viewer HTML 渲染验证 |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.41] - 2026-05-03
+
+### Fixed
+- Make auto-release open and auto-merge a changelog pull request when the main
+  branch is protected, then publish after that release PR is merged.
+
 ## [0.1.40] - 2026-05-03
 
 ### Changed

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,7 @@ python scripts/translate_i18n.py --file claude_tap/cli.py --object-name I18N --d
 
 Ensure release tags are documented in `CHANGELOG.md`.
 
-CI checks the latest repository tag, auto-release checks the next tag before creating it, and publish checks the exact tag being published.
+Publish checks the exact tag being published.
 
 ### Usage
 
@@ -52,7 +52,7 @@ python scripts/check_changelog.py --tag v0.1.40
 
 Insert a release section in `CHANGELOG.md` when one is missing.
 
-Auto-release uses this before tagging so normal feature/fix PRs are not blocked by changelog bookkeeping.
+Auto-release uses this before tagging so normal feature/fix PRs are not blocked by changelog bookkeeping. If the main branch is protected, auto-release opens a changelog PR, enables auto-merge, and publishes after that PR is merged.
 
 ### Usage
 


### PR DESCRIPTION
## Summary
- make auto-release open a release changelog PR instead of pushing directly to protected main
- continue tag creation and PyPI publish only when the target changelog entry already exists
- document the protected-branch flow and add a v0.1.41 changelog entry for this repair

## Tests
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- python3 scripts/check_changelog.py --tag v0.1.41 && python3 scripts/update_changelog.py --version 0.1.41
- uv run --extra dev pytest tests/test_check_changelog.py tests/test_update_changelog.py -q