### PR TITLE
fix: add Gemini LLM paths to viewer primary path filter

### DIFF
--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -2123,7 +2123,7 @@ let pathFilterExpanded = false;
  *   secondary – useful auxiliary APIs (MCP, models, token counting), collapsed behind "+N more"
  *   noise     – plugin manifests, bot APIs, asset downloads, version checks — hidden by default
  */
-const PRIMARY_PATH_PREFIXES = ['/v1/messages', '/v1/responses', '/backend-api/codex/responses', '/v1/chat/completions', '/v1/completions'];
+const PRIMARY_PATH_PREFIXES = ['/v1/messages', '/v1/responses', '/backend-api/codex/responses', '/v1/chat/completions', '/v1/completions', '/v1internal:generateContent', '/v1internal:streamGenerateContent'];
 const SECONDARY_PATH_PREFIXES = ['/v1/mcp', '/v1/models', '/v1/embeddings', '/v1/files', '/responses', '/models', '/chat/completions', '/completions', '/files', '/search', '/fetch', '/usages', '/feedback'];
 function isBedrockInvokePath(p) {
   return p.startsWith('/model/') && (p.endsWith('/invoke') || p.endsWith('/invoke-with-response-stream'));


### PR DESCRIPTION
## Summary
- Gemini CLI uses `/v1internal:generateContent` and `/v1internal:streamGenerateContent` for LLM calls
- These paths were missing from `PRIMARY_PATH_PREFIXES` in the viewer, so the sidebar couldn't auto-filter to just conversation turns
- Result: users saw 79+ `/log` telemetry entries mixed with actual LLM turns, making the Gemini trace look "very different" from Claude/Codex traces
- Fix: add both Gemini paths to the primary filter list

## Test plan
- [ ] Open a Gemini trace in the viewer — sidebar should now auto-filter to only `generateContent`/`streamGenerateContent` entries
- [ ] Claude/Codex traces still filter correctly (no regression)
- [ ] Path filter chips still show all paths when clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)