### PR TITLE
chore: update changelog for v0.1.53

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.53] - 2026-05-08
+
+### Changed
+- docs: strengthen Kimi evidence with real multiturn trace (#141)
 ## [0.1.52] - 2026-05-08
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.53. Auto-merge will continue the release after checks pass.