### PR TITLE
chore: update changelog for v0.1.69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.69] - 2026-05-14
+
+### Changed
+- Detect Claude custom upstream target (#118)
 ## [0.1.68] - 2026-05-14
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.69. Auto-merge will continue the release after checks pass.