### PR TITLE
chore: update changelog for v0.1.95

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.95] - 2026-06-01
+
+### Changed
+- feat: add readable tool call parameters (#261)
+- fix: support VSCode Claude wrapper browser controls (#244)
 ## [0.1.94] - 2026-05-31
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.95.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
