### PR TITLE
Reject JSON-RPC event logs in export

### DIFF
--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -21,8 +21,19 @@ def _normalize_record_for_export(record: object) -> dict | None:
     try:
         normalized = json.loads(_normalize_record_for_viewer(json.dumps(record, ensure_ascii=False)))
     except (TypeError, json.JSONDecodeError):
-        return record
-    return normalized if isinstance(normalized, dict) else record
+        normalized = record
+    if not isinstance(normalized, dict):
+        normalized = record
+    return normalized if _is_exportable_trace_record(normalized) else None
+
+
+def _is_exportable_trace_record(record: dict) -> bool:
+    """Return true for HTTP/LLM trace records, not side-channel event logs."""
+    request = record.get("request")
+    response = record.get("response")
+    return bool(isinstance(request, dict) and request) or bool(
+        isinstance(response, dict) and response
+    )
 
 
 def _request_body(record: dict) -> dict:
@@ -82,7 +93,10 @@ def export_main(argv: list[str] | None = None) -> int:
                     continue
 
     if not records:
-        print("Error: no valid records found in trace file", file=sys.stderr)
+        print(
+            "Error: no exportable HTTP/LLM trace records found in trace file",
+            file=sys.stderr,
+        )
         return 1
 
     # Sort by turn

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -100,6 +100,37 @@ def test_export_help_mentions_html(capsys) -> None:
     assert "for HTML" in help_text
 
 
+def test_export_rejects_jsonrpc_event_logs(tmp_path, capsys) -> None:
+    trace_path = tmp_path / "trace_gen1.jsonl"
+    trace_path.write_text(
+        "\n".join(
+            [
+                json.dumps(
+                    {
+                        "ts": "2026-05-25T08:00:54Z",
+                        "event": "trace_started",
+                        "generation": 1,
+                    }
+                ),
+                json.dumps(
+                    {
+                        "ts": "2026-05-25T08:00:56Z",
+                        "event": "jsonrpc_outgoing",
+                        "generation": 1,
+                        "method": "initialized",
+                        "params": {},
+                    }
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert export_main([str(trace_path), "-o", str(tmp_path / "trace.html")]) == 1
+
+    assert "no exportable HTTP/LLM trace records" in capsys.readouterr().err
+
+
 def _bedrock_frame(event: dict) -> str:
     payload = json.dumps(event).encode("utf-8")
     return json.dumps({"bytes": base64.b64encode(payload).decode("ascii")})


### PR DESCRIPTION
## Summary
- reject JSON-RPC side-channel event logs during HTML export instead of rendering empty turns
- keep exporting normal HTTP/LLM trace records
- add coverage for event-only JSONL files

## Verification
- uv run --extra dev pytest tests/test_export.py -q
- uv run --extra dev ruff check claude_tap/export.py tests/test_export.py
- uv run --extra dev python -m claude_tap export /home/liaohch3/.talon/reports/archived-trace-html-20260525T1444/trace_080054_gen1.jsonl -o /tmp/trace_080054_gen1.should_fail.html
- uv run --extra dev python -m claude_tap export /home/liaohch3/.talon/reports/archived-trace-html-20260525T1453/trace_080055.first20.jsonl -o /tmp/trace_080055.first20.verify.html
- served the first20 HTML on localhost and captured it with Playwright