### PR TITLE
chore: update changelog for v0.1.76

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 
+
+## [0.1.76] - 2026-05-22
+
+### Changed
+- fix: unblock protected auto release (#208)
 ## [0.1.75] - 2026-05-22
 
 ### Added


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.76.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
