### PR TITLE
Capture Codex forward traces selectively

### DIFF
--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -108,7 +108,7 @@ def export_main(argv: list[str] | None = None) -> int:
         if not html_path.exists():
             print("Error: failed to generate HTML viewer", file=sys.stderr)
             return 1
-        print(f"Exported {len(records)} turns to {html_path}")
+        print(f"Exported {len(records)} records to {html_path}")
         return 0
 
     if fmt == "json":
@@ -118,7 +118,7 @@ def export_main(argv: list[str] | None = None) -> int:
 
     if args.output:
         args.output.write_text(output, encoding="utf-8")
-        print(f"Exported {len(records)} turns to {args.output}")
+        print(f"Exported {len(records)} records to {args.output}")
     else:
         print(output)
 

--- a/claude_tap/forward_proxy.py
+++ b/claude_tap/forward_proxy.py
@@ -25,6 +25,7 @@ import logging
 import time
 import uuid
 import zlib
+from collections.abc import Mapping
 from urllib.parse import urlparse
 
 import aiohttp
@@ -36,6 +37,7 @@ from claude_tap.certs import CertificateAuthority
 from claude_tap.proxy import (
     HOP_BY_HOP,
     _build_record,
+    _is_allowed_path,
     filter_headers,
 )
 from claude_tap.sse import SSEReassembler
@@ -48,6 +50,34 @@ from claude_tap.ws_proxy import (
 )
 
 log = logging.getLogger("claude-tap")
+
+TRACE_BODY_MAX_BYTES = 2 * 1024 * 1024
+CODEX_BACKEND_API_TRACE_PREFIXES = (
+    "/backend-api/codex/responses",
+    "/backend-api/codex/responses/compact",
+)
+LLM_GENERATION_PATH_SUFFIXES = (
+    ":generateContent",
+    ":streamGenerateContent",
+    "/converse",
+    "/converse-stream",
+    "/invoke",
+    "/invoke-with-response-stream",
+)
+TEXTUAL_CONTENT_TYPES = (
+    "application/json",
+    "application/x-ndjson",
+    "application/problem+json",
+    "text/",
+)
+LLM_REQUEST_BODY_KEYS = (
+    "messages",
+    "input",
+    "prompt",
+    "contents",
+    "system",
+    "instructions",
+)
 
 
 def _matches_path_prefix(path: str, prefixes: tuple[str, ...]) -> bool:
@@ -121,6 +151,83 @@ def _is_websocket_upgrade(headers: dict[str, str]) -> bool:
 def _build_ws_accept(sec_key: str) -> str:
     digest = hashlib.sha1(sec_key.encode("utf-8") + WS_KEY).digest()
     return base64.b64encode(digest).decode("ascii")
+
+
+def _request_body_looks_like_llm(req_body: object) -> bool:
+    if not isinstance(req_body, dict):
+        return False
+    if not any(isinstance(req_body.get(key), (str, list, dict)) for key in LLM_REQUEST_BODY_KEYS):
+        return False
+    model = req_body.get("model")
+    return model is None or isinstance(model, str)
+
+
+def _should_record_forward_trace(hostname: str, path: str, req_body: object) -> bool:
+    clean = path.split("?", 1)[0].rstrip("/")
+    if _is_allowed_path(path):
+        return True
+    if _matches_path_prefix(path, CODEX_BACKEND_API_TRACE_PREFIXES):
+        return True
+    if any(clean.endswith(suffix) for suffix in LLM_GENERATION_PATH_SUFFIXES):
+        return True
+    if _request_body_looks_like_llm(req_body):
+        return True
+    log.debug("Skipping non-LLM forward-proxy trace: host=%s path=%s", hostname, path)
+    return False
+
+
+def _content_length(headers: Mapping[str, str]) -> int | None:
+    content_length = None
+    for key, value in dict(headers).items():
+        if key.lower() == "content-length":
+            content_length = value
+            break
+    if content_length is None:
+        return None
+    try:
+        return int(str(content_length))
+    except ValueError:
+        return None
+
+
+def _is_textual_content(headers: Mapping[str, str]) -> bool:
+    content_type = str(dict(headers).get("Content-Type", dict(headers).get("content-type", ""))).lower()
+    return any(content_type.startswith(prefix) or prefix in content_type for prefix in TEXTUAL_CONTENT_TYPES)
+
+
+def _omitted_body_summary(resp_bytes: bytes, headers: Mapping[str, str], reason: str) -> dict[str, object]:
+    header_dict = dict(headers)
+    return {
+        "_claude_tap_body": "omitted",
+        "reason": reason,
+        "bytes": len(resp_bytes),
+        "sha256": hashlib.sha256(resp_bytes).hexdigest(),
+        "content_type": header_dict.get("Content-Type") or header_dict.get("content-type", ""),
+    }
+
+
+def _response_body_for_trace(resp_bytes: bytes, headers: Mapping[str, str]) -> object:
+    content_encoding = str(dict(headers).get("Content-Encoding", dict(headers).get("content-encoding", ""))).lower()
+    decode_bytes = resp_bytes
+    if resp_bytes and content_encoding in ("gzip", "deflate"):
+        try:
+            if content_encoding == "gzip":
+                decode_bytes = gzip.decompress(resp_bytes)
+            else:
+                decode_bytes = zlib.decompress(resp_bytes)
+        except Exception:
+            decode_bytes = resp_bytes
+
+    try:
+        return json.loads(decode_bytes) if decode_bytes else None
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        pass
+
+    if len(decode_bytes) > TRACE_BODY_MAX_BYTES:
+        return _omitted_body_summary(resp_bytes, headers, "non_json_response_too_large")
+    if not _is_textual_content(headers):
+        return _omitted_body_summary(resp_bytes, headers, "non_text_response")
+    return decode_bytes.decode("utf-8", errors="replace") if decode_bytes else None
 
 
 class ForwardProxyServer:
@@ -393,11 +500,9 @@ class ForwardProxyServer:
         client_writer: asyncio.StreamWriter,
     ) -> None:
         """Forward request to upstream, record trace, send response back."""
-        self._turn_counter += 1
-        turn = self._turn_counter
-        req_id = f"req_{uuid.uuid4().hex[:12]}"
         t0 = time.monotonic()
-        log_prefix = f"[Turn {turn}]"
+        parsed_url = urlparse(upstream_url)
+        hostname = parsed_url.hostname or headers.get("Host", headers.get("host", ""))
 
         # Parse request body for logging
         try:
@@ -405,12 +510,23 @@ class ForwardProxyServer:
         except (json.JSONDecodeError, ValueError):
             req_body = body.decode("utf-8", errors="replace") if body else None
 
+        record_trace = _should_record_forward_trace(hostname, path, req_body)
+        if record_trace:
+            self._turn_counter += 1
+            turn = self._turn_counter
+            req_id = f"req_{uuid.uuid4().hex[:12]}"
+            log_prefix = f"[Turn {turn}]"
+        else:
+            turn = 0
+            req_id = ""
+            log_prefix = "[Pass-through]"
+
         is_streaming = False
         if isinstance(req_body, dict):
             is_streaming = req_body.get("stream", False)
 
         model = req_body.get("model", "") if isinstance(req_body, dict) else ""
-        log.info(f"{log_prefix} -> {method} {path} (model={model}, stream={is_streaming})")
+        log.info(f"{log_prefix} -> {method} {path} (model={model}, stream={is_streaming}, trace={record_trace})")
 
         # Prepare forwarding headers
         fwd_headers = filter_headers(headers)
@@ -433,26 +549,29 @@ class ForwardProxyServer:
             log.error(f"{log_prefix} upstream error: {exc}")
             error_text = str(exc)
             error_body = error_text.encode("utf-8", errors="replace")
-            record = _build_record(
-                req_id,
-                turn,
-                duration_ms,
-                method,
-                path,
-                headers,
-                req_body,
-                502,
-                {"Content-Type": "text/plain"},
-                {"error": error_text},
-            )
-            await self._writer.write(record)
+            if record_trace:
+                record = _build_record(
+                    req_id,
+                    turn,
+                    duration_ms,
+                    method,
+                    path,
+                    headers,
+                    req_body,
+                    502,
+                    {"Content-Type": "text/plain"},
+                    {"error": error_text},
+                )
+                await self._writer.write(record)
             response_line = b"HTTP/1.1 502 Bad Gateway\r\n"
             resp_headers = f"Content-Length: {len(error_body)}\r\nContent-Type: text/plain\r\n\r\n"
             client_writer.write(response_line + resp_headers.encode() + error_body)
             await client_writer.drain()
             return
 
-        if is_streaming and upstream_resp.status == 200:
+        if not record_trace:
+            await self._handle_passthrough(upstream_resp, client_writer, t0, log_prefix)
+        elif is_streaming and upstream_resp.status == 200:
             await self._handle_streaming(
                 upstream_resp,
                 client_writer,
@@ -478,6 +597,42 @@ class ForwardProxyServer:
                 req_body,
                 log_prefix,
             )
+
+    async def _handle_passthrough(
+        self,
+        upstream_resp: aiohttp.ClientResponse,
+        client_writer: asyncio.StreamWriter,
+        t0: float,
+        log_prefix: str,
+    ) -> None:
+        """Forward a response without recording its body in the trace."""
+        status_line = f"HTTP/1.1 {upstream_resp.status} {upstream_resp.reason}\r\n"
+        client_writer.write(status_line.encode())
+
+        has_content_length = _content_length(upstream_resp.headers) is not None
+        for key, value in upstream_resp.headers.items():
+            if key.lower() not in HOP_BY_HOP:
+                client_writer.write(f"{key}: {value}\r\n".encode())
+        if not has_content_length:
+            client_writer.write(b"Transfer-Encoding: chunked\r\n")
+        client_writer.write(b"\r\n")
+        await client_writer.drain()
+
+        total_bytes = 0
+        try:
+            async for chunk in upstream_resp.content.iter_any():
+                total_bytes += len(chunk)
+                if has_content_length:
+                    client_writer.write(chunk)
+                else:
+                    client_writer.write(f"{len(chunk):x}\r\n".encode() + chunk + b"\r\n")
+                await client_writer.drain()
+        finally:
+            if not has_content_length:
+                client_writer.write(b"0\r\n\r\n")
+                await client_writer.drain()
+        duration_ms = int((time.monotonic() - t0) * 1000)
+        log.info(f"{log_prefix} <- {upstream_resp.status} ({duration_ms}ms, {total_bytes} bytes, not recorded)")
 
     async def _handle_streaming(
         self,
@@ -569,22 +724,7 @@ class ForwardProxyServer:
         resp_bytes = await upstream_resp.read()
         duration_ms = int((time.monotonic() - t0) * 1000)
 
-        # Decompress for JSON parsing
-        content_encoding = upstream_resp.headers.get("Content-Encoding", "").lower()
-        decode_bytes = resp_bytes
-        if resp_bytes and content_encoding in ("gzip", "deflate"):
-            try:
-                if content_encoding == "gzip":
-                    decode_bytes = gzip.decompress(resp_bytes)
-                else:
-                    decode_bytes = zlib.decompress(resp_bytes)
-            except Exception:
-                pass
-
-        try:
-            resp_body = json.loads(decode_bytes) if decode_bytes else None
-        except (json.JSONDecodeError, ValueError):
-            resp_body = decode_bytes.decode("utf-8", errors="replace") if decode_bytes else None
+        resp_body = _response_body_for_trace(resp_bytes, upstream_resp.headers)
 
         log.info(f"{log_prefix} <- {upstream_resp.status} ({duration_ms}ms, {len(resp_bytes)} bytes)")
 
@@ -624,11 +764,17 @@ class ForwardProxyServer:
         writer: asyncio.StreamWriter,
     ) -> None:
         """Relay a WebSocket upgrade received inside the CONNECT tunnel."""
-        self._turn_counter += 1
-        turn = self._turn_counter
-        req_id = f"req_{uuid.uuid4().hex[:12]}"
+        record_trace = _should_record_forward_trace(hostname, path, None)
+        if record_trace:
+            self._turn_counter += 1
+            turn = self._turn_counter
+            req_id = f"req_{uuid.uuid4().hex[:12]}"
+            log_prefix = f"[Turn {turn}]"
+        else:
+            turn = 0
+            req_id = ""
+            log_prefix = "[Pass-through]"
         t0 = time.monotonic()
-        log_prefix = f"[Turn {turn}]"
         upstream_base_url = f"https://{hostname}:{port}"
         upstream_ws_url = f"wss://{hostname}:{port}{path}"
 
@@ -673,22 +819,23 @@ class ForwardProxyServer:
                 + error_body
             )
             await writer.drain()
-            record = {
-                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-                "request_id": req_id,
-                "turn": turn,
-                "duration_ms": duration_ms,
-                "transport": "websocket",
-                "request": {
-                    "method": "WEBSOCKET",
-                    "path": path,
-                    "headers": filter_headers(headers, redact_keys=True),
-                    "body": None,
-                },
-                "response": {"status": 502, "headers": {}, "body": None, "error": str(exc)},
-                "upstream_base_url": upstream_base_url,
-            }
-            await self._writer.write(record)
+            if record_trace:
+                record = {
+                    "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                    "request_id": req_id,
+                    "turn": turn,
+                    "duration_ms": duration_ms,
+                    "transport": "websocket",
+                    "request": {
+                        "method": "WEBSOCKET",
+                        "path": path,
+                        "headers": filter_headers(headers, redact_keys=True),
+                        "body": None,
+                    },
+                    "response": {"status": 502, "headers": {}, "body": None, "error": str(exc)},
+                    "upstream_base_url": upstream_base_url,
+                }
+                await self._writer.write(record)
             return
 
         sec_key = headers.get("Sec-WebSocket-Key") or headers.get("sec-websocket-key")
@@ -737,7 +884,8 @@ class ForwardProxyServer:
                     break
 
                 if msg.type == WSMsgType.TEXT:
-                    client_messages.append(msg.data)
+                    if record_trace:
+                        client_messages.append(msg.data)
                     await upstream_ws.send_str(msg.data)
                 elif msg.type == WSMsgType.BINARY:
                     await upstream_ws.send_bytes(msg.data)
@@ -754,7 +902,8 @@ class ForwardProxyServer:
         async def _relay_upstream_to_client() -> None:
             async for msg in upstream_ws:
                 if msg.type == WSMsgType.TEXT:
-                    server_messages.append(msg.data)
+                    if record_trace:
+                        server_messages.append(msg.data)
                     await ws_writer.send_frame(msg.data.encode("utf-8"), WSMsgType.TEXT)
                     await writer.drain()
                 elif msg.type == WSMsgType.BINARY:
@@ -802,29 +951,30 @@ class ForwardProxyServer:
             pass
 
         duration_ms = int((time.monotonic() - t0) * 1000)
-        record = {
-            "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-            "request_id": req_id,
-            "turn": turn,
-            "duration_ms": duration_ms,
-            "transport": "websocket",
-            "request": {
-                "method": "WEBSOCKET",
-                "path": path,
-                "headers": filter_headers(headers, redact_keys=True),
-                "body": reconstruct_ws_request_body(client_messages),
-                "ws_events": [json.loads(msg) if msg.startswith("{") else {"raw": msg} for msg in client_messages],
-            },
-            "response": {
-                "status": 101,
-                "headers": {},
-                "body": None,
-                "ws_events": [json.loads(msg) if msg.startswith("{") else {"raw": msg} for msg in server_messages],
-            },
-            "upstream_base_url": upstream_base_url,
-        }
-        record["response"]["body"] = reconstruct_ws_response_body(record["response"]["ws_events"])
-        await self._writer.write(record)
+        if record_trace:
+            record = {
+                "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "request_id": req_id,
+                "turn": turn,
+                "duration_ms": duration_ms,
+                "transport": "websocket",
+                "request": {
+                    "method": "WEBSOCKET",
+                    "path": path,
+                    "headers": filter_headers(headers, redact_keys=True),
+                    "body": reconstruct_ws_request_body(client_messages),
+                    "ws_events": [json.loads(msg) if msg.startswith("{") else {"raw": msg} for msg in client_messages],
+                },
+                "response": {
+                    "status": 101,
+                    "headers": {},
+                    "body": None,
+                    "ws_events": [json.loads(msg) if msg.startswith("{") else {"raw": msg} for msg in server_messages],
+                },
+                "upstream_base_url": upstream_base_url,
+            }
+            record["response"]["body"] = reconstruct_ws_response_body(record["response"]["ws_events"])
+            await self._writer.write(record)
         log.info(
             f"{log_prefix} <- WS closed ({duration_ms}ms, "
             f"{len(client_messages)} client→upstream, {len(server_messages)} upstream→client)"

--- a/claude_tap/viewer.html
+++ b/claude_tap/viewer.html
@@ -1862,6 +1862,9 @@ function buildStubEntry(meta, rawIdx) {
   return {
     _isStub: true,
     _rawIdx: rawIdx,
+    _wsIdx: meta.websocket_response_index || null,
+    derived_from_websocket: meta.derived_from_websocket || false,
+    websocket_response_index: meta.websocket_response_index || undefined,
     turn: meta.turn,
     request_id: meta.request_id || '',
     timestamp: meta.timestamp || '',
@@ -1880,6 +1883,27 @@ function buildStubEntry(meta, rawIdx) {
       },
     },
   };
+}
+
+function buildLazyEntriesFromMeta(metaList) {
+  const built = [];
+  (metaList || []).forEach((meta, rawIdx) => {
+    const wsCount = Number(meta.websocket_response_count || 0);
+    if (wsCount > 1) {
+      for (let i = 0; i < wsCount; i++) {
+        built.push(buildStubEntry({
+          ...meta,
+          turn: `${meta.turn || '?'}.${i + 1}`,
+          request_id: `${meta.request_id || 'ws'}:${i + 1}`,
+          derived_from_websocket: true,
+          websocket_response_index: i + 1
+        }, rawIdx));
+      }
+      return;
+    }
+    built.push(buildStubEntry(meta, rawIdx));
+  });
+  return built;
 }
 
 function toolDisplayName(td) {
@@ -1910,12 +1934,26 @@ function toolSchema(td) {
 function getFullEntry(entry) {
   if (!entry._isStub) return entry;
   const idx = entry._rawIdx;
-  if (entryCache.has(idx)) return entryCache.get(idx);
+  const rawKey = `raw:${idx}`;
+  if (entry._wsIdx) {
+    const wsKey = `ws:${idx}:${entry._wsIdx}`;
+    if (entryCache.has(wsKey)) return entryCache.get(wsKey);
+  } else if (entryCache.has(rawKey)) {
+    return entryCache.get(rawKey);
+  }
   const lines = getRawLines();
   if (idx < 0 || idx >= lines.length) return entry;
   try {
     const full = JSON.parse(lines[idx]);
-    entryCache.set(idx, full);
+    entryCache.set(rawKey, full);
+    if (entry._wsIdx) {
+      const expanded = expandWebSocketResponseEntries([full]);
+      const selected = expanded.find(e => e.derived_from_websocket && e.websocket_response_index === entry._wsIdx)
+        || expanded[entry._wsIdx - 1]
+        || full;
+      entryCache.set(`ws:${idx}:${entry._wsIdx}`, selected);
+      return selected;
+    }
     return full;
   } catch (e) {
     console.error('Failed to parse entry at index', idx, e);
@@ -2281,7 +2319,7 @@ if (typeof LIVE_MODE !== 'undefined' && LIVE_MODE) {
 } else if (typeof EMBEDDED_TRACE_META !== 'undefined') {
   // Lazy mode: build stub entries from metadata
   lazyMode = true;
-  entries = EMBEDDED_TRACE_META.map((meta, i) => buildStubEntry(meta, i));
+  entries = buildLazyEntriesFromMeta(EMBEDDED_TRACE_META);
   document.addEventListener('DOMContentLoaded', () => {
     initCommonUi();
     if (entries.length) renderApp();

--- a/claude_tap/viewer.py
+++ b/claude_tap/viewer.py
@@ -82,6 +82,105 @@ def _event_payload(event: dict) -> dict | None:
     return payload if isinstance(payload, dict) else None
 
 
+def _response_id_from_event(event: dict) -> str:
+    payload = _event_payload(event)
+    if not isinstance(payload, dict):
+        return ""
+    response = payload.get("response")
+    if isinstance(response, dict) and isinstance(response.get("id"), str):
+        return response["id"]
+    item = payload.get("item")
+    if isinstance(item, dict) and isinstance(item.get("id"), str):
+        return item["id"]
+    item_id = payload.get("item_id")
+    return item_id if isinstance(item_id, str) else ""
+
+
+def _response_event_matches_id(event: dict, response_id: str) -> bool:
+    if not response_id:
+        return False
+    payload = _event_payload(event)
+    if not isinstance(payload, dict):
+        return False
+    response = payload.get("response")
+    if isinstance(response, dict) and response.get("id") == response_id:
+        return True
+    item = payload.get("item")
+    item_id = item.get("id") if isinstance(item, dict) else payload.get("item_id")
+    return isinstance(item_id, str) and response_id[5:25] in item_id
+
+
+def _completed_response_from_events(events: list[dict]) -> dict | None:
+    for event in reversed(events):
+        if _event_type(event) not in {"response.completed", "response.done"}:
+            continue
+        payload = _event_payload(event)
+        response = payload.get("response") if isinstance(payload, dict) else None
+        if isinstance(response, dict):
+            return response
+    return None
+
+
+def _has_output_item_event(events: list[dict]) -> bool:
+    return any(_event_type(event) == "response.output_item.done" for event in events)
+
+
+def _split_websocket_response_events(events: list[dict]) -> list[dict[str, object]]:
+    groups: list[dict[str, object]] = []
+    current: dict[str, object] | None = None
+    for event in events:
+        event_type = _event_type(event)
+        if event_type == "response.created":
+            if current is not None and current.get("events"):
+                groups.append(current)
+            current = {"response_id": _response_id_from_event(event), "events": [event]}
+            continue
+        if current is None:
+            continue
+        response_id = str(current.get("response_id") or "")
+        if _response_event_matches_id(event, response_id) or event_type.startswith("response."):
+            group_events = current.get("events")
+            if isinstance(group_events, list):
+                group_events.append(event)
+        if event_type in {"response.completed", "response.done"}:
+            groups.append(current)
+            current = None
+    if current is not None and current.get("events"):
+        groups.append(current)
+    return [
+        group
+        for group in groups
+        if any(_event_type(event) in {"response.completed", "response.done"} for event in group.get("events", []))
+    ]
+
+
+def _is_displayable_websocket_response_group(group: dict[str, object]) -> bool:
+    events = group.get("events")
+    if not isinstance(events, list):
+        return False
+    completed = _completed_response_from_events(events)
+    if not completed:
+        return False
+    output_tokens = 0
+    usage = completed.get("usage")
+    if isinstance(usage, dict) and isinstance(usage.get("output_tokens"), int):
+        output_tokens = usage["output_tokens"]
+    return not (completed.get("generate") is False and not _has_output_item_event(events) and output_tokens == 0)
+
+
+def _codex_websocket_response_count(record: dict, request: dict, events: list[dict]) -> int:
+    if record.get("transport") != "websocket":
+        return 0
+    path = request.get("path")
+    if not isinstance(path, str):
+        return 0
+    if not (path.endswith("/backend-api/codex/responses") or path.endswith("/v1/responses") or path == "/responses"):
+        return 0
+    return sum(
+        1 for group in _split_websocket_response_events(events) if _is_displayable_websocket_response_group(group)
+    )
+
+
 def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
     """Extract Anthropic stream events from a decoded AWS EventStream body.
 
@@ -591,6 +690,7 @@ def _extract_metadata(record_json: str) -> dict | None:
     stream_events = _iter_response_events(resp)
     if not stream_events:
         stream_events = _parse_sse_data_frames(raw_resp_body)
+    websocket_response_count = _codex_websocket_response_count(r, req, stream_events)
 
     # Token usage — from response.body.usage or terminal stream event
     usage = resp_body.get("usage") or _extract_gemini_response_usage(raw_resp_body) or {}
@@ -665,6 +765,7 @@ def _extract_metadata(record_json: str) -> dict | None:
         "request_id": r.get("request_id", ""),
         "timestamp": r.get("timestamp", ""),
         "duration_ms": r.get("duration_ms", 0),
+        "transport": r.get("transport", ""),
         "method": req.get("method", ""),
         "path": req.get("path", ""),
         "model": body.get("model", ""),
@@ -679,6 +780,7 @@ def _extract_metadata(record_json: str) -> dict | None:
         "sys_hint": sys_text[:200],
         "tool_names": tool_names,
         "response_tool_names": response_tool_names,
+        "websocket_response_count": websocket_response_count,
     }
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -43,7 +43,7 @@ def test_export_html_inferred_from_output_suffix(tmp_path, capsys) -> None:
     assert "<!DOCTYPE html>" in html
     assert "EMBEDDED_TRACE_DATA" in html
     assert "hello from trace" in html
-    assert f"Exported 1 turns to {html_path}" in capsys.readouterr().out
+    assert f"Exported 1 records to {html_path}" in capsys.readouterr().out
 
 
 def test_export_html_format_defaults_to_trace_html_path(tmp_path, capsys) -> None:
@@ -54,7 +54,7 @@ def test_export_html_format_defaults_to_trace_html_path(tmp_path, capsys) -> Non
 
     assert html_path.exists()
     assert "hello from assistant" in html_path.read_text(encoding="utf-8")
-    assert f"Exported 1 turns to {html_path}" in capsys.readouterr().out
+    assert f"Exported 1 records to {html_path}" in capsys.readouterr().out
 
 
 def test_export_markdown_maps_responses_cached_tokens(tmp_path, capsys) -> None:
@@ -169,4 +169,4 @@ def test_export_json_tolerates_null_request_body_and_stream_text_response(tmp_pa
     assert exported[0]["response"]["usage"] == {"input_tokens": 4, "output_tokens": 3}
     assert exported[1]["model"] is None
     assert exported[1]["messages"] == []
-    assert f"Exported 2 turns to {json_path}" in capsys.readouterr().out
+    assert f"Exported 2 records to {json_path}" in capsys.readouterr().out

--- a/tests/test_forward_proxy_capture.py
+++ b/tests/test_forward_proxy_capture.py
@@ -1,0 +1,109 @@
+"""Tests for forward proxy capture filtering."""
+
+from __future__ import annotations
+
+import json
+
+import aiohttp
+import pytest
+from aiohttp import web
+
+from claude_tap.certs import CertificateAuthority, ensure_ca
+from claude_tap.forward_proxy import ForwardProxyServer
+from claude_tap.trace import TraceWriter
+
+
+async def _start_http_upstream(handler) -> tuple[web.AppRunner, int]:
+    app = web.Application()
+    app.router.add_route("*", "/{path:.*}", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    return runner, port
+
+
+@pytest.mark.asyncio
+async def test_forward_proxy_passes_non_llm_large_response_without_recording(tmp_path) -> None:
+    body = b"zip-bytes" * 1024 * 256
+
+    async def upstream_handler(_request: web.Request) -> web.Response:
+        return web.Response(body=body, content_type="application/zip")
+
+    upstream_runner, upstream_port = await _start_http_upstream(upstream_handler)
+    ca_cert_path, ca_key_path = ensure_ca(tmp_path / "ca")
+    writer = TraceWriter(tmp_path / "trace.jsonl")
+    session = aiohttp.ClientSession(auto_decompress=False)
+    proxy = ForwardProxyServer(
+        host="127.0.0.1",
+        port=0,
+        ca=CertificateAuthority(ca_cert_path, ca_key_path),
+        writer=writer,
+        session=session,
+    )
+    proxy_port = await proxy.start()
+
+    try:
+        async with aiohttp.ClientSession(auto_decompress=False) as client:
+            async with client.get(
+                f"http://127.0.0.1:{upstream_port}/world.zip",
+                proxy=f"http://127.0.0.1:{proxy_port}",
+            ) as resp:
+                assert resp.status == 200
+                assert await resp.read() == body
+
+        writer.close()
+        assert (tmp_path / "trace.jsonl").read_text(encoding="utf-8") == ""
+    finally:
+        await proxy.stop()
+        await session.close()
+        await upstream_runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_forward_proxy_records_openai_responses_request(tmp_path) -> None:
+    async def upstream_handler(_request: web.Request) -> web.Response:
+        return web.json_response(
+            {
+                "id": "resp_forward",
+                "model": "gpt-test",
+                "output": [{"type": "message", "content": [{"type": "output_text", "text": "ok"}]}],
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            }
+        )
+
+    upstream_runner, upstream_port = await _start_http_upstream(upstream_handler)
+    ca_cert_path, ca_key_path = ensure_ca(tmp_path / "ca")
+    trace_path = tmp_path / "trace.jsonl"
+    writer = TraceWriter(trace_path)
+    session = aiohttp.ClientSession(auto_decompress=False)
+    proxy = ForwardProxyServer(
+        host="127.0.0.1",
+        port=0,
+        ca=CertificateAuthority(ca_cert_path, ca_key_path),
+        writer=writer,
+        session=session,
+    )
+    proxy_port = await proxy.start()
+
+    try:
+        async with aiohttp.ClientSession(auto_decompress=False) as client:
+            async with client.post(
+                f"http://127.0.0.1:{upstream_port}/v1/responses",
+                proxy=f"http://127.0.0.1:{proxy_port}",
+                json={"model": "gpt-test", "input": [{"role": "user", "content": "hi"}]},
+            ) as resp:
+                assert resp.status == 200
+                assert (await resp.json())["id"] == "resp_forward"
+
+        writer.close()
+        records = [json.loads(line) for line in trace_path.read_text(encoding="utf-8").splitlines()]
+        assert len(records) == 1
+        assert records[0]["request"]["path"] == "/v1/responses"
+        assert records[0]["request"]["body"]["model"] == "gpt-test"
+        assert records[0]["response"]["body"]["id"] == "resp_forward"
+    finally:
+        await proxy.stop()
+        await session.close()
+        await upstream_runner.cleanup()

--- a/tests/test_viewer_non_dict_body.py
+++ b/tests/test_viewer_non_dict_body.py
@@ -163,6 +163,33 @@ def test_generate_html_viewer_does_not_crash_on_mixed_bodies(tmp_path: Path) -> 
     assert html_path.stat().st_size > 0
 
 
+def test_extract_metadata_counts_codex_websocket_response_turns() -> None:
+    trace_path = Path(__file__).parent / "fixtures" / "codex_ws_multi_response_trace.jsonl"
+    meta = _extract_metadata(trace_path.read_text(encoding="utf-8").strip())
+
+    assert meta is not None
+    assert meta["transport"] == "websocket"
+    assert meta["path"] == "/backend-api/codex/responses"
+    assert meta["websocket_response_count"] == 2
+
+
+def test_lazy_html_uses_metadata_to_expand_codex_websocket_turns(tmp_path: Path) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    codex_ws = (
+        (Path(__file__).parent / "fixtures" / "codex_ws_multi_response_trace.jsonl").read_text(encoding="utf-8").strip()
+    )
+    filler = json.dumps(_record({"model": "claude-x", "messages": []}, {"usage": {}, "content": []}))
+    trace_path.write_text("\n".join([codex_ws, *[filler for _ in range(LAZY_THRESHOLD + 1)]]) + "\n", encoding="utf-8")
+
+    html_path = tmp_path / "trace.html"
+    _generate_html_viewer(trace_path, html_path)
+    html = html_path.read_text(encoding="utf-8")
+
+    assert "EMBEDDED_TRACE_META" in html
+    assert '"websocket_response_count":2' in html
+    assert "buildLazyEntriesFromMeta" in html
+
+
 def _opencode_homepage_payload() -> str:
     """A minimal stand-in for the kind of HTML body the forward proxy captures
     when opencode hits a non-LLM upstream (e.g. opencode.ai homepage). The two


### PR DESCRIPTION
Summary
- Record forward-proxy traces only for LLM JSON traffic and Codex app-server WebSocket flows; pass through non-LLM or large/binary tool traffic without bloating JSONL traces.
- Keep recorded response bodies bounded with omission summaries for unsuitable payloads.
- Expand lazy HTML exports so one Codex WebSocket trace record can show multiple response/turn entries.

Validation
- Real sanitized Talon trace snapshot exported on this branch rendered 75 lazy entries, including 4 derived Codex WebSocket turns from one captured WebSocket record.

Tests
- uv run ruff check .
- uv run ruff format --check .
- uv run pytest tests/ -x --timeout=60
