### PR TITLE
Fix dotted WebSocket turn ordering

### DIFF
--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -2098,6 +2098,25 @@ function makeFilterChip(p, count) {
   return chip;
 }
 
+function turnSortSegments(value) {
+  if (value === undefined || value === null || value === '') return [0];
+  return String(value).split('.').map(part => {
+    const num = Number(part);
+    return Number.isFinite(num) ? num : 0;
+  });
+}
+
+function compareTurns(a, b) {
+  const aa = turnSortSegments(a);
+  const bb = turnSortSegments(b);
+  const len = Math.max(aa.length, bb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (aa[i] || 0) - (bb[i] || 0);
+    if (diff) return diff;
+  }
+  return String(a ?? '').localeCompare(String(b ?? ''));
+}
+
 function applyFilter(preserveDetail) {
   filtered = entries.filter(e => activePaths.has(getPath(e)));
   if (searchQuery) filtered = filtered.filter(e => matchSearch(e, searchQuery));
@@ -2109,7 +2128,7 @@ function applyFilter(preserveDetail) {
       return rc.some(b => b.type === 'tool_use' && activeTools.has(b.name));
     });
   }
-  filtered.sort((a, b) => (a.turn || 0) - (b.turn || 0));
+  filtered.sort((a, b) => compareTurns(a.turn, b.turn));
   let totalTokens = 0, totalDuration = 0;
   let sumInput = 0, sumOutput = 0, sumCacheRead = 0, sumCacheCreate = 0;
   filtered.forEach(e => {

--- a/tests/test_responses_browser.py
+++ b/tests/test_responses_browser.py
@@ -93,6 +93,42 @@ def test_viewer_treats_codex_forward_websocket_path_as_primary(responses_page) -
     assert result == {"tier": 0, "primary": True}
 
 
+def test_viewer_sorts_dotted_websocket_turns_by_numeric_segments(responses_page) -> None:
+    result = responses_page.evaluate(
+        """() => {
+          const makeEntry = (turn) => ({
+            timestamp: '2026-05-07T10:00:00Z',
+            request_id: 'req_' + turn,
+            turn,
+            duration_ms: 1,
+            request: {
+              method: 'POST',
+              path: '/backend-api/codex/responses',
+              body: { model: 'gpt-test' }
+            },
+            response: {
+              status: 200,
+              body: { usage: { input_tokens: 1, output_tokens: 1 }, output: [] }
+            }
+          });
+          entries = [makeEntry('1.12'), makeEntry('1.2'), makeEntry(2)];
+          activePaths = new Set(['/backend-api/codex/responses']);
+          searchQuery = '';
+          activeTools = null;
+          applyFilter(false);
+          return {
+            filteredTurns: filtered.map(e => e.turn),
+            sidebarTurns: [...document.querySelectorAll('.sidebar-item .si-turn')].map(el => el.textContent)
+          };
+        }"""
+    )
+
+    assert result == {
+        "filteredTurns": ["1.2", "1.12", 2],
+        "sidebarTurns": ["Turn 1.2", "Turn 1.12", "Turn 2"],
+    }
+
+
 def test_viewer_expands_codex_websocket_session_into_response_entries(codex_ws_multi_page) -> None:
     result = codex_ws_multi_page.evaluate(
         """() => ({


### PR DESCRIPTION
## Summary

Fix dotted WebSocket turn ordering.

修改前，会话 1.12 会排在 会话 1.2 之前，通过小数点分割后按照整数和小数来排序

## Type

- [x] Bug fix

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -x --timeout=60`

## Privacy

- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.
