### PR TITLE
feat(cli): support Cursor CLI tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [中文文档](README_zh.md)
 
-Intercept and inspect API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Codex CLI](https://github.com/openai/codex). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
+Intercept and inspect API traffic from [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), OpenCode, or [Cursor CLI](https://cursor.com/cli). See exactly how they construct system prompts, manage conversation history, select tools, and use tokens — in a beautiful trace viewer.
 
 ![Demo](docs/demo.gif)
 
@@ -28,7 +28,7 @@ Intercept and inspect API traffic from [Claude Code](https://docs.anthropic.com/
 
 ## Install
 
-Requires Python 3.11+ and [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (or [Codex CLI](https://github.com/openai/codex) for `--tap-client codex`).
+Requires Python 3.11+ and the CLI you want to trace: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), OpenCode, or [Cursor CLI](https://cursor.com/cli).
 
 ```bash
 # Recommended
@@ -91,6 +91,15 @@ claude-tap --tap-client codex -- --full-auto
 
 # OAuth + full auto + live viewer
 claude-tap --tap-client codex --tap-live -- --full-auto
+```
+
+### Cursor CLI
+
+Cursor CLI uses forward proxy mode by default. Use `--model auto` on free plans, and omit `--mode ask` when you want tool calls.
+
+```bash
+claude-tap --tap-client cursor -- -p --trust --model auto "hello"
+claude-tap --tap-client cursor -- -p --trust --model auto --continue "continue"
 ```
 
 ### Browser Preview
@@ -166,8 +175,8 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 
 **How it works:**
 
-1. `claude-tap` starts a reverse proxy and spawns the selected client (`claude` or `codex`) with the provider-specific base URL pointing to it
-2. Supported API requests flow through the proxy → upstream API → back through proxy
+1. `claude-tap` starts a reverse or forward proxy and spawns the selected client
+2. Base URL clients are pointed at the reverse proxy; clients without base URL support use proxy/CA environment variables
 3. SSE and WebSocket streams are forwarded as chunks/messages arrive with low proxy overhead
 4. Each request-response pair or WebSocket session is recorded to a dated `trace_*.jsonl`
 5. On exit, a self-contained HTML viewer is generated

--- a/README_zh.md
+++ b/README_zh.md
@@ -9,7 +9,7 @@
 
 [English](README.md)
 
-拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 或 [Codex CLI](https://github.com/openai/codex) 的 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、使用 token——通过一个美观的 trace 查看器。
+拦截并查看 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、OpenCode 或 [Cursor CLI](https://cursor.com/cli) 的 API 流量。看清它们如何构造 system prompt、管理对话历史、选择工具、使用 token——通过一个美观的 trace 查看器。
 
 ![演示](docs/demo_zh.gif)
 
@@ -26,7 +26,7 @@
 
 ## 安装
 
-需要 Python 3.11+ 和 [Claude Code](https://docs.anthropic.com/en/docs/claude-code)（使用 `--tap-client codex` 时需要 [Codex CLI](https://github.com/openai/codex)）。
+需要 Python 3.11+，以及你想 trace 的客户端：[Claude Code](https://docs.anthropic.com/en/docs/claude-code)、[Codex CLI](https://github.com/openai/codex)、OpenCode 或 [Cursor CLI](https://cursor.com/cli)。
 
 ```bash
 # 推荐
@@ -89,6 +89,15 @@ claude-tap --tap-client codex -- --full-auto
 
 # OAuth + 全自动 + 实时查看器
 claude-tap --tap-client codex --tap-live -- --full-auto
+```
+
+### Cursor CLI
+
+Cursor CLI 默认使用 forward proxy。免费套餐建议传 `--model auto`；需要工具调用时不要加 `--mode ask`。
+
+```bash
+claude-tap --tap-client cursor -- -p --trust --model auto "hello"
+claude-tap --tap-client cursor -- -p --trust --model auto --continue "continue"
 ```
 
 ### 浏览器预览
@@ -164,8 +173,8 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex -c 'openai_base_url="http://127.0
 
 **工作原理:**
 
-1. `claude-tap` 启动反向代理，并以对应服务商的 base URL 指向代理来启动所选客户端（`claude` 或 `codex`）
-2. 支持的 API 请求流经: 代理 → 上游 API → 代理返回
+1. `claude-tap` 启动反向代理或 forward proxy，并启动所选客户端
+2. 支持 base URL 的客户端会指向反向代理；不支持 base URL 的客户端会通过 proxy/CA 环境变量接入
 3. SSE 和 WebSocket 流会在收到 chunk/message 时实时转发，代理开销很低
 4. 每个请求-响应对或 WebSocket 会话记录到按日期保存的 `trace_*.jsonl`
 5. 退出时生成自包含的 HTML 查看器

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -12,6 +12,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 import webbrowser
@@ -23,6 +24,7 @@ import aiohttp
 from aiohttp import web
 
 from claude_tap.certs import CertificateAuthority, ensure_ca
+from claude_tap.cursor_transcript import import_cursor_transcripts
 from claude_tap.forward_proxy import ForwardProxyServer
 from claude_tap.live import LiveViewerServer
 from claude_tap.proxy import proxy_handler
@@ -107,6 +109,17 @@ CLIENT_CONFIGS: dict[str, ClientConfig] = {
         default_target="https://api.anthropic.com",
         default_proxy_mode="forward",
     ),
+    "cursor": ClientConfig(
+        cmd="cursor-agent",
+        label="Cursor CLI",
+        install_url="https://cursor.com/cli",
+        # Cursor CLI does not expose a provider base URL. Keep reverse-mode
+        # fields structurally valid, but default to forward proxy mode.
+        base_url_env="CURSOR_BASE_URL",
+        base_url_suffix="",
+        default_target="https://api2.cursor.sh",
+        default_proxy_mode="forward",
+    ),
 }
 
 
@@ -140,6 +153,7 @@ async def run_client(
         env["http_proxy"] = proxy_url
         env["https_proxy"] = proxy_url
         env["all_proxy"] = proxy_url
+        _extend_no_proxy(env, ("localhost", "127.0.0.1", "::1"))
         if ca_cert_path:
             env["NODE_EXTRA_CA_CERTS"] = str(ca_cert_path)
             # Codex is a Rust binary; NODE_EXTRA_CA_CERTS does not affect its TLS stack.
@@ -273,6 +287,27 @@ async def run_client(
     return code
 
 
+def _extend_no_proxy(env: dict[str, str], values: tuple[str, ...]) -> None:
+    """Append local proxy bypasses without discarding existing settings."""
+    existing: list[str] = []
+    for key in ("NO_PROXY", "no_proxy"):
+        raw = env.get(key, "")
+        existing.extend(part.strip() for part in raw.split(",") if part.strip())
+
+    merged: list[str] = []
+    seen: set[str] = set()
+    for value in [*existing, *values]:
+        lowered = value.lower()
+        if lowered in seen:
+            continue
+        seen.add(lowered)
+        merged.append(value)
+
+    no_proxy = ",".join(merged)
+    env["NO_PROXY"] = no_proxy
+    env["no_proxy"] = no_proxy
+
+
 def _has_config_override(args: list[str], key: str) -> bool:
     """Return True when argv already contains a matching -c/--config override."""
     prefixes = (f"{key}=",)
@@ -395,8 +430,10 @@ async def async_main(args: argparse.Namespace):
             pass
 
     exit_code = 0
+    client_started_at = time.time()
     try:
         if not args.no_launch:
+            client_started_at = time.time()
             try:
                 exit_code = await run_client(
                     actual_port,
@@ -415,13 +452,11 @@ async def async_main(args: argparse.Namespace):
             except asyncio.CancelledError:
                 pass
     finally:
-        try:
-            await session.close()
-        except Exception:
-            pass
         if forward_server:
             try:
-                await forward_server.stop()
+                await asyncio.wait_for(forward_server.stop(), timeout=10)
+            except asyncio.TimeoutError:
+                log.warning("Timed out stopping forward proxy")
             except Exception:
                 pass
         if runner:
@@ -436,6 +471,17 @@ async def async_main(args: argparse.Namespace):
                 await live_server.stop()
             except Exception:
                 pass
+        try:
+            await asyncio.wait_for(session.close(), timeout=5)
+        except asyncio.TimeoutError:
+            log.warning("Timed out closing upstream HTTP session")
+        except Exception:
+            pass
+
+        if args.client == "cursor" and not args.no_launch:
+            imported = await import_cursor_transcripts(writer, since=client_started_at)
+            if imported:
+                print(f"   Cursor transcript turns: {imported}")
 
         # Close writer before generating HTML
         writer.close()
@@ -519,7 +565,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
     tap_parser = argparse.ArgumentParser(
         prog="claude-tap",
-        description="Trace Claude Code or Codex API requests via a local proxy. "
+        description="Trace Claude Code, Codex CLI, OpenCode, or Cursor CLI API requests via a local proxy. "
         "All flags not listed below are forwarded to the selected client.",
         epilog=(
             "claude code:\n"
@@ -543,6 +589,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             "  claude-tap --tap-client opencode\n"
             "  # Force reverse mode (single ANTHROPIC_BASE_URL provider only)\n"
             "  claude-tap --tap-client opencode --tap-proxy-mode reverse\n"
+            "\n"
+            "cursor cli (defaults to forward proxy mode):\n"
+            '  claude-tap --tap-client cursor -- -p --trust --model auto "hello"\n'
+            "  # Cursor readable messages are imported from local transcripts after exit\n"
             "\n"
             "proxy-only mode (connect from another terminal):\n"
             "  claude-tap --tap-no-launch --tap-port 8080\n"
@@ -575,7 +625,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     proxy_group.add_argument(
         "--tap-client",
-        choices=["claude", "codex", "opencode"],
+        choices=["claude", "codex", "opencode", "cursor"],
         default="claude",
         dest="client",
         help="Client to launch (default: claude)",
@@ -593,7 +643,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         dest="proxy_mode",
         help=(
             "'reverse' sets provider base URL, 'forward' sets HTTPS_PROXY with CONNECT/TLS termination. "
-            "Default depends on the client: 'reverse' for claude/codex, 'forward' for opencode."
+            "Default depends on the client: 'reverse' for claude/codex, 'forward' for opencode/cursor."
         ),
     )
     proxy_group.add_argument(

--- a/claude_tap/cursor_transcript.py
+++ b/claude_tap/cursor_transcript.py
@@ -1,0 +1,206 @@
+"""Cursor CLI transcript import for viewer-friendly trace records."""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+from claude_tap.trace import TraceWriter
+
+
+def _cursor_projects_dir(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".cursor" / "projects"
+
+
+def _extract_content_blocks(message: object) -> list[dict]:
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    blocks: list[dict] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                blocks.append({"type": "text", "text": text})
+        elif item.get("type") == "tool_use":
+            name = item.get("name")
+            if not isinstance(name, str) or not name:
+                name = "Tool"
+            tool_input = item.get("input")
+            if not isinstance(tool_input, dict):
+                tool_input = {}
+            block = {"type": "tool_use", "name": name, "input": tool_input}
+            tool_id = item.get("id")
+            if isinstance(tool_id, str) and tool_id:
+                block["id"] = tool_id
+            blocks.append(block)
+    return blocks
+
+
+def _text_from_blocks(blocks: list[dict]) -> str:
+    return "\n".join(
+        block["text"] for block in blocks if block.get("type") == "text" and isinstance(block.get("text"), str)
+    ).strip()
+
+
+def _strip_cursor_wrappers(text: str) -> str:
+    """Remove Cursor's timestamp/query XML wrappers from user transcript text."""
+    match = re.search(r"<user_query>\s*(.*?)\s*</user_query>", text, flags=re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return re.sub(r"<timestamp>.*?</timestamp>\s*", "", text, flags=re.DOTALL).strip()
+
+
+def _load_transcript(path: Path) -> list[tuple[str, list[dict]]]:
+    messages: list[tuple[str, list[dict]]] = []
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return messages
+
+    for line in lines:
+        if not line.strip():
+            continue
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        role = record.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+        blocks = _extract_content_blocks(record.get("message"))
+        if not blocks:
+            continue
+        if role == "user":
+            text = _strip_cursor_wrappers(_text_from_blocks(blocks))
+            blocks = [{"type": "text", "text": text}] if text else []
+        messages.append((role, blocks))
+    return messages
+
+
+def _assistant_steps(messages: list[tuple[str, list[dict]]]) -> list[tuple[str, list[dict], int, int]]:
+    steps: list[tuple[str, list[dict], int, int]] = []
+    pending_user: str | None = None
+    cursor_turn = 0
+    cursor_step = 0
+
+    for role, blocks in messages:
+        if role == "user":
+            cursor_turn += 1
+            cursor_step = 0
+            pending_user = _text_from_blocks(blocks)
+        elif role == "assistant" and pending_user is not None:
+            cursor_step += 1
+            steps.append((pending_user, blocks or [{"type": "text", "text": ""}], cursor_turn, cursor_step))
+    return steps
+
+
+def _normalize_assistant_blocks(blocks: list[dict], *, turn_index: int) -> list[dict]:
+    normalized: list[dict] = []
+    for index, block in enumerate(blocks, start=1):
+        copied = dict(block)
+        if copied.get("type") == "tool_use" and not copied.get("id"):
+            copied["id"] = f"cursor_tool_{turn_index}_{index}"
+        normalized.append(copied)
+    return normalized
+
+
+def find_cursor_transcripts(
+    *,
+    since: float,
+    home: Path | None = None,
+) -> list[Path]:
+    """Return Cursor agent transcripts modified at or after ``since``."""
+    projects_dir = _cursor_projects_dir(home)
+    if not projects_dir.exists():
+        return []
+    candidates: list[tuple[float, Path]] = []
+    for path in projects_dir.glob("*/agent-transcripts/*/*.jsonl"):
+        try:
+            mtime = path.stat().st_mtime
+            if mtime >= since:
+                candidates.append((mtime, path))
+        except OSError:
+            continue
+    return [path for _, path in sorted(candidates, key=lambda item: item[0])]
+
+
+def build_cursor_transcript_records(
+    transcript_path: Path,
+    *,
+    start_turn: int,
+) -> list[dict]:
+    """Build Anthropic-shaped synthetic records from a Cursor transcript."""
+    session_id = transcript_path.stem
+    messages = _load_transcript(transcript_path)
+    steps = _assistant_steps(messages)
+    records: list[dict] = []
+    timestamp = datetime.now(timezone.utc).isoformat()
+
+    for index, (user_text, assistant_blocks, cursor_turn, cursor_step) in enumerate(steps, start=1):
+        turn = start_turn + index - 1
+        req_id = f"cursor_transcript_{uuid.uuid4().hex[:12]}"
+        response_content = _normalize_assistant_blocks(assistant_blocks, turn_index=index)
+        records.append(
+            {
+                "timestamp": timestamp,
+                "request_id": req_id,
+                "turn": turn,
+                "duration_ms": 0,
+                "transport": "cursor-transcript",
+                "request": {
+                    "method": "CURSOR_TRANSCRIPT",
+                    "path": f"/cursor/transcript/{session_id}/turn/{cursor_turn}/step/{cursor_step}",
+                    "headers": {},
+                    "body": {
+                        "model": "cursor-auto",
+                        "cursor_turn": cursor_turn,
+                        "cursor_step": cursor_step,
+                        "messages": [{"role": "user", "content": user_text}],
+                    },
+                },
+                "response": {
+                    "status": 200,
+                    "headers": {},
+                    "body": {
+                        "id": session_id,
+                        "type": "message",
+                        "role": "assistant",
+                        "content": response_content,
+                    },
+                },
+            }
+        )
+    return records
+
+
+async def import_cursor_transcripts(
+    writer: TraceWriter,
+    *,
+    since: float,
+    home: Path | None = None,
+) -> int:
+    """Append recent Cursor transcripts to the active trace.
+
+    Cursor CLI persists readable user/assistant messages locally, while its
+    network payloads are protobuf-oriented. Importing transcripts gives the
+    HTML viewer a readable multi-turn conversation without reverse-engineering
+    Cursor's private wire schema.
+    """
+    imported = 0
+    start_turn = writer.count + 1
+    for transcript_path in find_cursor_transcripts(since=since, home=home):
+        records = build_cursor_transcript_records(transcript_path, start_turn=start_turn + imported)
+        for record in records:
+            await writer.write(record)
+            imported += 1
+    return imported

--- a/claude_tap/forward_proxy.py
+++ b/claude_tap/forward_proxy.py
@@ -93,6 +93,8 @@ class ForwardProxyServer:
         self._writer = writer
         self._session = session
         self._server: asyncio.Server | None = None
+        self._client_tasks: set[asyncio.Task] = set()
+        self._client_writers: set[asyncio.StreamWriter] = set()
         self._turn_counter = 0
         self.actual_port: int = port
 
@@ -107,9 +109,26 @@ class ForwardProxyServer:
         if self._server:
             self._server.close()
             await self._server.wait_closed()
+        for writer in list(self._client_writers):
+            try:
+                writer.close()
+            except Exception:
+                pass
+        tasks = [task for task in self._client_tasks if not task.done()]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            try:
+                await asyncio.wait_for(asyncio.gather(*tasks, return_exceptions=True), timeout=5)
+            except asyncio.TimeoutError:
+                log.warning("Timed out waiting for forward proxy client connections to stop")
 
     async def _handle_client(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
         """Handle an incoming client connection."""
+        current_task = asyncio.current_task()
+        if current_task is not None:
+            self._client_tasks.add(current_task)
+        self._client_writers.add(writer)
         try:
             # Read the initial HTTP request line
             request_line = await asyncio.wait_for(reader.readline(), timeout=30)
@@ -136,6 +155,9 @@ class ForwardProxyServer:
         except Exception:
             log.exception("Error handling forward proxy connection")
         finally:
+            if current_task is not None:
+                self._client_tasks.discard(current_task)
+            self._client_writers.discard(writer)
             try:
                 writer.close()
                 await writer.wait_closed()

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -20,6 +20,7 @@ This document tracks all verified (client × auth × target × transport) combin
 | Codex CLI | OAuth (`codex login`) | `https://chatgpt.com/backend-api/codex` | `/v1` | WebSocket | Verified |
 | OpenCode | Provider creds via `opencode providers` | Forward proxy (any HTTPS upstream) | n/a | HTTP/SSE | Unit-tested |
 | OpenCode | Anthropic provider only (`--tap-proxy-mode reverse`) | `https://api.anthropic.com` | none | HTTP/SSE | Unit-tested |
+| Cursor CLI | Cursor login (`cursor-agent login`) | Forward proxy to `https://api2.cursor.sh` | n/a | HTTPS/protobuf + local transcript import | Real E2E verified |
 
 ## Default Proxy Mode by Client
 
@@ -31,6 +32,7 @@ Each client in `CLIENT_CONFIGS` declares a `default_proxy_mode` used when
 | `claude` | `reverse` | Single provider, native `ANTHROPIC_BASE_URL` env var |
 | `codex` | `reverse` | Single provider, native `OPENAI_BASE_URL` env var |
 | `opencode` | `forward` | Multi-provider; forward proxy captures every upstream regardless of which env var the client honors |
+| `cursor` | `forward` | Cursor CLI has no base URL override; forward proxy captures network traffic and local transcripts provide readable turns |
 
 Users can always override with `--tap-proxy-mode {reverse,forward}`.
 
@@ -65,6 +67,10 @@ strip = "/v1" if client == "codex" and "api.openai.com" not in target else ""
 - `test_codex_upstream_url_construction` — verifies URL construction for all 5 matrix combinations
 - `test_codex_client_reverse_proxy` — e2e with fake upstream (OAuth-like, with strip)
 - `test_websocket_proxy_basic` — WS relay and trace recording
+- `test_cursor_registered_in_client_configs` — verifies Cursor CLI registration and default forward mode
+- `test_run_client_cursor_forward_sets_proxy_ca_and_no_proxy` — verifies Cursor launch env for forward proxy mode
+- `test_import_cursor_transcripts_appends_viewer_friendly_records` — verifies readable Cursor transcript import
+- `test_import_cursor_transcripts_preserves_tool_uses` — verifies Cursor tool_use blocks render in the viewer trace shape
 
 ### Manual (pre-merge for proxy changes)
 
@@ -77,6 +83,10 @@ uv run python -m claude_tap --tap-client codex --tap-no-launch --tap-port 0
 uv run python -m claude_tap --tap-client codex \
   --tap-target https://chatgpt.com/backend-api/codex --tap-no-launch --tap-port 0
 # Verify log shows correct upstream URL
+
+# Cursor CLI
+uv run python -m claude_tap --tap-client cursor -- -p --trust --model auto "Reply OK"
+# Verify the trace contains raw proxy records plus cursor-transcript records
 ```
 
 ### Real E2E (optional, when auth is available)
@@ -87,6 +97,13 @@ tmux new-session -d -s verify \
   "uv run python -m claude_tap --tap-client codex --tap-target TARGET --tap-no-launch --tap-port 8080"
 # In another window:
 OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex exec "Reply: OK"
+```
+
+```bash
+# Cursor CLI real verification
+uv run python -m claude_tap --tap-client cursor -- -p --trust --model auto \
+  "Use tools to inspect the workspace and reply OK"
+# Verify the generated HTML contains cursor-transcript turns and tool_use blocks.
 ```
 
 ## Adding New Clients or Backends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
 name = "claude-tap"
 dynamic = ["version"]
-description = "Trace Claude Code API requests via a local reverse proxy. Inspect system prompts, messages, tools, and token usage."
+description = "Trace AI CLI API requests via local reverse and forward proxies. Inspect system prompts, messages, tools, and token usage."
 requires-python = ">=3.11"
 license = "MIT"
 authors = [{ name = "liaohch3" }]
 readme = "README.md"
-keywords = ["claude", "claude-code", "trace", "proxy", "api", "llm", "context-engineering"]
+keywords = ["claude", "claude-code", "codex", "cursor", "trace", "proxy", "api", "llm", "context-engineering"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Environment :: Console",

--- a/tests/test_cursor_launch.py
+++ b/tests/test_cursor_launch.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_tap import parse_args
+from claude_tap.cli import CLIENT_CONFIGS, run_client
+from claude_tap.cursor_transcript import import_cursor_transcripts
+from claude_tap.trace import TraceWriter
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.pid = 12345
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def test_cursor_registered_in_client_configs() -> None:
+    cfg = CLIENT_CONFIGS["cursor"]
+    assert cfg.cmd == "cursor-agent"
+    assert cfg.default_target == "https://api2.cursor.sh"
+    assert cfg.default_proxy_mode == "forward"
+
+
+def test_parse_args_cursor_defaults_to_forward_mode() -> None:
+    args = parse_args(["--tap-client", "cursor"])
+    assert args.client == "cursor"
+    assert args.proxy_mode == "forward"
+
+
+@pytest.mark.asyncio
+async def test_run_client_cursor_forward_sets_proxy_ca_and_no_proxy(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    ca_path = Path("/tmp/test-ca.pem")
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setenv("NO_PROXY", "example.com")
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda _: "/tmp/cursor-agent")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(
+        43123,
+        ["-p", "--trust", "--model", "auto", "hello"],
+        client="cursor",
+        proxy_mode="forward",
+        ca_cert_path=ca_path,
+    )
+
+    assert code == 0
+    assert captured["cmd"] == ("/tmp/cursor-agent", "-p", "--trust", "--model", "auto", "hello")
+    env = captured["env"]
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:43123"
+    assert env["NODE_EXTRA_CA_CERTS"] == str(ca_path)
+    assert "example.com" in env["NO_PROXY"]
+    assert "localhost" in env["NO_PROXY"]
+    assert "127.0.0.1" in env["NO_PROXY"]
+    assert "::1" in env["NO_PROXY"]
+    assert env["no_proxy"] == env["NO_PROXY"]
+
+
+@pytest.mark.asyncio
+async def test_import_cursor_transcripts_appends_viewer_friendly_records(tmp_path: Path) -> None:
+    session_id = "session-123"
+    transcript = (
+        tmp_path / ".cursor" / "projects" / "project-one" / "agent-transcripts" / session_id / f"{session_id}.jsonl"
+    )
+    transcript.parent.mkdir(parents=True)
+    rows = [
+        {
+            "role": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "text",
+                        "text": "<timestamp>now</timestamp>\n<user_query>\nhello cursor\n</user_query>",
+                    }
+                ]
+            },
+        },
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "hello back"}]}},
+        {"role": "user", "message": {"content": [{"type": "text", "text": "second turn"}]}},
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "second answer"}]}},
+    ]
+    transcript.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    writer = TraceWriter(tmp_path / "trace.jsonl")
+    imported = await import_cursor_transcripts(writer, since=0, home=tmp_path)
+    writer.close()
+
+    assert imported == 2
+    records = [json.loads(line) for line in (tmp_path / "trace.jsonl").read_text().splitlines()]
+    assert records[0]["transport"] == "cursor-transcript"
+    assert records[0]["request"]["body"]["messages"][0]["content"] == "hello cursor"
+    assert records[0]["response"]["body"]["content"][0]["text"] == "hello back"
+    assert records[1]["request"]["body"]["messages"][0]["content"] == "second turn"
+    assert records[1]["response"]["body"]["content"][0]["text"] == "second answer"
+
+
+@pytest.mark.asyncio
+async def test_import_cursor_transcripts_preserves_tool_uses(tmp_path: Path) -> None:
+    session_id = "tool-session"
+    transcript = (
+        tmp_path / ".cursor" / "projects" / "project-one" / "agent-transcripts" / session_id / f"{session_id}.jsonl"
+    )
+    transcript.parent.mkdir(parents=True)
+    rows = [
+        {"role": "user", "message": {"content": [{"type": "text", "text": "inspect files"}]}},
+        {
+            "role": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "I will inspect the workspace."},
+                    {
+                        "type": "tool_use",
+                        "name": "Shell",
+                        "input": {"command": "pwd && ls", "working_directory": "/tmp/work"},
+                    },
+                ]
+            },
+        },
+        {
+            "role": "assistant",
+            "message": {
+                "content": [{"type": "tool_use", "name": "ReadFile", "input": {"path": "/tmp/work/sample.txt"}}]
+            },
+        },
+        {"role": "assistant", "message": {"content": [{"type": "text", "text": "done"}]}},
+    ]
+    transcript.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+    writer = TraceWriter(tmp_path / "trace.jsonl")
+    imported = await import_cursor_transcripts(writer, since=0, home=tmp_path)
+    writer.close()
+
+    assert imported == 3
+    records = [json.loads(line) for line in (tmp_path / "trace.jsonl").read_text().splitlines()]
+
+    assert records[0]["request"]["path"].endswith("/turn/1/step/1")
+    assert records[1]["request"]["path"].endswith("/turn/1/step/2")
+    assert records[2]["request"]["path"].endswith("/turn/1/step/3")
+    assert records[1]["request"]["body"]["messages"][0]["content"] == "inspect files"
+
+    content = records[0]["response"]["body"]["content"]
+    assert content[0] == {"type": "text", "text": "I will inspect the workspace."}
+    assert content[1]["type"] == "tool_use"
+    assert content[1]["name"] == "Shell"
+    assert content[1]["id"] == "cursor_tool_1_2"
+
+    assert records[1]["response"]["body"]["content"][0]["name"] == "ReadFile"
+    assert records[2]["response"]["body"]["content"] == [{"type": "text", "text": "done"}]


### PR DESCRIPTION
## Summary
- Add `--tap-client cursor` with forward proxy defaults because Cursor CLI does not expose a base URL override.
- Import Cursor's local agent transcripts after the command exits so the HTML viewer can show readable messages and `tool_use` blocks.
- Split each Cursor assistant transcript step into its own synthetic `cursor-transcript` span, so a tool-use flow renders as separate tool-call and final-answer spans.
- Harden forward proxy shutdown for Cursor's long-lived CONNECT/TLS connections, and document Cursor usage in README/support matrix.

## Type
- [ ] Bug fix
- [x] Feature
- [x] Documentation
- [x] Test or tooling
- [ ] Maintenance

## Background
- Current limitation: Cursor CLI traffic is protobuf-oriented and cannot be made readable by a simple reverse-proxy base URL override.
- Why this feature is being added now: Cursor CLI can still be traced reliably with forward proxy mode, and readable conversations are available from Cursor's local agent transcript files.

## Scope
- Areas touched: CLI client registration, forward proxy launch env, Cursor transcript import, forward proxy cleanup, README/README_zh, support matrix, unit tests.
- Explicitly not changed: no protobuf schema reverse engineering; raw proxy records are still preserved, while readable messages/tool calls come from local transcripts.

## Validation
- [x] `.venv/bin/python -m ruff check .`
- [x] `.venv/bin/python -m ruff format --check .`
- [x] `PATH="$PWD/.venv/bin:$PATH" .venv/bin/python -m pytest -q`
- [x] Functional Cursor CLI E2E verification is listed below
- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.

## Results
- Full test suite: `202 passed, 25 skipped, 4 warnings`.
- Real Cursor CLI E2E: `claude-tap --tap-client cursor -- -p --trust --model auto --workspace ...` successfully let Cursor use `ReadFile` to read `sample.txt` and reply with the expected marker/content.
- Generated HTML trace was checked locally and now contains two effective `cursor-transcript` spans for the tool flow:
  - `/turn/1/step/1`: assistant text + `ReadFile` tool_use
  - `/turn/1/step/2`: final answer text

## Follow-up
- Cursor's local transcript format is not a public stability contract. If Cursor changes that layout, claude-tap will still capture raw proxy records, but readable transcript import may need an update.