### PR TITLE
docs: add Codex review guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,23 @@ External contributors should start with [`CONTRIBUTING.md`](CONTRIBUTING.md). Th
 
 Public user-facing documentation must be bilingual. Add or update the English document and the Simplified Chinese counterpart together; use `README.md` with `README_zh.md`, and use `*.zh.md` beside English guide files under `docs/guides/`.
 
+## Review Guidelines
+
+When reviewing pull requests, prioritize findings that can cause correctness bugs, regressions, security or privacy issues, release failures, broken CI, broken packaging, or misleading evidence. Treat these as high-priority review findings.
+
+Do not block on style-only or preference-only comments unless they make the code materially harder to maintain or violate an existing repository rule.
+
+For every pull request, check:
+
+1. The implementation matches the requested scope and does not mix unrelated refactors, feature work, or generated artifacts.
+2. Tests contain meaningful assertions that would fail for realistic regressions, not only line coverage.
+3. UI, viewer, or evidence changes include real trace-backed screenshots or recordings when required by repository policy.
+4. Public documentation changes are bilingual, with matching English and Simplified Chinese updates.
+5. Workflow, release, credential, subprocess, network, filesystem, and dependency changes use least privilege and avoid leaking secrets.
+6. Commit titles, PR titles, PR bodies, and evidence links follow the repository contribution and preflight requirements.
+
+When a finding is speculative, state the assumption and the concrete evidence needed to confirm it. Prefer a small number of actionable, high-signal findings over broad commentary.
+
 ## Pre-commit Hook
 
 项目提供了 `.githooks/pre-commit` 自动在 commit 前运行 lint 检查。首次 clone 后执行：


### PR DESCRIPTION
## Summary
- Add a `Review Guidelines` section to `AGENTS.md` for Codex GitHub code review.
- Focus automated review on correctness, regressions, security/privacy, release/CI risk, evidence quality, and repository policy compliance.
- Clarify that style-only comments should not block unless they affect maintainability or violate existing policy.

## Purpose
- Why this document, plan, or note is needed now: Codex GitHub code review can follow repository guidance from `AGENTS.md`, so the repository needs explicit review priorities before enabling automatic reviews.
- How it relates to implementation or reviewer workflow: This gives Codex and human reviewers a shared, high-signal checklist for PR review.

## Scope
- Files updated: `AGENTS.md`
- Code paths explicitly not changed: runtime code, viewer UI, tests, workflows, packaging, and release automation.

## Validation
- [x] Content reviewed for accuracy and consistency
- [x] Links, commands, and paths were checked
- [x] `uv run python scripts/check_legibility.py`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -x --timeout=60` (`425 passed, 25 skipped`)

## Evidence
- Screenshots / recordings / trace files: not required; docs-only maintainer guidance change.
- Runtime, viewer, client, proxy, and UI behavior were not changed.

## Privacy
- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.

## Notes
- After this merges, enable Codex code review in ChatGPT/Codex settings for `liaohch3/claude-tap`, then verify with `@codex review` on a PR.
