### PR TITLE
chore: update changelog for v0.1.110

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.110] - 2026-06-12
+
+### Changed
+- Add bulk session deletion and lazy dashboard paging (#298)
 ## [0.1.109] - 2026-06-12
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.110.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
