### PR TITLE
docs: add default community templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!--
+Prefer the structured bug report or feature request forms when they fit.
+Do not include API keys, auth tokens, private prompts, raw trace files, or
+generated HTML viewers unless they are fully redacted.
+-->
+
+## Summary
+
+
+## Environment
+
+- claude-tap version:
+- Client: Claude Code / Codex CLI / other
+- OS:
+- Python version:
+- Install method:
+
+## Details
+
+
+## Validation
+
+- [ ] I searched existing issues and pull requests.
+- [ ] I removed secrets and private trace data from this report.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+-
+
+## Type
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Test or tooling
+- [ ] Maintenance
+
+## Validation
+
+- [ ] `uv run ruff check .`
+- [ ] `uv run ruff format --check .`
+- [ ] `uv run pytest tests/ -x --timeout=60`
+- [ ] Not required; docs-only or metadata-only change.
+
+## Privacy
+
+- [ ] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.


### PR DESCRIPTION
## Summary
- add a default issue template recognized by GitHub community profile
- add a default pull request template for normal PR creation
- keep existing issue forms and specialized PR templates as optional structured workflows

## Tests
- python3 scripts/check_legibility.py (passes with existing stale-review warnings)