### PR TITLE
chore: update changelog for v0.1.91

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.1.91] - 2026-05-30
+
+### Changed
+- perf: guard trace compaction and skip package noise (#227)
 ### Changed
 - Skip persisted trace records for package registry metadata and archive downloads in forward proxy mode while still forwarding responses to clients.
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.91.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
