### PR TITLE
docs: add Phistory ecosystem showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ It works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code), [Co
   </tr>
 </table>
 
+## Built with claude-tap
+
+<table>
+  <tr>
+    <td width="55%">
+      <strong><a href="https://github.com/WEIFENG2333/phistory">Phistory</a></strong> archives versioned system prompt snapshots from agent CLIs such as Claude Code, Codex, Kimi, opencode, and Pi. It uses claude-tap's capture-only prompt export to preserve raw HTTP trace evidence and generate comparison-friendly prompt snapshots.
+      <br><br>
+      <a href="https://phistory.cc/">Open the prompt diff viewer</a> · <a href="https://github.com/WEIFENG2333/phistory">View repository</a>
+    </td>
+    <td width="45%" align="center">
+      <a href="https://phistory.cc/">
+        <img src="https://raw.githubusercontent.com/WEIFENG2333/phistory/main/docs/screenshot.png" alt="Phistory prompt diff viewer" width="420">
+      </a>
+    </td>
+  </tr>
+</table>
+
 ## Why use it
 
 - 👀 **See the exact context**: inspect prompts, messages, tool definitions, tool calls, tool results, reconstructed streaming responses, and token usage.
@@ -500,6 +517,10 @@ The viewer is a single self-contained HTML file (zero external dependencies):
 </details>
 
 ## Community
+
+### Ecosystem
+
+- [Phistory](https://github.com/WEIFENG2333/phistory) archives versioned system prompt snapshots from agent CLIs such as Claude Code, Codex, Kimi, opencode, and Pi. It uses claude-tap's capture-only prompt export to preserve raw HTTP trace evidence and generate comparison-friendly prompt snapshots.
 
 ### Star History
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -41,6 +41,23 @@
   </tr>
 </table>
 
+## 使用 claude-tap 构建
+
+<table>
+  <tr>
+    <td width="55%">
+      <strong><a href="https://github.com/WEIFENG2333/phistory">Phistory</a></strong> 会归档 Claude Code、Codex、Kimi、opencode、Pi 等 Agent CLI 的系统提示词版本快照。它基于 claude-tap 的 capture-only prompt export 能力，保留原始 HTTP trace 证据，并生成方便阅读和对比的 prompt 快照。
+      <br><br>
+      <a href="https://phistory.cc/">打开 prompt diff 查看器</a> · <a href="https://github.com/WEIFENG2333/phistory">查看仓库</a>
+    </td>
+    <td width="45%" align="center">
+      <a href="https://phistory.cc/">
+        <img src="https://raw.githubusercontent.com/WEIFENG2333/phistory/main/docs/screenshot.png" alt="Phistory prompt diff 查看器" width="420">
+      </a>
+    </td>
+  </tr>
+</table>
+
 ## 为什么用它
 
 - 👀 **看见真实上下文**：检查 prompt、messages、工具定义、工具调用、工具结果、流式 chunk 和 token 用量。
@@ -497,6 +514,10 @@ claude-tap --tap-no-open
 </details>
 
 ## 社区
+
+### 生态项目
+
+- [Phistory](https://github.com/WEIFENG2333/phistory) 会归档 Claude Code、Codex、Kimi、opencode、Pi 等 Agent CLI 的系统提示词版本快照。它基于 claude-tap 的 capture-only prompt export 能力，保留原始 HTTP trace 证据，并生成方便阅读和对比的 prompt 快照。
 
 ### Star 历史
 


### PR DESCRIPTION
## Summary

- Add a top README Phistory showcase card with a screenshot and links to the live prompt diff viewer and repository.
- Keep a smaller Phistory ecosystem entry in the Community section.
- Mirror the same placement and copy in README_zh.md.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `env -u OPENAI_BASE_URL uv run pytest tests/ -x --timeout=60` -> `710 passed, 25 skipped`
- `curl -I -L --max-time 20 https://raw.githubusercontent.com/WEIFENG2333/phistory/main/docs/screenshot.png` -> HTTP 200

## Evidence

- README screenshot asset: https://raw.githubusercontent.com/WEIFENG2333/phistory/main/docs/screenshot.png
- Docs-only README content change; no local runtime, viewer, or client behavior changed.
