### PR TITLE
docs: collapse detailed README sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,29 +40,45 @@ pip install claude-tap
 
 Upgrade: `uv tool upgrade claude-tap` or `pip install --upgrade claude-tap`
 
-## Usage
+## Quick Start
 
-### Claude Code
+Run the client you want to inspect through `claude-tap`:
 
 ```bash
-# Basic — launch Claude Code with tracing
+# Claude Code
 claude-tap
 
-# Live mode — watch API calls in real-time in browser
+# Claude Code with live browser viewer
 claude-tap --tap-live
 
-# Pass any flags through to Claude Code
+# Codex CLI
+claude-tap --tap-client codex
+
+# Cursor CLI
+claude-tap --tap-client cursor -- -p --trust --model auto "hello"
+```
+
+Flags that are not `--tap-*` are forwarded to the selected client after `--`.
+
+<details>
+<summary>Claude Code examples</summary>
+
+```bash
+# Pass flags through to Claude Code
 claude-tap -- --model claude-opus-4-6
 claude-tap -c    # continue last conversation
 
 # Skip all permission prompts (auto-accept tool calls)
 claude-tap -- --dangerously-skip-permissions
 
-# Full-power combo: live viewer + skip permissions + specific model
+# Live viewer + skip permissions + specific model
 claude-tap --tap-live -- --dangerously-skip-permissions --model claude-sonnet-4-6
 ```
 
-### Codex CLI
+</details>
+
+<details>
+<summary>Codex CLI auth modes and examples</summary>
 
 Codex CLI supports two authentication modes with different upstream targets:
 
@@ -93,7 +109,10 @@ claude-tap --tap-client codex -- --full-auto
 claude-tap --tap-client codex --tap-live -- --full-auto
 ```
 
-### Cursor CLI
+</details>
+
+<details>
+<summary>Cursor CLI examples</summary>
 
 Cursor CLI uses forward proxy mode by default. Use `--model auto` on free plans, and omit `--mode ask` when you want tool calls.
 
@@ -102,7 +121,10 @@ claude-tap --tap-client cursor -- -p --trust --model auto "hello"
 claude-tap --tap-client cursor -- -p --trust --model auto --continue "continue"
 ```
 
-### Browser Preview
+</details>
+
+<details>
+<summary>Browser preview, export, and proxy-only mode</summary>
 
 ```bash
 # Disable auto-open of HTML viewer after exit (on by default)
@@ -131,7 +153,7 @@ claude-tap export .traces/2026-02-28/trace_141557.jsonl -o trace.html
 claude-tap export .traces/2026-02-28/trace_141557.jsonl --format html
 ```
 
-### Proxy-Only Mode
+### Proxy-only mode
 
 Start the proxy without launching a client — useful for custom setups or connecting from a separate terminal:
 
@@ -154,7 +176,12 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex -c 'openai_base_url="http://127.0
 
 Run `claude-tap --help` for all options. Flags that are not `--tap-*` are forwarded to the selected client.
 
+</details>
+
 ## Viewer Features
+
+<details>
+<summary>Trace viewer capabilities</summary>
 
 The viewer is a single self-contained HTML file (zero external dependencies):
 
@@ -169,9 +196,14 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 - **Copy helpers** — one-click copy of request JSON or cURL command
 - **i18n** — English, 简体中文, 日本語, 한국어, Français, العربية, Deutsch, Русский
 
+</details>
+
 ## Architecture
 
 ![Architecture](docs/architecture.png)
+
+<details>
+<summary>How it works</summary>
 
 **How it works:**
 
@@ -183,6 +215,8 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 6. Live mode (optional) broadcasts updates to browser via SSE
 
 **Key features:** 🔒 Common auth headers auto-redacted · ⚡ Low-overhead streaming · 📦 Self-contained viewer · 🔄 Real-time live mode
+
+</details>
 
 ## Community
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -38,17 +38,30 @@ pip install claude-tap
 
 升级: `uv tool upgrade claude-tap` 或 `pip install --upgrade claude-tap`
 
-## 使用
+## 快速开始
 
-### Claude Code
+用 `claude-tap` 启动你想观察的客户端：
 
 ```bash
-# 基本用法 — 启动带 trace 的 Claude Code
+# Claude Code
 claude-tap
 
-# 实时模式 — 在浏览器中实时观察 API 调用
+# Claude Code + 浏览器实时查看
 claude-tap --tap-live
 
+# Codex CLI
+claude-tap --tap-client codex
+
+# Cursor CLI
+claude-tap --tap-client cursor -- -p --trust --model auto "hello"
+```
+
+非 `--tap-*` 参数会在 `--` 后透传给所选客户端。
+
+<details>
+<summary>Claude Code 更多示例</summary>
+
+```bash
 # 透传参数给 Claude Code
 claude-tap -- --model claude-opus-4-6
 claude-tap -c    # 继续上次对话
@@ -56,11 +69,14 @@ claude-tap -c    # 继续上次对话
 # 跳过所有权限确认（自动批准工具调用）
 claude-tap -- --dangerously-skip-permissions
 
-# 全功能组合：实时查看器 + 跳过权限确认 + 指定模型
+# 实时查看器 + 跳过权限确认 + 指定模型
 claude-tap --tap-live -- --dangerously-skip-permissions --model claude-sonnet-4-6
 ```
 
-### Codex CLI
+</details>
+
+<details>
+<summary>Codex CLI 认证方式和示例</summary>
 
 Codex CLI 支持两种认证方式，对应不同的上游目标：
 
@@ -91,7 +107,10 @@ claude-tap --tap-client codex -- --full-auto
 claude-tap --tap-client codex --tap-live -- --full-auto
 ```
 
-### Cursor CLI
+</details>
+
+<details>
+<summary>Cursor CLI 示例</summary>
 
 Cursor CLI 默认使用 forward proxy。免费套餐建议传 `--model auto`；需要工具调用时不要加 `--mode ask`。
 
@@ -100,7 +119,10 @@ claude-tap --tap-client cursor -- -p --trust --model auto "hello"
 claude-tap --tap-client cursor -- -p --trust --model auto --continue "continue"
 ```
 
-### 浏览器预览
+</details>
+
+<details>
+<summary>浏览器预览、导出和纯代理模式</summary>
 
 ```bash
 # 禁用退出后自动打开 HTML 查看器（默认开启）
@@ -152,7 +174,12 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex -c 'openai_base_url="http://127.0
 
 运行 `claude-tap --help` 查看完整选项。非 `--tap-*` 参数会透传给所选客户端。
 
+</details>
+
 ## 查看器功能
+
+<details>
+<summary>Trace 查看器能力</summary>
 
 查看器是一个自包含的 HTML 文件（零外部依赖）：
 
@@ -167,9 +194,14 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex -c 'openai_base_url="http://127.0
 - **复制助手** — 一键复制请求 JSON 或 cURL 命令
 - **多语言** — English, 简体中文, 日本語, 한국어, Français, العربية, Deutsch, Русский
 
+</details>
+
 ## 架构
 
 ![架构图](docs/architecture.png)
+
+<details>
+<summary>工作原理</summary>
 
 **工作原理:**
 
@@ -181,6 +213,8 @@ OPENAI_BASE_URL=http://127.0.0.1:8080/v1 codex -c 'openai_base_url="http://127.0
 6. 实时模式（可选）通过 SSE 向浏览器广播更新
 
 **核心特性:** 🔒 常见认证 header 自动脱敏 · ⚡ 低开销流式转发 · 📦 自包含查看器 · 🔄 实时模式
+
+</details>
 
 ## 社区
 


### PR DESCRIPTION
## Summary
- Convert README and README_zh to a shorter rendered homepage with quick-start commands up front.
- Put detailed Claude/Codex/Cursor examples, browser/export/proxy usage, viewer capabilities, architecture details, and community tables behind `<details>` sections.
- Keep existing screenshots and contributor markers intact.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -x --timeout=60`
- `git diff --check`
- Checked `<details>` open/close counts for both READMEs.

## Evidence
README-only rendered-content change. Existing real viewer screenshot for PR evidence gate:

![viewer light](https://raw.githubusercontent.com/liaohch3/claude-tap/docs/collapse-readme-details/docs/viewer-light.png)