### PR TITLE
chore: update changelog for v0.1.60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.60] - 2026-05-11
+
+### Changed
+- add --tap-allow-path argument to support custom api prefixes (#122)
 ## [0.1.59] - 2026-05-11
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.60. Auto-merge will continue the release after checks pass.