### PR TITLE
chore: update changelog for v0.1.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.105] - 2026-06-09
+
+### Changed
+- fix: guard against None values in usage token fields causing dashboard 500 (#303)
 ## [0.1.104] - 2026-06-09
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.105.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
