### PR TITLE
Add session transplant to resume a capture on another machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,13 @@ claude-tap export .traces/2026-02-28/trace_141557.jsonl -o trace.html
 claude-tap export <session-id> --format compact -o trace.ctap.json
 claude-tap export trace.ctap.json -o trace.html
 
+# Move an in-progress Claude Code session to another machine.
+# On machine A: rebuild the conversation as a resumable session log.
+claude-tap export <session-id> --format claude-resume -o transplant.jsonl
+# On machine B: install it into Claude Code's store, then resume.
+claude-tap import-resume transplant.jsonl --cwd /path/to/project
+claude --resume <printed-session-id>
+
 # Capture only the prompt surface for automation; also writes trace.jsonl next to prompt.md
 claude-tap --tap-export-prompt prompt.md -- -p "hello"
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -407,6 +407,13 @@ claude-tap export .traces/2026-02-28/trace_141557.jsonl -o trace.html
 claude-tap export <session-id> --format compact -o trace.ctap.json
 claude-tap export trace.ctap.json -o trace.html
 
+# 把进行到一半的 Claude Code 会话搬到另一台机器。
+# 在 A 机：把对话重建成可续聊的会话日志。
+claude-tap export <session-id> --format claude-resume -o transplant.jsonl
+# 在 B 机：装进 Claude Code 的会话存储，然后续聊。
+claude-tap import-resume transplant.jsonl --cwd /path/to/project
+claude --resume <打印出的 session-id>
+
 # 只捕获 prompt 表面用于自动化；同时在 prompt.md 旁写入 trace.jsonl
 claude-tap --tap-export-prompt prompt.md -- -p "hello"
 

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -831,6 +831,11 @@ def main_entry() -> None:
 
         sys.exit(export_main(sys.argv[2:]))
 
+    if len(sys.argv) > 1 and sys.argv[1] == "import-resume":
+        from claude_tap.import_resume import import_resume_main
+
+        sys.exit(import_resume_main(sys.argv[2:]))
+
     if len(sys.argv) > 1 and sys.argv[1] == "update":
         sys.exit(update_main(sys.argv[2:]))
 

--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -106,9 +106,15 @@ def export_main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument(
         "--format",
-        choices=["markdown", "json", "html", "compact", "prompt-md"],
+        choices=["markdown", "json", "html", "compact", "prompt-md", "claude-resume"],
         default=None,
         help="Output format (default: inferred from -o extension, or markdown)",
+    )
+    parser.add_argument(
+        "--cwd",
+        dest="cwd",
+        default=None,
+        help="Working directory to stamp on a claude-resume export (default: current dir)",
     )
 
     args = parser.parse_args(argv)
@@ -222,6 +228,28 @@ def export_main(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             print(f"Error: {exc}", file=sys.stderr)
             return 1
+    elif fmt == "claude-resume":
+        import os
+        import uuid
+
+        from claude_tap.session_transplant import (
+            TransplantEnv,
+            build_session_jsonl,
+            detect_claude_version,
+            extract_conversation,
+        )
+
+        try:
+            messages = extract_conversation(records)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+        env = TransplantEnv(
+            cwd=args.cwd or os.getcwd(),
+            session_id=source_session_id or str(uuid.uuid4()),
+            version=detect_claude_version(),
+        )
+        output = build_session_jsonl(messages, env)
     elif fmt == "json":
         output = _export_json(_normalize_records_for_export(records))
     else:

--- a/claude_tap/import_resume.py
+++ b/claude_tap/import_resume.py
@@ -1,0 +1,79 @@
+"""Install a transplanted conversation as a resumable Claude Code session."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+from claude_tap.session_transplant import (
+    detect_claude_version,
+    install_resume_session,
+    parse_jsonl_conversation,
+)
+
+
+def _source_cwds(text: str) -> set[str]:
+    found: set[str] = set()
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict) and isinstance(event.get("cwd"), str):
+            found.add(event["cwd"])
+    return found
+
+
+def import_resume_main(argv: list[str] | None = None) -> int:
+    """Entry point for the import-resume subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="claude-tap import-resume",
+        description="Install a transplant/session JSONL into Claude Code's project store so it can be resumed.",
+    )
+    parser.add_argument("source", type=Path, help="Path to a claude-resume export or a Claude Code session JSONL")
+    parser.add_argument("--cwd", default=None, help="Target project directory to resume in (default: current dir)")
+    parser.add_argument("--git-branch", default="", help="Git branch to stamp on the session")
+    parser.add_argument("--session-id", default=None, help="Force a specific session id (default: new random uuid)")
+    parser.add_argument("--home", type=Path, default=None, help="Override the Claude home dir (default: ~/.claude)")
+    args = parser.parse_args(argv)
+
+    if not args.source.exists():
+        print(f"Error: source not found: {args.source}", file=sys.stderr)
+        return 1
+
+    text = args.source.read_text(encoding="utf-8")
+    messages = parse_jsonl_conversation(text)
+    if not messages:
+        print("Error: no user/assistant messages found in source", file=sys.stderr)
+        return 1
+
+    target_cwd = os.path.abspath(args.cwd) if args.cwd else os.getcwd()
+    source_cwds = {c for c in _source_cwds(text) if c}
+    target_key = os.path.normcase(os.path.normpath(target_cwd))
+    source_keys = {os.path.normcase(os.path.normpath(c)) for c in source_cwds}
+    if source_cwds and target_key not in source_keys:
+        origin = ", ".join(sorted(source_cwds))
+        print(
+            f"Warning: source was captured under {origin}; resuming in {target_cwd}. "
+            "File paths in the conversation may not match this machine.",
+            file=sys.stderr,
+        )
+
+    installed = install_resume_session(
+        messages,
+        target_cwd,
+        home=args.home,
+        version=detect_claude_version(),
+        git_branch=args.git_branch,
+        session_id=args.session_id,
+    )
+
+    print(f"Installed {installed.message_count} messages -> {installed.path}")
+    print(f"Resume with:\n  cd {target_cwd} && {installed.resume_command}")
+    return 0

--- a/claude_tap/session_transplant.py
+++ b/claude_tap/session_transplant.py
@@ -1,0 +1,345 @@
+"""Reconstruct a resumable Claude Code session from captured trace traffic.
+
+claude-tap records the wire traffic exchanged with the Anthropic Messages API.
+The largest request body in a session already carries the entire conversation
+as ``messages[]`` (every user turn, assistant turn with ``tool_use`` blocks, and
+``tool_result`` reply). Claude Code's own resume log
+(``~/.claude/projects/<slug>/<session-uuid>.jsonl``) stores the same
+conversation in a different shape: one JSONL event per content block, threaded
+through ``uuid``/``parentUuid`` into a tree where each ``tool_result`` points at
+the ``tool_use`` it answers.
+
+This module bridges the two so a session captured on machine A can be re-homed
+and resumed on machine B with ``claude --resume <id>``. Only the conversation is
+transplanted; Claude Code rebuilds the system prompt and tool definitions itself
+at launch from its own version, which is the desired behaviour.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import uuid
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+DEFAULT_VERSION = "2.1.167"
+_USER = "user"
+_ASSISTANT = "assistant"
+
+
+@dataclass
+class TransplantEnv:
+    """Machine-local context stamped onto reconstructed session events."""
+
+    cwd: str
+    session_id: str
+    version: str = DEFAULT_VERSION
+    git_branch: str = ""
+    user_type: str = "external"
+    entrypoint: str = "cli"
+    new_uuid: Callable[[], str] = field(default=lambda: str(uuid.uuid4()))
+    timestamp: str = "1970-01-01T00:00:00.000Z"
+
+
+def detect_claude_version(default: str = DEFAULT_VERSION) -> str:
+    """Best-effort read of the installed Claude Code version (``X.Y.Z``)."""
+
+    import shutil
+    import subprocess  # noqa: S404 - reading a local version string
+
+    binary = shutil.which("claude")
+    if not binary:
+        return default
+    try:
+        out = subprocess.run([binary, "--version"], capture_output=True, text=True, timeout=10)  # noqa: S603
+    except (OSError, subprocess.SubprocessError):
+        return default
+    match = re.search(r"\d+\.\d+\.\d+", out.stdout or "")
+    return match.group(0) if match else default
+
+
+def _as_dict(value: object) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _request_body(record: dict) -> dict:
+    return _as_dict(_as_dict(record.get("request")).get("body"))
+
+
+def _response_body(record: dict) -> dict:
+    return _as_dict(_as_dict(record.get("response")).get("body"))
+
+
+def _is_anthropic(record: dict) -> bool:
+    path = str(_as_dict(record.get("request")).get("path") or "")
+    body = _request_body(record)
+    if path.startswith(("/v1/messages", "/model/")):
+        return True
+    return "messages" in body and ("system" in body or "anthropic_version" in body)
+
+
+def extract_conversation(records: Iterable[dict]) -> list[dict]:
+    """Pick the fullest request and return the complete linear conversation.
+
+    The request carrying the most messages is the most complete history; its
+    own response is the latest assistant turn that no later request echoes back,
+    so it is appended to close the tail.
+    """
+
+    best: dict | None = None
+    best_key: tuple[int, int] = (-1, -1)
+    for record in records:
+        if not isinstance(record, dict) or not _is_anthropic(record):
+            continue
+        messages = _request_body(record).get("messages")
+        if not isinstance(messages, list) or not messages:
+            continue
+        turn = record.get("turn") if isinstance(record.get("turn"), int) else 0
+        key = (len(messages), turn)
+        if key > best_key:
+            best_key = key
+            best = record
+
+    if best is None:
+        raise ValueError("no Anthropic conversation found in trace")
+
+    conversation = [dict(msg) for msg in _request_body(best).get("messages", []) if isinstance(msg, dict)]
+    response_content = _response_body(best).get("content")
+    if isinstance(response_content, list) and response_content:
+        conversation.append({"role": _ASSISTANT, "content": response_content})
+    return conversation
+
+
+def _envelope(env: TransplantEnv, uuid_str: str, parent: str | None, *, source_uuid: str | None = None) -> dict:
+    event: dict[str, Any] = {
+        "parentUuid": parent,
+        "isSidechain": False,
+        "uuid": uuid_str,
+        "timestamp": env.timestamp,
+        "userType": env.user_type,
+        "entrypoint": env.entrypoint,
+        "cwd": env.cwd,
+        "sessionId": env.session_id,
+        "version": env.version,
+        "gitBranch": env.git_branch,
+    }
+    if source_uuid is not None:
+        event["sourceToolAssistantUUID"] = source_uuid
+    return event
+
+
+def _content_blocks(content: object) -> list[Any]:
+    if isinstance(content, list):
+        return content
+    if content is None:
+        return []
+    return [content]
+
+
+def conversation_to_events(messages: list[dict], env: TransplantEnv) -> list[dict]:
+    """Explode API messages into Claude Code resume events.
+
+    Mirrors Claude Code's native layout: one event per content block, assistant
+    blocks sharing a single ``message.id``, and every ``tool_result`` threaded as
+    a child of the ``tool_use`` event that produced its ``tool_use_id``.
+    """
+
+    events: list[dict] = []
+    parent: str | None = None
+    tool_use_uuid: dict[str, str] = {}
+
+    for message in messages:
+        role = message.get("role")
+        blocks = _content_blocks(message.get("content"))
+
+        if role == _ASSISTANT:
+            message_id = str(message.get("id") or f"msg_{env.new_uuid()}")
+            model = message.get("model") or "claude-opus-4-8"
+            for block in blocks:
+                uuid_str = env.new_uuid()
+                event = _envelope(env, uuid_str, parent)
+                event["type"] = _ASSISTANT
+                event["requestId"] = message_id
+                event["message"] = {
+                    "id": message_id,
+                    "type": "message",
+                    "role": _ASSISTANT,
+                    "model": model,
+                    "content": [block],
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                }
+                events.append(event)
+                if isinstance(block, dict) and block.get("type") == "tool_use" and block.get("id"):
+                    tool_use_uuid[str(block["id"])] = uuid_str
+                parent = uuid_str
+            continue
+
+        # user (real prompt) or tool results returned to the model
+        if isinstance(message.get("content"), str):
+            uuid_str = env.new_uuid()
+            event = _envelope(env, uuid_str, parent)
+            event["type"] = _USER
+            event["message"] = {"role": _USER, "content": message["content"]}
+            events.append(event)
+            parent = uuid_str
+            continue
+
+        plain: list[Any] = []
+        for block in blocks:
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                source = tool_use_uuid.get(str(block.get("tool_use_id") or ""))
+                uuid_str = env.new_uuid()
+                event = _envelope(env, uuid_str, source if source is not None else parent, source_uuid=source)
+                event["type"] = _USER
+                event["message"] = {"role": _USER, "content": [block]}
+                event["toolUseResult"] = block.get("content")
+                events.append(event)
+                parent = uuid_str
+            else:
+                plain.append(block)
+        if plain:
+            uuid_str = env.new_uuid()
+            event = _envelope(env, uuid_str, parent)
+            event["type"] = _USER
+            event["message"] = {"role": _USER, "content": plain}
+            events.append(event)
+            parent = uuid_str
+
+    return events
+
+
+def build_session_jsonl(messages: list[dict], env: TransplantEnv, *, last_prompt: str = "") -> str:
+    """Render a complete, resumable session JSONL document."""
+
+    events = conversation_to_events(messages, env)
+    leaf_uuid = events[-1]["uuid"] if events else None
+
+    lines: list[dict] = [
+        {"type": "mode", "mode": "normal", "sessionId": env.session_id},
+        {"type": "permission-mode", "permissionMode": "default", "sessionId": env.session_id},
+    ]
+    lines.extend(events)
+    if leaf_uuid is not None:
+        lines.append(
+            {
+                "type": "last-prompt",
+                "lastPrompt": last_prompt or _derive_last_prompt(messages),
+                "leafUuid": leaf_uuid,
+                "sessionId": env.session_id,
+            }
+        )
+    return "".join(json.dumps(line, ensure_ascii=False) + "\n" for line in lines)
+
+
+def _derive_last_prompt(messages: list[dict]) -> str:
+    for message in reversed(messages):
+        if message.get("role") != _USER:
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            return content[:200]
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    return str(block.get("text", ""))[:200]
+    return ""
+
+
+def project_slug(cwd: str) -> str:
+    """Reproduce Claude Code's project directory slug for a working directory.
+
+    Every character outside ``[A-Za-z0-9]`` is collapsed to ``-`` (drive letters,
+    separators, and dots included), matching dirs such as ``G--project-claude-tap``.
+    """
+
+    return re.sub(r"[^A-Za-z0-9]", "-", cwd)
+
+
+def claude_home(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".claude"
+
+
+@dataclass
+class InstalledSession:
+    session_id: str
+    path: Path
+    project_dir: Path
+    resume_command: str
+    message_count: int
+
+
+def install_resume_session(
+    messages: list[dict],
+    target_cwd: str,
+    *,
+    home: Path | None = None,
+    version: str = DEFAULT_VERSION,
+    git_branch: str = "",
+    session_id: str | None = None,
+    timestamp: str = "1970-01-01T00:00:00.000Z",
+    last_prompt: str = "",
+) -> InstalledSession:
+    """Write a resumable session into Claude Code's project store for ``target_cwd``."""
+
+    sid = session_id or str(uuid.uuid4())
+    env = TransplantEnv(
+        cwd=target_cwd,
+        session_id=sid,
+        version=version,
+        git_branch=git_branch,
+        timestamp=timestamp,
+    )
+    document = build_session_jsonl(messages, env, last_prompt=last_prompt)
+    project_dir = claude_home(home) / "projects" / project_slug(target_cwd)
+    project_dir.mkdir(parents=True, exist_ok=True)
+    path = project_dir / f"{sid}.jsonl"
+    path.write_text(document, encoding="utf-8")
+    return InstalledSession(
+        session_id=sid,
+        path=path,
+        project_dir=project_dir,
+        resume_command=f"claude --resume {sid}",
+        message_count=len(messages),
+    )
+
+
+def parse_jsonl_conversation(text: str) -> list[dict]:
+    """Rebuild API messages from a Claude Code-shaped session JSONL.
+
+    Lets ``import-resume`` consume either a claude-tap transplant file or a
+    native Claude Code session log, merging consecutive same-role blocks back
+    into the Messages API ``messages[]`` shape.
+    """
+
+    messages: list[dict] = []
+    for raw in text.splitlines():
+        raw = raw.strip()
+        if not raw:
+            continue
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict) or event.get("type") not in (_USER, _ASSISTANT):
+            continue
+        message = event.get("message")
+        if not isinstance(message, dict):
+            continue
+        role = message.get("role")
+        content = message.get("content")
+        blocks = (
+            content
+            if isinstance(content, list)
+            else [{"type": "text", "text": content}]
+            if isinstance(content, str)
+            else []
+        )
+        if messages and messages[-1]["role"] == role:
+            messages[-1]["content"].extend(blocks)
+        else:
+            messages.append({"role": role, "content": list(blocks)})
+    return messages

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -110,7 +110,7 @@ def test_export_help_mentions_html(capsys) -> None:
 
     assert exc_info.value.code == 0
     help_text = capsys.readouterr().out
-    assert "{markdown,json,html,compact,prompt-md}" in help_text
+    assert "{markdown,json,html,compact,prompt-md,claude-resume}" in help_text
     assert "for HTML" in help_text
 
 

--- a/tests/test_session_transplant.py
+++ b/tests/test_session_transplant.py
@@ -1,0 +1,240 @@
+"""Tests for trace -> Claude Code resume session transplant."""
+
+from __future__ import annotations
+
+import itertools
+import json
+
+import pytest
+
+from claude_tap.export import export_main
+from claude_tap.import_resume import import_resume_main
+from claude_tap.session_transplant import (
+    TransplantEnv,
+    build_session_jsonl,
+    conversation_to_events,
+    extract_conversation,
+    install_resume_session,
+    parse_jsonl_conversation,
+    project_slug,
+)
+
+
+def _det_env(**kwargs) -> TransplantEnv:
+    counter = itertools.count(1)
+    defaults = dict(
+        cwd=r"C:\work\proj",
+        session_id="SID",
+        new_uuid=lambda: f"u{next(counter):04d}",
+    )
+    defaults.update(kwargs)
+    return TransplantEnv(**defaults)
+
+
+def _tool_conversation() -> list[dict]:
+    return [
+        {"role": "user", "content": "fix the bug"},
+        {
+            "role": "assistant",
+            "id": "msg_1",
+            "content": [
+                {"type": "thinking", "thinking": "let me look"},
+                {"type": "text", "text": "Checking two files."},
+                {"type": "tool_use", "id": "tu_a", "name": "Read", "input": {"f": "a"}},
+                {"type": "tool_use", "id": "tu_b", "name": "Read", "input": {"f": "b"}},
+            ],
+        },
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tu_a", "content": "A body"},
+                {"type": "tool_result", "tool_use_id": "tu_b", "content": "B body"},
+            ],
+        },
+        {"role": "assistant", "id": "msg_2", "content": [{"type": "text", "text": "Done."}]},
+    ]
+
+
+def test_project_slug_collapses_non_alphanumeric() -> None:
+    assert project_slug(r"G:\project\claude-tap") == "G--project-claude-tap"
+    assert project_slug(r"C:\Users\23638") == "C--Users-23638"
+    # dots and mixed separators all collapse to single dashes
+    assert project_slug("/home/me/app.v2") == "-home-me-app-v2"
+
+
+def test_extract_conversation_picks_fullest_and_appends_response() -> None:
+    records = [
+        {
+            "turn": 1,
+            "request": {
+                "path": "/v1/messages",
+                "body": {"model": "m", "messages": [{"role": "user", "content": "hi"}]},
+            },
+            "response": {"body": {"content": [{"type": "text", "text": "early"}]}},
+        },
+        {
+            "turn": 2,
+            "request": {
+                "path": "/v1/messages",
+                "body": {
+                    "model": "m",
+                    "messages": [
+                        {"role": "user", "content": "hi"},
+                        {"role": "assistant", "content": [{"type": "text", "text": "early"}]},
+                        {"role": "user", "content": "more"},
+                    ],
+                },
+            },
+            "response": {"body": {"content": [{"type": "text", "text": "final answer"}]}},
+        },
+    ]
+
+    convo = extract_conversation(records)
+
+    # fullest request (turn 2, 3 messages) + appended final response = 4 messages
+    assert len(convo) == 4
+    assert convo[-1] == {"role": "assistant", "content": [{"type": "text", "text": "final answer"}]}
+
+
+def test_extract_conversation_raises_without_anthropic_traffic() -> None:
+    with pytest.raises(ValueError, match="no Anthropic conversation"):
+        extract_conversation([{"turn": 1, "request": {"path": "/v1/responses", "body": {"input": "x"}}}])
+
+
+def test_tool_results_thread_to_their_tool_use() -> None:
+    events = conversation_to_events(_tool_conversation(), _det_env())
+
+    by_uuid = {e["uuid"]: e for e in events}
+    tool_use_uuid: dict[str, str] = {}
+    tool_result_parent: dict[str, str] = {}
+    for e in events:
+        for block in e["message"]["content"]:
+            if isinstance(block, dict) and block.get("type") == "tool_use":
+                tool_use_uuid[block["id"]] = e["uuid"]
+            if isinstance(block, dict) and block.get("type") == "tool_result":
+                tool_result_parent[block["tool_use_id"]] = e["parentUuid"]
+
+    # each tool_result event's parent is exactly the matching tool_use event
+    assert tool_result_parent["tu_a"] == tool_use_uuid["tu_a"]
+    assert tool_result_parent["tu_b"] == tool_use_uuid["tu_b"]
+    # every parent reference resolves (or is the root)
+    for e in events:
+        assert e["parentUuid"] is None or e["parentUuid"] in by_uuid
+
+
+def test_assistant_blocks_share_message_id_and_explode_per_block() -> None:
+    events = conversation_to_events(_tool_conversation(), _det_env())
+    assistant_events = [e for e in events if e["type"] == "assistant"]
+
+    # first assistant message had 4 content blocks -> 4 events, one block each
+    first_msg = [e for e in assistant_events if e["requestId"] == "msg_1"]
+    assert len(first_msg) == 4
+    assert all(len(e["message"]["content"]) == 1 for e in first_msg)
+    assert {e["message"]["id"] for e in first_msg} == {"msg_1"}
+
+
+def test_round_trip_build_parse_reaches_a_stable_fixpoint() -> None:
+    # parse normalizes string content into a text block (both are valid API
+    # shapes); the meaningful guarantee is that build/parse then stabilizes, so
+    # a re-homed session reproduces the same messages[] Claude Code will resend.
+    convo = _tool_conversation()
+    parsed = parse_jsonl_conversation(build_session_jsonl(convo, _det_env()))
+    again = parse_jsonl_conversation(build_session_jsonl(parsed, _det_env()))
+
+    assert parsed == again
+    # the original user prompt and the tool round survive intact
+    assert parsed[0] == {"role": "user", "content": [{"type": "text", "text": "fix the bug"}]}
+    assert {b["type"] for b in parsed[1]["content"]} == {"thinking", "text", "tool_use"}
+    tool_results = [b for b in parsed[2]["content"] if b["type"] == "tool_result"]
+    assert {b["tool_use_id"] for b in tool_results} == {"tu_a", "tu_b"}
+
+
+def test_build_session_jsonl_sets_leaf_and_session_header() -> None:
+    doc = build_session_jsonl(_tool_conversation(), _det_env())
+    lines = [json.loads(line) for line in doc.splitlines()]
+
+    assert lines[0] == {"type": "mode", "mode": "normal", "sessionId": "SID"}
+    assert lines[1]["type"] == "permission-mode"
+    last = lines[-1]
+    assert last["type"] == "last-prompt"
+    conversation_uuids = [line["uuid"] for line in lines if line.get("type") in ("user", "assistant")]
+    assert last["leafUuid"] == conversation_uuids[-1]
+
+
+def test_export_claude_resume_format(tmp_path, capsys) -> None:
+    trace_path = tmp_path / "trace.jsonl"
+    record = {
+        "turn": 1,
+        "request": {"path": "/v1/messages", "body": {"model": "m", "messages": [{"role": "user", "content": "hello"}]}},
+        "response": {"body": {"content": [{"type": "text", "text": "hi there"}]}},
+    }
+    trace_path.write_text(json.dumps(record) + "\n", encoding="utf-8")
+    out_path = tmp_path / "transplant.jsonl"
+
+    assert export_main([str(trace_path), "--format", "claude-resume", "-o", str(out_path), "--cwd", r"C:\b"]) == 0
+
+    messages = parse_jsonl_conversation(out_path.read_text(encoding="utf-8"))
+    assert messages == [
+        {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        {"role": "assistant", "content": [{"type": "text", "text": "hi there"}]},
+    ]
+
+
+def test_install_resume_session_writes_under_project_slug(tmp_path) -> None:
+    installed = install_resume_session(
+        _tool_conversation(),
+        r"C:\work\proj",
+        home=tmp_path,
+        session_id="abc123",
+    )
+
+    expected = tmp_path / ".claude" / "projects" / "C--work-proj" / "abc123.jsonl"
+    assert installed.path == expected
+    assert expected.exists()
+    assert installed.resume_command == "claude --resume abc123"
+    assert installed.message_count == 4
+
+
+def test_import_resume_main_installs_and_warns_on_cwd_divergence(tmp_path, capsys) -> None:
+    # a transplant file captured under a different cwd
+    src = tmp_path / "transplant.jsonl"
+    env = _det_env(cwd=r"D:\other\place")
+    src.write_text(build_session_jsonl(_tool_conversation(), env), encoding="utf-8")
+
+    target = tmp_path / "dest"
+    target.mkdir()
+    rc = import_resume_main([str(src), "--cwd", str(target), "--home", str(tmp_path / "home"), "--session-id", "sid9"])
+
+    assert rc == 0
+    out = capsys.readouterr()
+    assert "Warning" in out.err and r"D:\other\place" in out.err
+    installed = tmp_path / "home" / ".claude" / "projects" / project_slug(str(target)) / "sid9.jsonl"
+    assert installed.exists()
+    assert "claude --resume sid9" in out.out
+    # the re-homed session reproduces the original conversation (string content
+    # normalized to a text block by the parse round-trip)
+    expected = parse_jsonl_conversation(build_session_jsonl(_tool_conversation(), _det_env()))
+    assert parse_jsonl_conversation(installed.read_text(encoding="utf-8")) == expected
+
+
+def test_import_resume_main_no_warning_for_same_dir_written_differently(tmp_path, capsys) -> None:
+    import os
+
+    target = tmp_path / "dest"
+    target.mkdir()
+    src = tmp_path / "transplant.jsonl"
+    src.write_text(build_session_jsonl(_tool_conversation(), _det_env(cwd=str(target))), encoding="utf-8")
+
+    # same directory, expressed with a redundant "." segment -> must not warn
+    rc = import_resume_main([str(src), "--cwd", os.path.join(str(target), "."), "--home", str(tmp_path / "home")])
+
+    assert rc == 0
+    assert "Warning" not in capsys.readouterr().err
+
+
+def test_import_resume_main_rejects_empty_source(tmp_path, capsys) -> None:
+    src = tmp_path / "empty.jsonl"
+    src.write_text('{"type": "mode", "mode": "normal"}\n', encoding="utf-8")
+
+    assert import_resume_main([str(src), "--home", str(tmp_path / "home")]) == 1
+    assert "no user/assistant messages" in capsys.readouterr().err


### PR DESCRIPTION
## What

Adds **session transplant**: move an in-progress Claude Code session from one machine to another.

claude-tap records the Anthropic wire traffic, and the fullest request body already carries the entire conversation (`messages[]`). This reconstructs that into Claude Code's own resume log so a session captured on machine A can be re-homed and resumed on machine B with `claude --resume`.

- `session_transplant.py` - picks the fullest request + final response, explodes messages into per-block resume events, threads each `tool_result` to the `tool_use` it answers (matching Claude Code's native tree), and installs under the project slug.
- `export --format claude-resume` - emits the resumable JSONL (machine A).
- `import-resume <file> --cwd <dir>` - installs into `~/.claude/projects/<slug>/<uuid>.jsonl`, prints the resume command, and warns when paths diverge (machine B). Also accepts a native Claude Code session log, so any session can be re-homed.

Only the conversation is transplanted; Claude Code rebuilds the system prompt and tool definitions itself at launch, which is the desired behavior.

## Why this is correct

The format was reverse-engineered from real Claude Code 2.1.x session logs (per-block events, `uuid`/`parentUuid` tree, `tool_result -> tool_use` threading, `last-prompt.leafUuid`). De-risk: a build->parse round-trip against a **real, known-good** session reproduces an identical `messages[]` (52 messages, 28/28 tool pairs matched) - the same array Claude Code already sent successfully, so it is API-valid.

## Least privilege

- Filesystem writes are confined to `~/.claude/projects/<slug>/` (overridable via `--home`).
- `detect_claude_version()` runs `claude --version` only (fixed argv, 10s timeout, best-effort with a static fallback).

## Testing

- New `tests/test_session_transplant.py` (12 tests): slug vs real dirs, fullest-request extraction, tool-result threading, per-block explosion, build/parse fixpoint, leaf wiring, export format, install path, import end-to-end + cwd-divergence warning.
- `ruff check .`, `ruff format --check .`, and legibility check pass.
- Full suite green except pre-existing Windows-only environment failures on `main` (cert permissions, `WinError` file locks, ws-proxy env, `Path.is_absolute` on `/tmp`) - confirmed present with this branch stashed; unaffected by these changes and covered separately by the windows-compat work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
