### PR TITLE
chore: update changelog for v0.1.129

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.129] - 2026-07-10
+
+### Changed
+- fix(viewer): read Responses additional tools
+- test: add additional tools viewer evidence
+- fix(viewer): preserve Codex websocket tools
 ## [0.1.128] - 2026-07-10
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.129.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
