### PR TITLE
chore: update changelog for v0.1.135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.135] - 2026-07-18
+
+### Changed
+- fix: prevent SQLite locks from blocking clients (#385)
+- test: avoid PID collisions in monitor cleanup test (#390)
 ## [0.1.134] - 2026-07-11
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.135.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
