### PR TITLE
chore: update changelog for v0.1.123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.1.123] - 2026-06-27
+
+### Changed
+- fix: refresh stale dashboard after updates (#348)
+- feat: support Claude Code Vertex and Bedrock gateways (#349)
 ### Added
 - Add Claude Code Vertex `ANTHROPIC_VERTEX_BASE_URL` target detection and proxy routing support.
 - Add Claude Code compatibility for Anthropic-compatible Bedrock gateway models such as `bedrock/claude-opus-4-6`.


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.123.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
