### PR TITLE
fix: write completed websocket traces immediately

### DIFF
--- a/claude_tap/ws_proxy.py
+++ b/claude_tap/ws_proxy.py
@@ -140,6 +140,27 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
 
     client_messages: list[str] = []
     server_messages: list[str] = []
+    completed_records_written = 0
+    completed_response_keys: set[str] = set()
+
+    async def _write_completed_record(response_key: str) -> None:
+        nonlocal completed_records_written
+        if response_key in completed_response_keys:
+            return
+        completed_response_keys.add(response_key)
+        completed_records_written += 1
+        snapshot_turn: int | str = turn if completed_records_written == 1 else f"{turn}.{completed_records_written}"
+        record = _build_ws_record(
+            req_id=req_id if completed_records_written == 1 else f"{req_id}_{completed_records_written}",
+            turn=snapshot_turn,
+            duration_ms=int((time.monotonic() - t0) * 1000),
+            path_qs=request.path_qs,
+            req_headers=request.headers,
+            client_messages=client_messages.copy(),
+            server_messages=server_messages.copy(),
+            upstream_base_url=target,
+        )
+        await writer.write(record)
 
     async def _relay_client_to_upstream():
         try:
@@ -166,6 +187,9 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
                 if msg.type == aiohttp.WSMsgType.TEXT:
                     server_messages.append(msg.data)
                     await client_ws.send_str(msg.data)
+                    response_key = _response_completed_message_key(msg.data)
+                    if response_key is not None:
+                        await _write_completed_record(response_key)
                 elif msg.type == aiohttp.WSMsgType.BINARY:
                     await client_ws.send_bytes(msg.data)
                 elif msg.type in (
@@ -199,17 +223,18 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
 
     duration_ms = int((time.monotonic() - t0) * 1000)
 
-    record = _build_ws_record(
-        req_id=req_id,
-        turn=turn,
-        duration_ms=duration_ms,
-        path_qs=request.path_qs,
-        req_headers=request.headers,
-        client_messages=client_messages,
-        server_messages=server_messages,
-        upstream_base_url=target,
-    )
-    await writer.write(record)
+    if completed_records_written == 0:
+        record = _build_ws_record(
+            req_id=req_id,
+            turn=turn,
+            duration_ms=duration_ms,
+            path_qs=request.path_qs,
+            req_headers=request.headers,
+            client_messages=client_messages,
+            server_messages=server_messages,
+            upstream_base_url=target,
+        )
+        await writer.write(record)
 
     log.info(
         f"{log_prefix} ← WS closed ({duration_ms}ms, "
@@ -222,7 +247,7 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
 
 def _build_ws_record(
     req_id: str,
-    turn: int,
+    turn: int | str,
     duration_ms: int,
     path_qs: str,
     req_headers: dict,
@@ -284,6 +309,19 @@ def _parse_ws_messages(messages: list[str]) -> list[dict]:
         except (json.JSONDecodeError, ValueError):
             parsed_messages.append({"raw": msg})
     return parsed_messages
+
+
+def _response_completed_message_key(message: str) -> str | None:
+    try:
+        parsed = json.loads(message)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(parsed, dict) or parsed.get("type") not in ("response.completed", "response.done"):
+        return None
+    response = parsed.get("response")
+    if isinstance(response, dict) and response.get("id"):
+        return str(response["id"])
+    return json.dumps(parsed, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
 
 def _reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:

--- a/tests/test_ws_proxy.py
+++ b/tests/test_ws_proxy.py
@@ -159,6 +159,76 @@ async def test_websocket_proxy_basic(trace_dir):
         await upstream_runner.cleanup()
 
 
+@pytest.mark.asyncio
+async def test_websocket_completed_response_is_written_before_socket_close(trace_dir):
+    """A completed WS response should be visible before a long-lived socket closes."""
+    allow_close = asyncio.Event()
+
+    async def ws_upstream_handler(request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        async for msg in ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                data = json.loads(msg.data)
+                model = data.get("model", "test-model")
+                await ws.send_json(
+                    {
+                        "type": "response.completed",
+                        "response": {
+                            "id": "resp_live",
+                            "model": model,
+                            "status": "completed",
+                            "output": [{"type": "message", "content": [{"type": "output_text", "text": "done"}]}],
+                            "usage": {"input_tokens": 3, "output_tokens": 1},
+                        },
+                    }
+                )
+                await allow_close.wait()
+                await ws.close()
+                break
+        return ws
+
+    trace_path = Path(trace_dir) / "trace_ws_live.jsonl"
+    writer = TraceWriter(trace_path)
+
+    upstream_runner, upstream_port = await _start_ws_upstream(ws_upstream_handler)
+    proxy_runner, proxy_port, proxy_session = await _start_proxy(
+        f"http://127.0.0.1:{upstream_port}",
+        writer,
+        strip_prefix="/v1",
+    )
+
+    try:
+        async with aiohttp.ClientSession() as client:
+            ws = await client.ws_connect(f"http://127.0.0.1:{proxy_port}/v1/responses")
+            await ws.send_json({"model": "gpt-test", "input": "hello"})
+
+            msg = await asyncio.wait_for(ws.receive(), timeout=5)
+            assert msg.type == aiohttp.WSMsgType.TEXT
+            assert json.loads(msg.data)["type"] == "response.completed"
+
+            await asyncio.sleep(0.1)
+            records = [json.loads(line) for line in trace_path.read_text().splitlines() if line.strip()]
+            assert len(records) == 1
+            assert records[0]["response"]["body"]["status"] == "completed"
+            assert records[0]["request"]["body"]["model"] == "gpt-test"
+
+            allow_close.set()
+            await ws.close()
+
+        await asyncio.sleep(0.1)
+        writer.close()
+
+        records = [json.loads(line) for line in trace_path.read_text().splitlines() if line.strip()]
+        assert len(records) == 1
+
+    finally:
+        allow_close.set()
+        await proxy_session.close()
+        await proxy_runner.cleanup()
+        await upstream_runner.cleanup()
+
+
 # ---------------------------------------------------------------------------
 # Test 2: upstream ws_connect should inherit trust_env proxy behavior
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Write a WebSocket trace record as soon as a response.completed or response.done event arrives.
- Deduplicate completed/done events by response id so long-lived sockets do not duplicate completed records on close.
- Add regression coverage for completed WebSocket responses becoming visible before socket close.

## Validation

- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/ -x --timeout=60