### PR TITLE
fix: add --tap-no-verify-ssl to skip upstream SSL verification

### DIFF
--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -229,7 +229,8 @@ async def async_main(args: argparse.Namespace):
     # Honor system proxy env (HTTP_PROXY/HTTPS_PROXY/ALL_PROXY/NO_PROXY) for
     # outbound upstream requests. This is important when users route traffic
     # through tools like Clash/VPN.
-    session = aiohttp.ClientSession(auto_decompress=False, trust_env=True)
+    connector = aiohttp.TCPConnector(ssl=False) if args.no_verify_ssl else None
+    session = aiohttp.ClientSession(auto_decompress=False, trust_env=True, connector=connector)
 
     # Forward proxy mode: raw TCP server with CONNECT/TLS termination
     # Reverse proxy mode: aiohttp web app (current behavior)
@@ -525,6 +526,13 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     proxy_group.add_argument(
         "--tap-no-launch", action="store_true", dest="no_launch", help="Only start the proxy, don't launch client"
+    )
+    proxy_group.add_argument(
+        "--tap-no-verify-ssl",
+        action="store_true",
+        dest="no_verify_ssl",
+        default=False,
+        help="Skip SSL certificate verification for upstream connections (useful behind corporate proxies)",
     )
     proxy_group.add_argument(
         "--tap-allow-path",

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2622,6 +2622,24 @@ def test_parse_args_new_flags():
     print("  test_parse_args_new_flags PASSED")
 
 
+def test_parse_args_no_verify_ssl():
+    """Test --tap-no-verify-ssl flag parsing."""
+    from claude_tap import parse_args
+
+    # Default: SSL verification enabled
+    a = parse_args([])
+    assert a.no_verify_ssl is False
+
+    # Explicit disable
+    a = parse_args(["--tap-no-verify-ssl"])
+    assert a.no_verify_ssl is True
+
+    # Combined with other flags
+    a = parse_args(["--tap-no-verify-ssl", "--tap-target", "https://example.com/api"])
+    assert a.no_verify_ssl is True
+    assert a.target == "https://example.com/api"
+
+
 def test_parse_dashboard_args():
     """Test standalone dashboard argument parsing."""
     from claude_tap import parse_dashboard_args


### PR DESCRIPTION
## Summary

- Add `--tap-no-verify-ssl` CLI flag that disables SSL certificate verification for outbound upstream connections.
- When set, creates `aiohttp.TCPConnector(ssl=False)` for the upstream session, bypassing certificate chain validation.
- Both reverse and forward proxy modes benefit since they share the same session object.

Closes #191

## Problem

Users routing Claude Code through third-party Anthropic-compatible providers (DashScope, GLM, etc.) encounter `502 SSLCertVerificationError: certificate verify failed: unable to get local issuer certificate` because the upstream session uses the system CA store, which may not include the provider's certificate chain — especially behind corporate proxies or on misconfigured environments.

## Validation

- [x] `python3 -c "import ast; ast.parse(open('claude_tap/cli.py').read())"` — syntax OK
- [x] New test `test_parse_args_no_verify_ssl` covers flag parsing (default off, explicit enable, combined with other flags)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Test or tooling
- [ ] Maintenance

## Privacy

- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.

Made with [Cursor](https://cursor.com)