### PR TITLE
refactor(cli): support multiple reverse base URL envs

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -63,6 +63,7 @@ class ClientConfig:
     base_url_env: str
     base_url_suffix: str  # appended to http://127.0.0.1:{port}
     default_target: str
+    extra_base_url_envs: tuple[str, ...] = ()
     nesting_env_keys: tuple[str, ...] = ()  # env vars to clear before launch
     # Some CLIs need process env duplicated into a CLI settings payload.
     inject_settings_env: bool = False
@@ -85,6 +86,21 @@ class ClientConfig:
 
     def reverse_base_url(self, port: int) -> str:
         return f"http://127.0.0.1:{port}{self.base_url_suffix}"
+
+    @property
+    def reverse_base_url_envs(self) -> tuple[str, ...]:
+        seen: set[str] = set()
+        env_keys: list[str] = []
+        for env_key in (self.base_url_env, *self.extra_base_url_envs):
+            if env_key in seen:
+                continue
+            seen.add(env_key)
+            env_keys.append(env_key)
+        return tuple(env_keys)
+
+    def reverse_base_url_env_map(self, port: int) -> dict[str, str]:
+        base_url = self.reverse_base_url(port)
+        return {env_key: base_url for env_key in self.reverse_base_url_envs}
 
     def reverse_strip_path_prefix(self, target: str) -> str:
         if not self.strip_path_prefix:
@@ -222,14 +238,15 @@ async def run_client(
                 cmd_args = _settings_arg(settings_payload["env"]) + cmd_args
         # Don't set provider-specific base URL in forward mode
     else:
-        base_url = cfg.reverse_base_url(port)
-        env[cfg.base_url_env] = base_url
+        reverse_env = cfg.reverse_base_url_env_map(port)
+        env.update(reverse_env)
         env["NO_PROXY"] = "127.0.0.1"
         if cfg.inject_settings_env and not _has_settings_arg(cmd_args):
-            cmd_args = _settings_arg({cfg.base_url_env: base_url}) + cmd_args
+            cmd_args = _settings_arg(reverse_env) + cmd_args
         if cfg.base_url_config_key and not has_base_url_config_override:
             # Some clients ignore their base URL env in selected auth/transport modes
             # unless the same value is also supplied as a config override.
+            base_url = cfg.reverse_base_url(port)
             cmd_args = ["-c", f'{cfg.base_url_config_key}="{base_url}"'] + cmd_args
 
     for key in cfg.nesting_env_keys:
@@ -242,7 +259,8 @@ async def run_client(
         if ca_cert_path:
             print(f"   NODE_EXTRA_CA_CERTS={ca_cert_path}")
     else:
-        print(f"   {cfg.base_url_env}={cfg.reverse_base_url(port)}")
+        for env_key, base_url in cfg.reverse_base_url_env_map(port).items():
+            print(f"   {env_key}={base_url}")
     print()
 
     # Give child its own process group and make it the foreground group

--- a/tests/test_client_config_framework.py
+++ b/tests/test_client_config_framework.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from claude_tap import parse_args
+from claude_tap.cli import CLIENT_CONFIGS, ClientConfig, run_client
+
+EXISTING_CLIENTS = {
+    "claude",
+    "codex",
+    "kimi",
+    "opencode",
+    "hermes",
+    "cursor",
+}
+
+EXISTING_DEFAULT_PROXY_MODES = {
+    "claude": "reverse",
+    "codex": "reverse",
+    "kimi": "reverse",
+    "opencode": "forward",
+    "hermes": "forward",
+    "cursor": "forward",
+}
+
+
+class _DummyProc:
+    def __init__(self) -> None:
+        self.pid = 12345
+        self.returncode: int | None = None
+
+    async def wait(self) -> int:
+        self.returncode = 0
+        return 0
+
+    def terminate(self) -> None:
+        self.returncode = 0
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def test_framework_refactor_keeps_existing_client_matrix_only() -> None:
+    assert set(CLIENT_CONFIGS) == EXISTING_CLIENTS
+
+
+@pytest.mark.parametrize("client", sorted(EXISTING_CLIENTS))
+def test_existing_client_default_proxy_modes_are_unchanged(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    client: str,
+) -> None:
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex-home"))
+
+    args = parse_args(["--tap-client", client])
+
+    assert args.client == client
+    assert args.proxy_mode == EXISTING_DEFAULT_PROXY_MODES[client]
+
+
+@pytest.mark.parametrize("client", sorted(EXISTING_CLIENTS))
+def test_existing_clients_keep_single_reverse_base_url_env(client: str) -> None:
+    cfg = CLIENT_CONFIGS[client]
+
+    assert cfg.reverse_base_url_envs == (cfg.base_url_env,)
+
+
+def test_reverse_base_url_envs_deduplicate_primary_and_extra_envs() -> None:
+    cfg = ClientConfig(
+        cmd="multi-cli",
+        label="Multi CLI",
+        install_url="https://example.com",
+        base_url_env="PRIMARY_BASE_URL",
+        extra_base_url_envs=("SECONDARY_BASE_URL", "PRIMARY_BASE_URL"),
+        base_url_suffix="/v1",
+        default_target="https://example.com",
+    )
+
+    assert cfg.reverse_base_url_envs == ("PRIMARY_BASE_URL", "SECONDARY_BASE_URL")
+    assert cfg.reverse_base_url_env_map(43123) == {
+        "PRIMARY_BASE_URL": "http://127.0.0.1:43123/v1",
+        "SECONDARY_BASE_URL": "http://127.0.0.1:43123/v1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_client_reverse_sets_all_base_url_envs_and_settings(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    cfg = ClientConfig(
+        cmd="multi-cli",
+        label="Multi CLI",
+        install_url="https://example.com",
+        base_url_env="PRIMARY_BASE_URL",
+        extra_base_url_envs=("SECONDARY_BASE_URL",),
+        base_url_suffix="/v1",
+        default_target="https://example.com",
+        inject_settings_env=True,
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_create_subprocess_exec(*cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs["env"]
+        return _DummyProc()
+
+    monkeypatch.setitem(CLIENT_CONFIGS, "multi-env", cfg)
+    monkeypatch.setattr("claude_tap.cli.shutil.which", lambda name: f"/tmp/{name}")
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_create_subprocess_exec)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+    code = await run_client(43123, ["--flag"], client="multi-env", proxy_mode="reverse")
+
+    assert code == 0
+    base_url = "http://127.0.0.1:43123/v1"
+    env = captured["env"]
+    assert env["PRIMARY_BASE_URL"] == base_url
+    assert env["SECONDARY_BASE_URL"] == base_url
+
+    cmd = captured["cmd"]
+    assert cmd[:3] == (
+        "/tmp/multi-cli",
+        "--settings",
+        json.dumps({"env": cfg.reverse_base_url_env_map(43123)}, separators=(",", ":")),
+    )
+    assert cmd[3:] == ("--flag",)
+
+    out = capsys.readouterr().out
+    assert out.count("PRIMARY_BASE_URL=http://127.0.0.1:43123/v1") == 1
+    assert out.count("SECONDARY_BASE_URL=http://127.0.0.1:43123/v1") == 1


### PR DESCRIPTION
## Summary

Extract the framework-only part of #159 into a smaller PR.

This PR does **not** add any new CLI clients. It only makes the existing client configuration layer able to describe more than one reverse-proxy base URL environment variable for future clients.

## Changes

- Add `ClientConfig.extra_base_url_envs`.
- Add `ClientConfig.reverse_base_url_envs` and `reverse_base_url_env_map()` helpers.
- Update reverse-mode launch to inject and print every configured base URL env.
- Reuse the full env map when a client mirrors env values into `--settings`.
- Add focused regression tests proving the existing client matrix is unchanged: `claude`, `codex`, `kimi`, `opencode`, `hermes`, `cursor`.

## Explicit Non-Goals

- No Gemini/Pi/iFlow/Qoder/Devin client support in this PR.
- No path allowlist changes.
- No public documentation or viewer UI changes.
- No screenshot evidence added because this is non-UI framework plumbing.

## Testing

- `uv run ruff check .` - pass
- `uv run ruff format --check .` - pass
- `uv run pytest tests/test_client_config_framework.py tests/test_codex_launch.py tests/test_kimi_launch.py tests/test_opencode_launch.py tests/test_cursor_launch.py tests/test_hermes_launch.py -q` - pass, 59 passed
- `uv run pytest tests/ -x --timeout=60` - pass, 295 passed, 25 skipped, 4 warnings

