### PR TITLE
ci: enable workflow dependency caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
@@ -73,6 +77,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
       - run: pip install -e ".[dev]"
       - run: python -m pytest tests/ -x --timeout=60
 
@@ -85,6 +93,17 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - run: pip install -e ".[dev]" playwright
       - run: python -m playwright install --with-deps chromium
       - run: python -m coverage erase

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -38,13 +42,33 @@ jobs:
 
   screenshot-quality:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Collect screenshot-related changes
+        id: screenshot_changes
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr view "$PR_NUMBER" --json files --jq '.files[].path' > /tmp/pr-changed-files.txt
+          if grep -Eq '^(\.agents/evidence/pr/|scripts/check_screenshots\.(py|sh))' /tmp/pr-changed-files.txt; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Validate screenshot evidence quality
+        if: github.event_name != 'pull_request' || steps.screenshot_changes.outputs.should_run == 'true'
         run: python scripts/check_screenshots.py .agents/evidence/pr/
+      - name: Skip unchanged screenshot evidence
+        if: github.event_name == 'pull_request' && steps.screenshot_changes.outputs.should_run != 'true'
+        run: echo "No screenshot evidence or screenshot checker changes in this PR; skipping full screenshot scan."
 
   pr-policy:
     runs-on: ubuntu-latest

--- a/.github/workflows/legibility.yml
+++ b/.github/workflows/legibility.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   legibility:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,10 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
@@ -46,6 +50,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
 
       - name: Set up Python
         run: uv python install 3.13


### PR DESCRIPTION
## Summary
- Enable `actions/setup-python` pip caching for CI lint/test/coverage jobs.
- Cache Playwright browser downloads for the coverage workflow.
- Enable `astral-sh/setup-uv` caching for the PyPI publish build job.
- Add workflow concurrency so new pushes cancel stale CI/legibility runs for the same PR.
- Skip full screenshot evidence scans on PRs that did not change screenshot evidence or the screenshot checker.

## Context
- Why this maintenance change is needed now: CI repeatedly reinstalls Python dependencies and Playwright browsers from scratch, and PRs wait on slow non-required screenshot scans even when no evidence changed.
- What friction, drift, or operational cost it removes: repeated dependency downloads, stale queued runs after force-pushes, and noisy/slow screenshot checks for unrelated PRs.

## Scope
- Areas touched: `.github/workflows/ci.yml`, `.github/workflows/legibility.yml`, `.github/workflows/publish.yml`.
- Explicitly not changed: runtime code, package dependencies, tests, viewer/UI behavior.

## Validation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -x --timeout=60`
- [x] `uv lock --check`
- [x] Workflow YAML parsed with `uv run --with pyyaml python ...`
- [x] CI attempt 1 passed and saved caches.
- [x] CI attempt 2 passed and restored the saved caches.
- [x] Any required evidence uses real data from `.traces/`
- [x] If any gate is skipped, explain why and get reviewer approval before merge

## Results
- `uv run pytest tests/ -x --timeout=60`: 454 passed, 25 skipped.
- GitHub CI attempt 2 passed.
- Pip cache hit examples from attempt 2:
  - `lint`: `Cache hit for: setup-python-Linux-x64-24.04-Ubuntu-python-3.12.13-pip-...`, `Cache restored successfully`.
  - `test (3.11)`: restored ~27 MB pip cache.
  - `test (3.12)`: restored ~12 MB pip cache.
  - `test (3.13)` / `coverage`: restored ~27 MB pip cache.
- Playwright cache hit from attempt 2: `Cache hit for: Linux-playwright-...`, restored ~259 MB, then skipped saving because the primary key already hit.
- Merge experience improvement: screenshot scan now only runs on PRs that touch `.agents/evidence/pr/` or `scripts/check_screenshots.(py|sh)`; this PR now skips the full scan in 8s instead of spending ~100s scanning historical evidence.
- Screenshot evidence is not applicable because this is workflow-only CI metadata.

## Follow-up
- Consider converting CI dependency installation from `pip install` to `uv sync` in a separate PR if we want larger install-time wins.

## Risk / Rollback
- Main risk: a cache key or cache path is too broad/stale, or screenshot scan skipping misses a new screenshot path convention.
- Rollback plan: revert these workflow-only commits.
