### PR TITLE
fix(sse): reconstruct Codex Responses output from output_item events

### DIFF
--- a/claude_tap/sse.py
+++ b/claude_tap/sse.py
@@ -77,12 +77,31 @@ class SSEReassembler:
 
             if event_type == "message_start":
                 self._snapshot = copy.deepcopy(data.get("message", {}))
-            elif event_type in ("response.created", "response.completed", "response.done"):
+            elif event_type == "response.created":
                 response = data.get("response")
                 if isinstance(response, dict):
                     self._snapshot = copy.deepcopy(response)
-                elif event_type in ("response.completed", "response.done"):
-                    self._snapshot = copy.deepcopy(data)
+            elif event_type in ("response.output_item.added", "response.output_item.done"):
+                # The Codex/ChatGPT backend streams each output item here and
+                # sends response.completed with an EMPTY output array, so the
+                # items have to be accumulated rather than read off the
+                # terminal event. Must run before the `_snapshot is None`
+                # guard since output_item.added can be the first event.
+                self._accumulate_responses_output_item(data)
+            elif event_type == "response.output_text.delta":
+                self._accumulate_responses_output_text(data)
+            elif event_type in (
+                "response.completed",
+                "response.done",
+                "response.incomplete",
+                "response.failed",
+            ):
+                # incomplete (e.g. max_output_tokens) and failed carry the same
+                # {"response": {...}} shape as completed, with the final status,
+                # usage and error / incomplete_details — merge them the same way.
+                self._merge_responses_terminal(data)
+            elif event_type == "response.error":
+                self._record_responses_error(data)
             elif gemini_chunk is not None:
                 # Gemini streamGenerateContent uses bare `data: {...}` frames
                 # with no `event:` header. Accumulate them before the generic
@@ -140,6 +159,90 @@ class SSEReassembler:
                     self._snapshot["usage"].update(normalize_usage(usage))
         except Exception:
             pass
+
+    def _ensure_responses_output(self) -> list:
+        """Return the snapshot's OpenAI Responses `output` list, creating the
+        snapshot and/or the list if a streaming output item arrives before
+        response.created."""
+        if self._snapshot is None:
+            self._snapshot = {"output": []}
+        output = self._snapshot.get("output")
+        if not isinstance(output, list):
+            output = []
+            self._snapshot["output"] = output
+        return output
+
+    def _accumulate_responses_output_item(self, data: dict) -> None:
+        """Place an OpenAI Responses output item into the snapshot at its
+        output_index. response.output_item.done carries the complete item and
+        is authoritative; response.output_item.added seeds a placeholder that
+        text deltas can append to."""
+        item = data.get("item")
+        if not isinstance(item, dict):
+            return
+        output = self._ensure_responses_output()
+        idx = data.get("output_index")
+        if not isinstance(idx, int) or idx < 0:
+            idx = len(output)
+        while len(output) <= idx:
+            output.append({})
+        output[idx] = copy.deepcopy(item)
+
+    def _accumulate_responses_output_text(self, data: dict) -> None:
+        """Append a response.output_text.delta to the in-progress message item
+        so partial/truncated streams still retain their text even if the
+        terminal response.output_item.done never arrives."""
+        delta = data.get("delta")
+        if not isinstance(delta, str) or not delta:
+            return
+        output = self._ensure_responses_output()
+        idx = data.get("output_index")
+        if not isinstance(idx, int) or idx < 0:
+            idx = len(output) - 1
+        if idx < 0 or idx >= len(output):
+            return
+        item = output[idx]
+        if not isinstance(item, dict):
+            return
+        content = item.get("content")
+        if not isinstance(content, list):
+            content = []
+            item["content"] = content
+        part = next((c for c in content if isinstance(c, dict) and c.get("type") == "output_text"), None)
+        if part is None:
+            part = {"type": "output_text", "text": ""}
+            content.append(part)
+        part["text"] = (part.get("text") or "") + delta
+
+    def _merge_responses_terminal(self, data: dict) -> None:
+        """Apply a terminal response.completed / response.done event.
+
+        The terminal `response` object carries the final status and usage but
+        the Codex/ChatGPT backend leaves its `output` empty (the items were
+        streamed via response.output_item.* events), so preserve the output
+        already accumulated in the snapshot when the terminal one is empty."""
+        response = data.get("response")
+        if not isinstance(response, dict):
+            self._snapshot = copy.deepcopy(data)
+            return
+        response = copy.deepcopy(response)
+        accumulated = self._snapshot.get("output") if isinstance(self._snapshot, dict) else None
+        if not response.get("output") and isinstance(accumulated, list) and accumulated:
+            response["output"] = accumulated
+        self._snapshot = response
+
+    def _record_responses_error(self, data: dict) -> None:
+        """Capture a stream-level response.error event. It carries no response
+        object, so attach the error to the snapshot without discarding output
+        already accumulated from response.output_item.* events."""
+        if self._snapshot is None:
+            self._snapshot = {"output": []}
+        error = {k: data[k] for k in ("code", "message", "param") if k in data}
+        self._snapshot["error"] = error or copy.deepcopy(data)
+        # The stream errored out, so promote a still-running status to failed
+        # but never override a status a terminal event already set.
+        if self._snapshot.get("status") in (None, "", "queued", "in_progress"):
+            self._snapshot["status"] = "failed"
 
     def _content_block_for_delta(self, idx: int, delta: dict) -> dict | None:
         if not isinstance(idx, int) or idx < 0:

--- a/tests/test_responses_support.py
+++ b/tests/test_responses_support.py
@@ -26,6 +26,181 @@ def test_sse_reassembler_reconstructs_openai_responses_completed_event() -> None
     assert body["usage"] == {"input_tokens": 12, "output_tokens": 3, "reasoning_tokens": 0}
 
 
+def test_sse_reassembler_recovers_output_from_item_events_when_completed_is_empty() -> None:
+    # The Codex/ChatGPT backend over HTTP/SSE (model_provider = "openai_http")
+    # streams output via response.output_item.* events and sends a terminal
+    # response.completed with output: []. The reassembler must keep the items.
+    reassembler = SSEReassembler()
+    for frame in (
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_1","status":"in_progress","model":"gpt-5.5","output":[]}}\n\n',
+        b'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant","content":[]}}\n\n',
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":"Hello"}\n\n',
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":" world"}\n\n',
+        b'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Hello world"}]}}\n\n',
+        b'event: response.completed\ndata: {"type":"response.completed","response":{"id":"resp_1","status":"completed","model":"gpt-5.5","output":[],"usage":{"input_tokens":13159,"output_tokens":18,"total_tokens":13177}}}\n\n',
+    ):
+        reassembler.feed_bytes(frame)
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["status"] == "completed"
+    assert body["output"][0]["content"][0]["text"] == "Hello world"
+    assert body["usage"] == {"input_tokens": 13159, "output_tokens": 18, "total_tokens": 13177}
+
+
+def test_sse_reassembler_keeps_streamed_text_when_completed_done_is_missing() -> None:
+    # A truncated capture: output_item.done / response.completed never arrive,
+    # so the accumulated output_text.delta content must survive on its own.
+    reassembler = SSEReassembler()
+    for frame in (
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"resp_2","status":"in_progress","output":[]}}\n\n',
+        b'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant","content":[]}}\n\n',
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":"partial"}\n\n',
+    ):
+        reassembler.feed_bytes(frame)
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["output"][0]["content"][0]["text"] == "partial"
+
+
+def test_sse_reassembler_merges_response_incomplete_terminal_event() -> None:
+    # A response truncated by max_output_tokens ends with response.incomplete,
+    # not response.completed. The final status/usage/details must be captured
+    # while the streamed output items are preserved.
+    reassembler = SSEReassembler()
+    for frame in (
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"r","status":"in_progress","output":[]}}\n\n',
+        b'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"cut off"}]}}\n\n',
+        b'event: response.incomplete\ndata: {"type":"response.incomplete","response":{"id":"r","status":"incomplete","output":[],"incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":5,"output_tokens":7}}}\n\n',
+    ):
+        reassembler.feed_bytes(frame)
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["status"] == "incomplete"
+    assert body["incomplete_details"] == {"reason": "max_output_tokens"}
+    assert body["usage"] == {"input_tokens": 5, "output_tokens": 7}
+    assert body["output"][0]["content"][0]["text"] == "cut off"
+
+
+def test_sse_reassembler_merges_response_failed_terminal_event() -> None:
+    reassembler = SSEReassembler()
+    for frame in (
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"r","status":"in_progress","output":[]}}\n\n',
+        b'event: response.failed\ndata: {"type":"response.failed","response":{"id":"r","status":"failed","output":[],"error":{"code":"server_error","message":"boom"},"usage":{"input_tokens":3,"output_tokens":0}}}\n\n',
+    ):
+        reassembler.feed_bytes(frame)
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["status"] == "failed"
+    assert body["error"] == {"code": "server_error", "message": "boom"}
+
+
+def test_sse_reassembler_records_stream_level_response_error_event() -> None:
+    # response.error has no "response" object and can arrive mid-stream; the
+    # error must be attached without discarding accumulated output.
+    reassembler = SSEReassembler()
+    for frame in (
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"r","status":"in_progress","output":[]}}\n\n',
+        b'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":0,"item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi"}]}}\n\n',
+        b'event: response.error\ndata: {"type":"error","code":"rate_limit_exceeded","message":"slow down","param":null}\n\n',
+    ):
+        reassembler.feed_bytes(frame)
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["status"] == "failed"
+    assert body["error"]["code"] == "rate_limit_exceeded"
+    assert body["error"]["message"] == "slow down"
+    assert body["output"][0]["content"][0]["text"] == "hi"
+
+
+def test_sse_reassembler_accepts_output_item_before_response_created() -> None:
+    reassembler = SSEReassembler()
+    reassembler.feed_bytes(
+        b'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":"bad","item":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"early"}]}}\n\n'
+    )
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["output"][0]["content"][0]["text"] == "early"
+
+
+def test_sse_reassembler_repairs_non_list_responses_output_and_content() -> None:
+    reassembler = SSEReassembler()
+    for frame in (
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"r","status":"in_progress","output":{"unexpected":true}}}\n\n',
+        b'event: response.output_item.added\ndata: {"type":"response.output_item.added","output_index":0,"item":{"type":"message","role":"assistant","content":{"unexpected":true}}}\n\n',
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","delta":"repaired"}\n\n',
+    ):
+        reassembler.feed_bytes(frame)
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["output"][0]["content"] == [{"type": "output_text", "text": "repaired"}]
+
+
+def test_sse_reassembler_ignores_malformed_responses_item_and_text_events() -> None:
+    item_reassembler = SSEReassembler()
+    item_reassembler.feed_bytes(
+        b'event: response.output_item.done\ndata: {"type":"response.output_item.done","output_index":0,"item":null}\n\n'
+    )
+    assert item_reassembler.reconstruct() is None
+
+    empty_delta_reassembler = SSEReassembler()
+    empty_delta_reassembler.feed_bytes(
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":""}\n\n'
+    )
+    assert empty_delta_reassembler.reconstruct() is None
+
+    out_of_range_reassembler = SSEReassembler()
+    out_of_range_reassembler.feed_bytes(
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"r","output":[]}}\n\n'
+    )
+    out_of_range_reassembler.feed_bytes(
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":"ignored"}\n\n'
+    )
+    assert out_of_range_reassembler.reconstruct() == {"id": "r", "output": []}
+
+    non_dict_item_reassembler = SSEReassembler()
+    non_dict_item_reassembler.feed_bytes(
+        b'event: response.created\ndata: {"type":"response.created","response":{"id":"r","output":["raw"]}}\n\n'
+    )
+    non_dict_item_reassembler.feed_bytes(
+        b'event: response.output_text.delta\ndata: {"type":"response.output_text.delta","output_index":0,"delta":"ignored"}\n\n'
+    )
+    assert non_dict_item_reassembler.reconstruct() == {"id": "r", "output": ["raw"]}
+
+
+def test_sse_reassembler_handles_responses_terminal_without_response_object() -> None:
+    reassembler = SSEReassembler()
+    reassembler.feed_bytes(b'event: response.completed\ndata: {"type":"response.completed","id":"r"}\n\n')
+
+    body = reassembler.reconstruct()
+
+    assert body == {"type": "response.completed", "id": "r"}
+
+
+def test_sse_reassembler_records_response_error_before_any_snapshot() -> None:
+    reassembler = SSEReassembler()
+    reassembler.feed_bytes(b'event: response.error\ndata: {"type":"error","code":"server_error","message":"boom"}\n\n')
+
+    body = reassembler.reconstruct()
+
+    assert body is not None
+    assert body["status"] == "failed"
+    assert body["error"] == {"code": "server_error", "message": "boom"}
+
+
 def test_extract_metadata_supports_responses_input_roles_and_ws_usage() -> None:
     fixture_path = Path(__file__).parent / "fixtures" / "openai_responses_trace.jsonl"
     record_json = fixture_path.read_text(encoding="utf-8").splitlines()[0]


### PR DESCRIPTION
## Summary

Codex HTTP/SSE (`model_provider = "openai_http"`, Responses wire API) streams assistant content through `response.output_item.added` / `.done` and `response.output_text.delta`, while the terminal `response.completed` can carry `output: []`.

Before this change, `SSEReassembler` ignored those output item events and replaced the snapshot with the empty terminal response, so HTTP/SSE traces kept usage but lost assistant output.

This change:

- accumulates `response.output_item.added` / `.done` by `output_index`
- accumulates `response.output_text.delta` so truncated streams keep partial text
- merges `response.completed`, `response.done`, `response.incomplete`, and `response.failed` without discarding accumulated output
- records stream-level `response.error` events without dropping partial output

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Test or tooling
- [ ] Maintenance

## Validation

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -x --timeout=60`
- [x] CI coverage-equivalent local run completed, ending with `uv run python scripts/check_coverage.py --python-coverage .coverage.json`
- [ ] Not required; docs-only or metadata-only change.

## Evidence

Real trace/viewer source: `.traces`-backed Codex Responses viewer export for a `/backend-api/codex/responses` run; no raw trace or generated viewer is committed.

![trace viewer evidence](https://raw.githubusercontent.com/liaohch3/claude-tap/main/.agents/evidence/pr/227/codex-forward-trace-viewer.png)

## Privacy

- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.
