### PR TITLE
fix(viewer): count Responses function calls

### DIFF
--- a/claude_tap/viewer.py
+++ b/claude_tap/viewer.py
@@ -123,6 +123,17 @@ def _normalize_record_for_viewer(record_json: str) -> str:
     return json.dumps(record, ensure_ascii=False, separators=(",", ":"))
 
 
+def _parse_function_call_arguments(arguments: object) -> object:
+    if isinstance(arguments, str):
+        try:
+            return json.loads(arguments)
+        except (json.JSONDecodeError, TypeError):
+            return arguments
+    if arguments is None:
+        return {}
+    return arguments
+
+
 def _extract_request_messages(body: dict) -> list[dict]:
     if not isinstance(body, dict):
         return []
@@ -138,7 +149,25 @@ def _extract_request_messages(body: dict) -> list[dict]:
     for item in inp:
         if not isinstance(item, dict):
             continue
-        if item.get("type") not in (None, "message") and "role" not in item:
+        item_type = item.get("type")
+        if item_type == "function_call":
+            normalized.append(
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": item.get("name", ""),
+                            "input": _parse_function_call_arguments(item.get("arguments")),
+                        }
+                    ],
+                }
+            )
+            continue
+        if item_type == "function_call_output":
+            normalized.append({"role": "tool", "content": item.get("output", "")})
+            continue
+        if item_type not in (None, "message") and "role" not in item:
             continue
         role = item.get("role")
         if not isinstance(role, str) or not role:

--- a/tests/test_responses_support.py
+++ b/tests/test_responses_support.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from claude_tap.sse import SSEReassembler
-from claude_tap.viewer import _extract_metadata
+from claude_tap.viewer import _extract_metadata, _extract_request_messages
 
 
 def test_sse_reassembler_reconstructs_openai_responses_completed_event() -> None:
@@ -99,6 +99,82 @@ def test_extract_metadata_supports_interleaved_responses_roles_without_type() ->
     assert meta["message_count"] == 3
     assert meta["input_tokens"] == 1
     assert meta["output_tokens"] == 1
+
+
+def test_extract_metadata_counts_responses_function_call_input_items() -> None:
+    record = {
+        "turn": 1,
+        "request": {
+            "method": "POST",
+            "path": "/v1/responses",
+            "body": {
+                "model": "gpt-5.4",
+                "instructions": "Use tools when needed.",
+                "input": [
+                    {"role": "user", "content": [{"type": "input_text", "text": "Read pyproject."}]},
+                    {
+                        "type": "function_call",
+                        "name": "read_file",
+                        "arguments": '{"path":"pyproject.toml"}',
+                    },
+                    {
+                        "type": "function_call_output",
+                        "call_id": "call_1",
+                        "output": '[project]\nname = "claude-tap"',
+                    },
+                ],
+                "tools": [{"type": "function", "name": "read_file"}],
+            },
+        },
+        "response": {"status": 200, "body": {"usage": {"input_tokens": 4, "output_tokens": 2}}},
+    }
+
+    meta = _extract_metadata(json.dumps(record))
+
+    assert meta is not None
+    assert meta["message_count"] == 3
+    assert meta["has_system"] is True
+    assert meta["input_tokens"] == 4
+    assert meta["output_tokens"] == 2
+    assert "read_file" in meta["tool_names"]
+
+
+def test_extract_request_messages_normalizes_responses_function_call_input_items() -> None:
+    messages = _extract_request_messages(
+        {
+            "input": [
+                {"role": "user", "content": [{"type": "input_text", "text": "Read pyproject."}]},
+                {
+                    "type": "function_call",
+                    "name": "read_file",
+                    "arguments": '{"path":"pyproject.toml"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_1",
+                    "output": '[project]\nname = "claude-tap"',
+                },
+                {
+                    "type": "function_call",
+                    "name": "shell",
+                    "arguments": "not json",
+                },
+                {
+                    "type": "function_call",
+                    "name": "missing_args",
+                },
+            ]
+        }
+    )
+
+    assert messages[0]["role"] == "user"
+    assert messages[1] == {
+        "role": "assistant",
+        "content": [{"type": "tool_use", "name": "read_file", "input": {"path": "pyproject.toml"}}],
+    }
+    assert messages[2] == {"role": "tool", "content": '[project]\nname = "claude-tap"'}
+    assert messages[3]["content"][0]["input"] == "not json"
+    assert messages[4]["content"][0]["input"] == {}
 
 
 def test_extract_metadata_ignores_list_response_body() -> None:


### PR DESCRIPTION
## Summary

- Normalize Responses API function_call input items in the Python request metadata extractor.
- Normalize function_call_output input items so sidebar metadata counts tool results too.
- Parse function_call.arguments as JSON when possible, falling back to the raw value when it is not valid JSON.

This carries forward the remaining Python-side value from #59 without rescuing the stale/conflicting branch.

## Testing

- uv run pytest tests/test_responses_support.py -x --timeout=60
- uv run ruff check .
- uv run ruff format --check .
- git rebase origin/main
- uv lock --check
- uv run pytest tests/ -x --timeout=60

## Screenshot evidence

N/A: Python metadata extraction only. No browser/UI rendering code changed.