### PR TITLE
Document local proxy upstream support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Co
 
 | Client | Typical use |
 |--------|-------------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic API, AWS Bedrock, or Claude-compatible gateways such as DeepSeek / GLM |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic API, AWS Bedrock, Claude-compatible gateways such as DeepSeek / GLM, or local proxy upstreams such as CC Switch |
 | [Codex CLI](https://github.com/openai/codex) | OpenAI API key mode or ChatGPT subscription OAuth |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google OAuth / Code Assist traffic |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | Kimi Code or Moonshot Open Platform |
@@ -133,6 +133,8 @@ claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6
 `claude-tap` auto-detects custom Claude Code upstreams from `ANTHROPIC_BASE_URL`
 or `ANTHROPIC_BEDROCK_BASE_URL` in your environment or Claude settings. Use
 `--tap-target` only when you want to override that detected target.
+
+Local proxy upstreams are supported too: if a tool such as [CC Switch](https://github.com/farion1231/cc-switch) points Claude Code at a local `ANTHROPIC_BASE_URL`, `claude-tap` detects that value from Claude settings and records the traffic before forwarding it upstream. Run the normal Claude Code command (`claude-tap`); no separate `--tap-client` value is needed.
 
 For the Claude Code VS Code extension, set `Claude Code: Claude Process Wrapper` to `claude-tap`; on Windows, use the full `claude-tap.exe` path if VS Code cannot find it.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6
 or `ANTHROPIC_BEDROCK_BASE_URL` in your environment or Claude settings. Use
 `--tap-target` only when you want to override that detected target.
 
-Local proxy upstreams are supported too: if a tool such as [CC Switch](https://github.com/farion1231/cc-switch) points Claude Code at a local `ANTHROPIC_BASE_URL`, `claude-tap` detects that value from Claude settings and records the traffic before forwarding it upstream. Run the normal Claude Code command (`claude-tap`); no separate `--tap-client` value is needed.
+Local proxy upstreams are supported too: if a tool such as [CC Switch](https://github.com/farion1231/cc-switch) points Claude Code at a local `ANTHROPIC_BASE_URL`, `claude-tap` detects that value from Claude settings and records the traffic before forwarding it upstream. Use `claude-tap` in place of `claude`, such as `claude-tap -- <claude-args>`; no separate `--tap-client` value is needed.
 
 For the Claude Code VS Code extension, set `Claude Code: Claude Process Wrapper` to `claude-tap`; on Windows, use the full `claude-tap.exe` path if VS Code cannot find it.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -133,7 +133,7 @@ claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6
 `claude-tap` 会从环境变量或 Claude settings 中的 `ANTHROPIC_BASE_URL` 或
 `ANTHROPIC_BEDROCK_BASE_URL` 自动识别自定义 Claude Code 上游；只有想手动覆盖时才需要传 `--tap-target`。
 
-也支持本地代理上游：如果 [CC Switch](https://github.com/farion1231/cc-switch) 等工具把 Claude Code 指向本地 `ANTHROPIC_BASE_URL`，`claude-tap` 会从 Claude settings 中检测到该值，并在转发到上游前记录流量。直接运行常规 Claude Code 命令（`claude-tap`）即可，不需要单独的 `--tap-client` 值。
+也支持本地代理上游：如果 [CC Switch](https://github.com/farion1231/cc-switch) 等工具把 Claude Code 指向本地 `ANTHROPIC_BASE_URL`，`claude-tap` 会从 Claude settings 中检测到该值，并在转发到上游前记录流量。用 `claude-tap` 替代 `claude` 运行，例如 `claude-tap -- <Claude Code 参数>`；不需要单独的 `--tap-client` 值。
 
 使用 Claude Code VS Code 插件时，把 `Claude Code: Claude Process Wrapper` 设置为 `claude-tap`；如果 Windows 上 VS Code 找不到它，请填写完整的 `claude-tap.exe` 路径。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -53,7 +53,7 @@
 
 | 客户端 | 典型用途 |
 |--------|----------|
-| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic API、AWS Bedrock，或 DeepSeek / GLM 等 Claude 兼容网关 |
+| [Claude Code](https://docs.anthropic.com/en/docs/claude-code) | Anthropic API、AWS Bedrock、DeepSeek / GLM 等 Claude 兼容网关，或 CC Switch 等本地代理上游 |
 | [Codex CLI](https://github.com/openai/codex) | OpenAI API 密钥模式，或 ChatGPT 订阅 OAuth |
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | Google OAuth / Code Assist 的多 Google 端点流量 |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | Kimi Code 或 Moonshot Open Platform |
@@ -132,6 +132,8 @@ claude-tap -- --dangerously-skip-permissions --model claude-sonnet-4-6
 
 `claude-tap` 会从环境变量或 Claude settings 中的 `ANTHROPIC_BASE_URL` 或
 `ANTHROPIC_BEDROCK_BASE_URL` 自动识别自定义 Claude Code 上游；只有想手动覆盖时才需要传 `--tap-target`。
+
+也支持本地代理上游：如果 [CC Switch](https://github.com/farion1231/cc-switch) 等工具把 Claude Code 指向本地 `ANTHROPIC_BASE_URL`，`claude-tap` 会从 Claude settings 中检测到该值，并在转发到上游前记录流量。直接运行常规 Claude Code 命令（`claude-tap`）即可，不需要单独的 `--tap-client` 值。
 
 使用 Claude Code VS Code 插件时，把 `Claude Code: Claude Process Wrapper` 设置为 `claude-tap`；如果 Windows 上 VS Code 找不到它，请填写完整的 `claude-tap.exe` 路径。
 


### PR DESCRIPTION
## Summary
- Document that Claude Code tracing supports local proxy upstreams such as CC Switch.
- Keep the English and Simplified Chinese README support tables and Claude Code notes in sync.

## Validation
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check .
- git diff --check
- Manually verified a local Claude Code upstream chain by running claude-tap against `http://127.0.0.1:3456`; the dashboard recorded the proxied `/v1/messages` request and response successfully.