### PR TITLE
chore: update changelog for v0.1.57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.57] - 2026-05-11
+
+### Changed
+- fix(viewer): improve diff targets and tool details (#148)
 ## [0.1.56] - 2026-05-11
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.57. Auto-merge will continue the release after checks pass.