### PR TITLE
chore: update changelog for v0.1.114

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.114] - 2026-06-12
+
+### Changed
+- fix: decode double-serialized JSON request bodies
 ## [0.1.113] - 2026-06-12
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.114.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
