### PR TITLE
chore: update changelog for v0.1.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.1.85] - 2026-05-28
+
+### Changed
+- fix(codex): capture custom provider base URLs (#228)
 ### Fixed
 - Capture Codex custom OpenAI-compatible providers by overriding the selected provider base URL, not only `openai_base_url`.
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.85.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
