### PR TITLE
chore: update changelog for v0.1.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.96] - 2026-06-01
+
+### Changed
+- perf: compact repeated trace payload fields (#250)
+- fix: hide Windows background subprocess consoles (#260)
 ## [0.1.95] - 2026-06-01
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.96.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
