### PR TITLE
[skip release] fix(ci): avoid duplicate publish dispatch

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,7 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      actions: write
     steps:
       - name: Validate release bot token
         env:
@@ -93,12 +92,3 @@ jobs:
           git tag "$tag"
           git push origin "$tag"
           echo "Created tag $tag"
-
-      - name: Trigger publish workflow
-        if: steps.changelog.outputs.changed == 'false'
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
-        run: |
-          tag="${{ steps.version.outputs.tag }}"
-          gh workflow run publish.yml --field tag="$tag"
-          echo "Triggered publish.yml for $tag"


### PR DESCRIPTION
## Summary
- remove the manual publish workflow_dispatch from auto-release
- rely on the release bot tag push to trigger publish.yml once
- drop the unused actions: write permission from auto-release

## Testing
- uv run --with pyyaml python -c "import yaml; yaml.safe_load(open('.github/workflows/auto-release.yml'))"
- git diff --check