### PR TITLE
chore: update changelog for v0.1.125

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+## [0.1.125] - 2026-07-01
+
+### Changed
+- Show macOS monitor startup failures (#335)
 ### Added
 - Add a local macOS menu bar app launcher with dashboard monitor controls.
 


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.125.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
