### PR TITLE
chore: update changelog for v0.1.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.59] - 2026-05-11
+
+### Changed
+- feat(cli): add hermes-agent client (forward proxy by default) (#97)
 ## [0.1.58] - 2026-05-11
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.59. Auto-merge will continue the release after checks pass.