### PR TITLE
[skip release] docs: update README stars and contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![PyPI downloads](https://img.shields.io/pypi/dm/claude-tap.svg)](https://pypi.org/project/claude-tap/)
 [![Python version](https://img.shields.io/pypi/pyversions/claude-tap.svg)](https://pypi.org/project/claude-tap/)
 [![License](https://img.shields.io/github/license/liaohch3/claude-tap.svg)](https://github.com/liaohch3/claude-tap/blob/main/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/liaohch3/claude-tap?style=social)](https://github.com/liaohch3/claude-tap/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/liaohch3/claude-tap.svg)](https://github.com/liaohch3/claude-tap/graphs/contributors)
 
 [中文文档](README_zh.md)
 
@@ -175,7 +177,11 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 
 ## Community
 
+### Star History
+
 [![Star History Chart](https://api.star-history.com/svg?repos=liaohch3/claude-tap&type=Date)](https://www.star-history.com/#liaohch3/claude-tap&Date)
+
+### Contributors
 
 <a href="https://github.com/liaohch3/claude-tap/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=liaohch3/claude-tap" alt="Contributors" />

--- a/README_zh.md
+++ b/README_zh.md
@@ -4,6 +4,8 @@
 [![PyPI downloads](https://img.shields.io/pypi/dm/claude-tap.svg)](https://pypi.org/project/claude-tap/)
 [![Python version](https://img.shields.io/pypi/pyversions/claude-tap.svg)](https://pypi.org/project/claude-tap/)
 [![License](https://img.shields.io/github/license/liaohch3/claude-tap.svg)](https://github.com/liaohch3/claude-tap/blob/main/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/liaohch3/claude-tap?style=social)](https://github.com/liaohch3/claude-tap/stargazers)
+[![Contributors](https://img.shields.io/github/contributors/liaohch3/claude-tap.svg)](https://github.com/liaohch3/claude-tap/graphs/contributors)
 
 [English](README.md)
 
@@ -173,7 +175,11 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex -c 'openai_base_url="http://127.0
 
 ## 社区
 
+### Star 历史
+
 [![Star History Chart](https://api.star-history.com/svg?repos=liaohch3/claude-tap&type=Date)](https://www.star-history.com/#liaohch3/claude-tap&Date)
+
+### 贡献者
 
 <a href="https://github.com/liaohch3/claude-tap/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=liaohch3/claude-tap" alt="贡献者" />


### PR DESCRIPTION
## Summary
- add GitHub Stars and Contributors badges to both README files
- split the Community section into Star History and Contributors subsections
- keep the existing star-history and contrib.rocks images visible in English and Chinese docs

## Testing
- git diff --check