### PR TITLE
chore: update changelog for v0.1.46

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.46] - 2026-05-06
+
+### Changed
+- feat(cli): support cursor cli tracing (#119)
 ## [0.1.45] - 2026-05-05
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.46. Auto-merge will continue the release after checks pass.