### PR TITLE
chore: update changelog for v0.1.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.72] - 2026-05-17
+
+### Changed
+- Add Qoder CLI support (#179)
 ## [0.1.71] - 2026-05-17
 
 ### Changed


### PR DESCRIPTION
Auto-generated release changelog for v0.1.72. Auto-merge will continue the release after checks pass.