### PR TITLE
chore: update changelog for v0.1.56

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.56] - 2026-05-11
+
+### Changed
+- fix(viewer): interleave Codex tool results (#151)
 ## [0.1.55] - 2026-05-09
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.56. Auto-merge will continue the release after checks pass.