### PR TITLE
fix(cli): 解决 Claude Code 自定义 base URL 导致 tap-live 401

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -153,6 +153,11 @@ async def run_client(
         base_url = cfg.reverse_base_url(port)
         env[cfg.base_url_env] = base_url
         env["NO_PROXY"] = "127.0.0.1"
+        if client == "claude":
+            has_settings_arg = any(arg == "--settings" or arg.startswith("--settings=") for arg in cmd_args)
+            if not has_settings_arg:
+                settings_payload = {"env": {cfg.base_url_env: base_url}}
+                cmd_args = ["--settings", json.dumps(settings_payload, separators=(",", ":"))] + cmd_args
         if client == "codex" and not has_openai_base_override:
             # Newer Codex builds may ignore OPENAI_BASE_URL in OAuth/WebSocket mode
             # unless the same value is also supplied as a config override.

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -75,7 +75,14 @@ async def test_run_client_passes_resolved_path_for_cmd_shim(monkeypatch) -> None
 
     code = await run_client(43123, ["--version"], client="claude", proxy_mode="reverse")
     assert code == 0
-    assert captured["cmd"] == (shim_path, "--version")
+    cmd = captured["cmd"]
+    assert cmd[0] == shim_path, "resolved .cmd shim path must be preserved"
+    assert cmd[1] == "--settings", "--settings must be injected before forwarded args"
+    import json
+
+    injected = json.loads(cmd[2])
+    assert injected == {"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:43123"}}
+    assert cmd[3:] == ("--version",), "original args must follow --settings payload"
 
 
 def test_module_import_reconfigures_stdout_to_utf8() -> None:


### PR DESCRIPTION
## 概要

- 修复 `claude-tap --tap-live` 在 Claude Code reverse proxy 模式下可能绕过本地代理的问题。
- 根因是用户在 `~/.claude/settings.json` 中配置了 `ANTHROPIC_BASE_URL` 时，Claude Code 会优先读取 settings 中的环境变量，而不是 claude-tap 传入子进程的 process env。
- 现在 reverse 模式会复用 forward 模式的做法，在未显式传入 `--settings` 时自动注入 `--settings`，把 `ANTHROPIC_BASE_URL` 指向 claude-tap 本地代理。
- 如果用户已经手动传入 `--settings`，不会覆盖用户参数。

## 影响

- 解决使用个人或公司 API base URL 配置时，`claude-tap --tap-live` 会直接连到旧上游并触发 401 `Invalid bearer token` 的问题。
- 对没有自定义 Claude Code settings 的用户没有行为变化。
- 只影响 Claude Code reverse proxy 启动参数；Codex 和 forward proxy 路径不变。

## 验证

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -x --timeout=60`
- CI 已通过 `lint`、`legibility`、`screenshot-evidence`、Python 3.11/3.12/3.13 测试。

## 截图

本 PR 不是 UI 变更，不需要截图证据。
