### PR TITLE
chore: update changelog for v0.1.68

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.68] - 2026-05-14
+
+### Changed
+- docs: show Anthropic Python SDK in proxy-only mode
 ## [0.1.67] - 2026-05-14
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.68. Auto-merge will continue the release after checks pass.