### PR TITLE
Fix OpenCode link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Intercept and inspect API traffic from [Claude Code](https://docs.anthropic.com/
 
 ## Install
 
-Requires Python 3.11+ and the CLI you want to trace: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), OpenCode, or [Cursor CLI](https://cursor.com/cli).
+Requires Python 3.11+ and the CLI you want to trace: [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Codex CLI](https://github.com/openai/codex), [OpenCode](https://github.com/anomalyco/opencode), or [Cursor CLI](https://cursor.com/cli).
 
 ```bash
 # Recommended


### PR DESCRIPTION
Updated OpenCode link in installation instructions.

## Summary

-

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Test or tooling
- [ ] Maintenance

## Validation

- [ ] `uv run ruff check .`
- [ ] `uv run ruff format --check .`
- [ ] `uv run pytest tests/ -x --timeout=60`
- [ ] Not required; docs-only or metadata-only change.

## Privacy

- [ ] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.
