### PR TITLE
chore: update changelog for v0.1.128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.128] - 2026-07-10
+
+### Changed
+- Make compact trace the default export format (#368)
 ## [0.1.127] - 2026-07-09
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.128.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
