### PR TITLE
docs: document VS Code wrapper setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6
 in your environment or Claude settings. Use `--tap-target` only when you want to
 override that detected target.
 
+For the Claude Code VS Code extension, set `Claude Code: Claude Process Wrapper` to `claude-tap`; on Windows, use the full `claude-tap.exe` path if VS Code cannot find it.
+
 </details>
 
 <details>

--- a/README_zh.md
+++ b/README_zh.md
@@ -127,6 +127,8 @@ claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6
 `claude-tap` 会从环境变量或 Claude settings 中的 `ANTHROPIC_BASE_URL`
 自动识别自定义 Claude Code 上游；只有想手动覆盖时才需要传 `--tap-target`。
 
+使用 Claude Code VS Code 插件时，把 `Claude Code: Claude Process Wrapper` 设置为 `claude-tap`；如果 Windows 上 VS Code 找不到它，请填写完整的 `claude-tap.exe` 路径。
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Add a concise README note for using claude-tap with the Claude Code VS Code extension.
- Document both the normal `claude-tap` wrapper value and the Windows full-path fallback.
- Update English and Simplified Chinese README files together.

## Purpose
- Why this document, plan, or note is needed now: users asked how to configure the Claude Code VS Code extension with claude-tap.
- How it relates to implementation or reviewer workflow: this answers the setup question directly in the main README.

## Scope
- Files updated: `README.md`, `README_zh.md`
- Code paths explicitly not changed: runtime code, tests, packaging, workflows, and viewer UI.

## Validation
- [x] Content reviewed for accuracy and consistency
- [x] Links, commands, and paths were checked
- [x] `uv run python scripts/check_legibility.py`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -x --timeout=60` (`425 passed, 25 skipped`)

## Evidence
- Screenshots / recordings / trace files: not required; documentation-only change.
- Runtime, viewer, client, proxy, and UI behavior were not changed.

## Privacy
- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.

Closes #188
