### PR TITLE
chore: update changelog for v0.1.49

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.49] - 2026-05-07
+
+### Changed
+- fix(viewer): count Responses function calls (#131)
 ## [0.1.48] - 2026-05-07
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.49. Auto-merge will continue the release after checks pass.