### PR TITLE
chore: update changelog for v0.1.55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.55] - 2026-05-09
+
+### Changed
+- fix(viewer): generalize Responses tool item normalization (#145)
 ## [0.1.54] - 2026-05-09
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.55. Auto-merge will continue the release after checks pass.