### PR TITLE
ci: enforce pull request policy gate

### DIFF
--- a/.agents/docs/standards/workflow-and-review.md
+++ b/.agents/docs/standards/workflow-and-review.md
@@ -1,6 +1,6 @@
 ---
 owner: claude-tap-maintainers
-last_reviewed: 2026-05-06
+last_reviewed: 2026-05-20
 source_of_truth: AGENTS.md
 ---
 
@@ -27,6 +27,32 @@ git branch -d feat/<name>
 3. `uv run pytest tests/ -x --timeout=60`
 4. `git diff` 并检查每一行变更。
 5. 确认只改动了相关文件。
+
+# PR 正文策略门禁
+
+`scripts/check_pr_policy.py` 是 PR 正文和 evidence 规则的统一机器检查入口。开 PR 前和 review preflight 都必须让它通过。
+
+该门禁检查：
+
+1. PR 正文包含 Summary/Problem/Goal 等摘要段落。
+2. PR 正文包含 Validation/Test plan/Results 等验证段落。
+3. 改动 runtime、viewer、client、proxy 或 UI 行为时，PR 正文包含 `raw.githubusercontent.com` 截图证据链接。
+4. PR 正文中的图片链接使用 `raw.githubusercontent.com` 绝对 URL。
+5. PR 不包含 raw trace、生成的 trace viewer、日志、secret-like 文件或明显 token。
+
+本地检查：
+
+```bash
+scripts/check_pr.sh <pr-number> --no-tests
+```
+
+CI 检查：
+
+```bash
+python scripts/check_pr_policy.py --event-path "$GITHUB_EVENT_PATH" --changed-files-file /tmp/pr-changed-files.txt
+```
+
+CI 同时在独立的 `pr-policy` job 和现有 required `lint` job 中运行该检查，避免新增 required status check 之前出现可绕过窗口。
 
 # 复利式工程实践
 

--- a/.agents/skills/pr-preflight/SKILL.md
+++ b/.agents/skills/pr-preflight/SKILL.md
@@ -21,7 +21,7 @@ This runs:
    - `uv run ruff check .`
    - `uv run ruff format --check .`
    - `uv run pytest tests/ -x --timeout=60`
-4. **Screenshot evidence** — scans PR body for image links (required by project policy)
+4. **PR body policy** — validates required sections, evidence links, and blocked artifacts
 5. **Verdict** — `READY` or `NOT_READY` with specific reasons
 
 ### Options
@@ -62,7 +62,7 @@ The script reports `NOT_READY` if any of these are true:
 - Any CI check is failing
 - Any CI check is still pending
 - Local gates (lint/format/tests) fail
-- No screenshot evidence in PR body
+- PR body policy fails, such as missing evidence for runtime/viewer/client changes
 
 ## Typical workflow
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,6 +17,11 @@
 - [ ] `uv run pytest tests/ -x --timeout=60`
 - [ ] Not required; docs-only or metadata-only change.
 
+## Evidence
+
+- Screenshots / recordings / trace files:
+- If runtime, viewer, client, proxy, or UI behavior changed, include `raw.githubusercontent.com` screenshot URLs here.
+
 ## Privacy
 
 - [ ] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,8 +22,17 @@ jobs:
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
+      - name: Collect changed files for PR policy
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr-changed-files.txt
+      - name: Validate PR body policy
+        if: github.event_name == 'pull_request'
+        run: python scripts/check_pr_policy.py --event-path "$GITHUB_EVENT_PATH" --changed-files-file /tmp/pr-changed-files.txt
 
-  screenshot-evidence:
+  screenshot-quality:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +41,25 @@ jobs:
           python-version: "3.12"
       - name: Validate screenshot evidence quality
         run: python scripts/check_screenshots.py .agents/evidence/pr/
+
+  pr-policy:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Collect changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr-changed-files.txt
+      - name: Validate PR body policy
+        run: python scripts/check_pr_policy.py --event-path "$GITHUB_EVENT_PATH" --changed-files-file /tmp/pr-changed-files.txt
 
   test:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ git config core.hooksPath .githooks
 | `check_changelog.py` | `legibility-check` | publish 阶段校验 release tag 与 `CHANGELOG.md` 覆盖 |
 | `update_changelog.py` | `legibility-check` | auto-release 发 tag 前自动补齐 `CHANGELOG.md` release section，分支保护下会走 auto-merge release PR |
 | `check_coverage.py` | - | Python/backend 与 viewer.html/frontend 的项目覆盖率和增量覆盖率 gate |
+| `check_pr_policy.py` | `pr-preflight` | PR body、证据链接、危险文件和运行时变更 evidence policy gate（CI: `pr-policy`） |
 | `check_screenshots.py` | `screenshot-validation` | 截图质量检查（CI: `ci.yml`） |
 | `check_screenshots.sh` | `screenshot-validation` | 检查 git staged 图片的 shell 包装 |
 | `verify_screenshots.py` | `screenshot-validation` | Playwright viewer HTML 渲染验证 |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,6 +22,39 @@ python -m coverage json -o .coverage.json
 python scripts/check_coverage.py --python-coverage .coverage.json
 ```
 
+## `check_pr_policy.py`
+
+Validate PR body policy against the changed files in a pull request.
+
+The check enforces machine-readable maintainer rules:
+
+- Summary/Problem/Goal and Validation/Test plan/Results sections are present
+- Runtime, viewer, client, proxy, or UI behavior changes include
+  `raw.githubusercontent.com` screenshot evidence
+- PR image links use `raw.githubusercontent.com`
+- Raw traces, generated trace viewers, logs, and secret-like files are not part
+  of the PR
+- PR body does not include obvious API keys or bearer tokens
+
+### Usage
+
+```bash
+python scripts/check_pr_policy.py \
+  --body-file /tmp/pr-body.md \
+  --changed-files-file /tmp/pr-files.txt
+```
+
+In GitHub Actions, pass the event payload:
+
+```bash
+python scripts/check_pr_policy.py \
+  --event-path "$GITHUB_EVENT_PATH" \
+  --changed-files-file /tmp/pr-files.txt
+```
+
+The CI workflow runs this check both as a standalone `pr-policy` job and inside
+the existing required `lint` job.
+
 ## `translate_i18n.py`
 
 Translate missing i18n strings in `claude_tap/viewer_i18n.json` using OpenRouter.

--- a/scripts/check_pr.sh
+++ b/scripts/check_pr.sh
@@ -66,6 +66,7 @@ if [ -z "$pr_number" ]; then
 fi
 
 require_cmd gh
+require_cmd python3
 if [ "$run_tests" -eq 1 ]; then
   require_cmd uv
 fi
@@ -91,6 +92,7 @@ pr_base=$(printf '%s\n' "$metadata" | sed -n '6p')
 pr_url=$(printf '%s\n' "$metadata" | sed -n '7p')
 
 pr_body="$(gh pr view "$pr_number" --repo "$repo" --json body --template '{{.body}}')"
+pr_files="$(gh pr view "$pr_number" --repo "$repo" --json files --jq '.files[].path')"
 
 if [ -z "$pr_title" ] || [ -z "$pr_state" ] || [ -z "$pr_merge_status" ]; then
   echo "error: failed to parse PR metadata from gh" >&2
@@ -173,38 +175,15 @@ else
   echo 'Local gates: skipped (--no-tests)'
 fi
 
-# Screenshot / evidence check
-has_screenshot=0
-if printf '%s' "$pr_body" | grep -qiE '!\[.*\]\(.*\.(png|jpg|jpeg|gif|svg|webp)'; then
-  has_screenshot=1
-fi
-if printf '%s' "$pr_body" | grep -qiE '\.(png|jpg|jpeg|gif|svg|webp)\)'; then
-  has_screenshot=1
-fi
-if printf '%s' "$pr_body" | grep -qiE '<img '; then
-  has_screenshot=1
-fi
-
-if [ "$has_screenshot" -eq 1 ]; then
-  echo 'Screenshots: found in PR body'
+policy_failed=0
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+printf '%s' "$pr_body" >"$tmp_dir/body.md"
+printf '%s\n' "$pr_files" >"$tmp_dir/files.txt"
+if python3 scripts/check_pr_policy.py --body-file "$tmp_dir/body.md" --changed-files-file "$tmp_dir/files.txt"; then
+  :
 else
-  cat <<'SCREENSHOT_ERR'
-Screenshots: MISSING
-
-  Every PR must include screenshots of the real running system.
-
-  Our screenshot standard (.agents/docs/standards/screenshot-standards.md):
-  - Screenshots must show the trace viewer HTML at desktop viewport (>=1280px)
-  - Must capture the exact feature/fix claimed (e.g. WEBSOCKET 101, not unrelated GET)
-  - Use ASCII-safe characters, no raw Unicode arrows that may garble
-  - Run `python3 scripts/check_screenshots.py .agents/evidence/pr/` before commit
-
-  What to do:
-  1. Run the feature, open the trace viewer HTML in a browser (>=1280px wide)
-  2. Screenshot the specific row/panel proving the fix works
-  3. Add image to .agents/evidence/pr/ and link in PR body with ![description](url)
-  4. Verify: no garbled text, correct content shown, legible at normal zoom
-SCREENSHOT_ERR
+  policy_failed=1
 fi
 
 ready=1
@@ -251,9 +230,9 @@ if [ "$gate_failed" -eq 1 ]; then
   ready=0
   append_reason 'local gates failed'
 fi
-if [ "$has_screenshot" -eq 0 ]; then
+if [ "$policy_failed" -eq 1 ]; then
   ready=0
-  append_reason 'no screenshots in PR body'
+  append_reason 'PR policy failed'
 fi
 
 if [ "$ready" -eq 1 ]; then

--- a/scripts/check_pr_policy.py
+++ b/scripts/check_pr_policy.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Validate pull request body and changed-file policy gates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+IMAGE_EXT_RE = re.compile(r"\.(?:png|jpe?g|gif|svg|webp)(?:[?#][^\s)]*)?$", re.IGNORECASE)
+MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)", re.IGNORECASE)
+HTML_IMAGE_RE = re.compile(r"<img\b[^>]*\bsrc=[\"']([^\"']+)[\"']", re.IGNORECASE)
+PLAIN_IMAGE_URL_RE = re.compile(
+    r"https?://[^\s<>()\"']+\.(?:png|jpe?g|gif|svg|webp)(?:[?#][^\s<>()\"']*)?", re.IGNORECASE
+)
+
+SUMMARY_HEADINGS = {
+    "summary",
+    "problem",
+    "goal",
+    "refactor summary",
+    "fix summary",
+}
+VALIDATION_HEADINGS = {
+    "validation",
+    "test plan",
+    "results",
+}
+
+EVIDENCE_REQUIRED_PATHS = (
+    "claude_tap/",
+    "docs/support-matrix.md",
+)
+
+SECRET_PATTERNS = (
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}"),
+    re.compile(r"\bBearer\s+eyJ[A-Za-z0-9_.-]+"),
+    re.compile(r"\b(?:ANTHROPIC|OPENAI|OPENROUTER|GITHUB)_[A-Z0-9_]*KEY\s*="),
+)
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    ok: bool
+    failures: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+
+def _heading_names(body: str) -> set[str]:
+    headings: set[str] = set()
+    for line in body.splitlines():
+        match = re.match(r"^\s{0,3}#{1,6}\s+(.+?)\s*$", line)
+        if match:
+            headings.add(match.group(1).strip().lower())
+    return headings
+
+
+def _image_urls(body: str) -> list[str]:
+    urls = [match.group(1).strip() for match in MARKDOWN_IMAGE_RE.finditer(body)]
+    urls.extend(match.group(1).strip() for match in HTML_IMAGE_RE.finditer(body))
+    urls.extend(match.group(0).strip() for match in PLAIN_IMAGE_URL_RE.finditer(body))
+
+    unique: list[str] = []
+    seen: set[str] = set()
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            unique.append(url)
+    return unique
+
+
+def _raw_image_urls(urls: list[str]) -> list[str]:
+    return [url for url in urls if "://raw.githubusercontent.com/" in url and IMAGE_EXT_RE.search(url)]
+
+
+def _evidence_required_paths(changed_files: list[str]) -> list[str]:
+    required: list[str] = []
+    for path in changed_files:
+        normalized = path.strip()
+        if not normalized:
+            continue
+        if normalized.startswith(EVIDENCE_REQUIRED_PATHS):
+            required.append(normalized)
+    return required
+
+
+def _dangerous_files(changed_files: list[str]) -> list[str]:
+    dangerous: list[str] = []
+    for path in changed_files:
+        normalized = path.strip()
+        if not normalized:
+            continue
+        name = Path(normalized).name.lower()
+        suffix = Path(normalized).suffix.lower()
+        if normalized.startswith(".traces/") and suffix in {".jsonl", ".html", ".log"}:
+            dangerous.append(normalized)
+        elif name.startswith("trace_") and suffix in {".jsonl", ".html", ".log"}:
+            dangerous.append(normalized)
+        elif name in {".env", "id_rsa", "id_ed25519"}:
+            dangerous.append(normalized)
+    return dangerous
+
+
+def validate_policy(body: str, changed_files: list[str]) -> PolicyResult:
+    failures: list[str] = []
+    warnings: list[str] = []
+    body = body.strip()
+
+    if not body:
+        failures.append("PR body is empty")
+        return PolicyResult(ok=False, failures=tuple(failures), warnings=())
+
+    headings = _heading_names(body)
+    if not headings.intersection(SUMMARY_HEADINGS):
+        failures.append("PR body is missing a Summary, Problem, Goal, or equivalent section")
+    if not headings.intersection(VALIDATION_HEADINGS):
+        failures.append("PR body is missing a Validation, Test plan, or Results section")
+
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(body):
+            failures.append("PR body appears to contain a secret or bearer token")
+            break
+
+    image_urls = _image_urls(body)
+    raw_urls = _raw_image_urls(image_urls)
+    non_raw_urls = [url for url in image_urls if url not in raw_urls]
+    if non_raw_urls:
+        failures.append("PR image evidence must use raw.githubusercontent.com URLs")
+
+    evidence_paths = _evidence_required_paths(changed_files)
+    if evidence_paths and not raw_urls:
+        failures.append(
+            "PR changes runtime/viewer/client behavior but has no raw.githubusercontent.com screenshot evidence"
+        )
+        warnings.append("Evidence-triggering files: " + ", ".join(evidence_paths[:8]))
+
+    dangerous = _dangerous_files(changed_files)
+    if dangerous:
+        failures.append("PR includes raw trace, generated viewer, log, or secret-like files")
+        warnings.append("Blocked files: " + ", ".join(dangerous[:8]))
+
+    return PolicyResult(ok=not failures, failures=tuple(failures), warnings=tuple(warnings))
+
+
+def _load_body(args: argparse.Namespace) -> str:
+    if args.body is not None:
+        return args.body
+    if args.body_file:
+        return Path(args.body_file).read_text(encoding="utf-8")
+    event_path = args.event_path or os.environ.get("GITHUB_EVENT_PATH")
+    if event_path:
+        data = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        body = data.get("pull_request", {}).get("body")
+        if isinstance(body, str):
+            return body
+    raise SystemExit("error: provide --body, --body-file, or --event-path with pull_request.body")
+
+
+def _load_changed_files(args: argparse.Namespace) -> list[str]:
+    if args.changed_file:
+        return args.changed_file
+    if args.changed_files_file:
+        return [
+            line.strip()
+            for line in Path(args.changed_files_file).read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body", help="PR body text")
+    parser.add_argument("--body-file", help="File containing the PR body")
+    parser.add_argument("--event-path", help="GitHub event JSON path")
+    parser.add_argument("--changed-files-file", help="File containing changed paths, one per line")
+    parser.add_argument("--changed-file", action="append", default=[], help="Changed path; repeatable")
+    args = parser.parse_args(argv)
+
+    result = validate_policy(_load_body(args), _load_changed_files(args))
+    if result.ok:
+        print("PR Policy: PASS")
+        for warning in result.warnings:
+            print(f"  WARN {warning}")
+        return 0
+
+    print("PR Policy: FAIL")
+    for failure in result.failures:
+        print(f"  FAIL {failure}")
+    for warning in result.warnings:
+        print(f"  INFO {warning}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_pr_policy.py
+++ b/tests/test_check_pr_policy.py
@@ -1,0 +1,143 @@
+"""Unit tests for scripts/check_pr_policy.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_pr_policy.py"
+MODULE_NAME = "check_pr_policy"
+
+
+def _load_module() -> Any:
+    spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_policy_requires_raw_screenshot_for_client_changes() -> None:
+    module = _load_module()
+    body = """## Summary
+- Add a client.
+
+## Test plan
+- `uv run pytest tests/ -x --timeout=60`
+"""
+
+    result = module.validate_policy(body, ["claude_tap/cli.py"])
+
+    assert result.ok is False
+    assert any("no raw.githubusercontent.com screenshot evidence" in item for item in result.failures)
+
+
+def test_policy_accepts_raw_screenshot_for_runtime_changes() -> None:
+    module = _load_module()
+    body = """## Summary
+- Update viewer behavior.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+
+## Evidence
+![viewer](https://raw.githubusercontent.com/liaohch3/claude-tap/branch/.agents/evidence/pr/viewer.png)
+"""
+
+    result = module.validate_policy(body, ["claude_tap/viewer.html"])
+
+    assert result.ok is True
+
+
+def test_policy_requires_raw_screenshot_for_package_runtime_changes() -> None:
+    module = _load_module()
+    body = """## Summary
+- Update HTML export behavior.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+"""
+
+    result = module.validate_policy(body, ["claude_tap/export.py"])
+
+    assert result.ok is False
+    assert any("no raw.githubusercontent.com screenshot evidence" in item for item in result.failures)
+
+
+def test_policy_rejects_non_raw_image_urls() -> None:
+    module = _load_module()
+    body = """## Summary
+- Update viewer behavior.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+
+## Evidence
+![viewer](https://github.com/liaohch3/claude-tap/blob/branch/viewer.png)
+"""
+
+    result = module.validate_policy(body, ["claude_tap/viewer.html"])
+
+    assert result.ok is False
+    assert "PR image evidence must use raw.githubusercontent.com URLs" in result.failures
+
+
+def test_policy_blocks_raw_trace_artifacts() -> None:
+    module = _load_module()
+    body = """## Summary
+- Add evidence.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+"""
+
+    result = module.validate_policy(body, [".traces/2026-05-20/trace_120000.jsonl"])
+
+    assert result.ok is False
+    assert "PR includes raw trace, generated viewer, log, or secret-like files" in result.failures
+
+
+def test_policy_allows_docs_without_runtime_evidence() -> None:
+    module = _load_module()
+    body = """## Summary
+- Clarify docs.
+
+## Validation
+- Reviewed only.
+"""
+
+    result = module.validate_policy(body, ["docs/guides/example.md"])
+
+    assert result.ok is True
+
+
+def test_policy_reads_github_event_body(tmp_path: Path, capsys) -> None:
+    module = _load_module()
+    event = tmp_path / "event.json"
+    files = tmp_path / "files.txt"
+    event.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "body": """## Summary
+- Add a client.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+"""
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    files.write_text("claude_tap/cli.py\n", encoding="utf-8")
+
+    exit_code = module.main(["--event-path", str(event), "--changed-files-file", str(files)])
+
+    output = capsys.readouterr().out
+    assert exit_code == 2
+    assert "PR Policy: FAIL" in output

--- a/tests/test_check_pr_script.py
+++ b/tests/test_check_pr_script.py
@@ -25,7 +25,30 @@ if [ "$cmd1" = "pr" ] && [ "$cmd2" = "view" ]; then
   # Check if this is a body-only query
   case "$*" in
     *--json\\ body*)
-      echo '## Evidence\n![trace](https://example.com/evidence/trace.png)'
+      if [ "${GH_BODY_MODE:-}" = "missing_evidence" ]; then
+        cat <<'EOF'
+## Summary
+- Improve merge readiness automation.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+EOF
+        exit 0
+      fi
+      cat <<'EOF'
+## Summary
+- Improve merge readiness automation.
+
+## Validation
+- `uv run pytest tests/ -x --timeout=60`
+
+## Evidence
+![trace](https://raw.githubusercontent.com/octo/demo/feature/checker/.agents/evidence/pr/trace.png)
+EOF
+      exit 0
+      ;;
+    *--json\\ files*)
+      echo 'claude_tap/viewer.html'
       exit 0
       ;;
   esac
@@ -149,3 +172,26 @@ def test_check_pr_handles_pending_checks_exit_code(tmp_path: Path) -> None:
     assert result.returncode == 2
     assert "Checks: pass=1 fail=0 pending=1 total=2" in result.stdout
     assert "VERDICT: NOT_READY - 1 CI check(s) pending" in result.stdout
+
+
+def test_check_pr_reports_pr_policy_failure(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(fake_bin / "gh", GH_STUB)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["GH_BODY_MODE"] = "missing_evidence"
+
+    result = subprocess.run(
+        [str(SCRIPT_PATH), "42", "--no-tests"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=SCRIPT_PATH.parent.parent,
+    )
+
+    assert result.returncode == 2
+    assert "PR Policy: FAIL" in result.stdout
+    assert "VERDICT: NOT_READY - PR policy failed" in result.stdout


### PR DESCRIPTION
## Summary
- Add `scripts/check_pr_policy.py` as the unified machine gate for PR body sections, evidence links, dangerous files, and obvious secrets.
- Wire the gate into CI as `pr-policy` and into `scripts/check_pr.sh` preflight.
- Update the PR template, maintainer standards, script docs, and pr-preflight skill to point at the same policy.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python scripts/check_legibility.py`
- `uv run pytest tests/ -x --timeout=60`
- `uv lock --check`

## Evidence
- Screenshot evidence is not required for this PR because it changes CI, scripts, PR template, and maintainer documentation only; no `claude_tap/` runtime/viewer/client/proxy file changed.
- Unit coverage verifies missing screenshot evidence fails for `claude_tap/` changes and passes for docs-only changes.

## Privacy
- No raw trace, generated viewer, log file, API key, or bearer token is included.