### PR TITLE
test: avoid PID collisions in monitor cleanup test

### DIFF
--- a/tests/test_global_inject.py
+++ b/tests/test_global_inject.py
@@ -461,6 +461,10 @@ def test_restore_files_skips_invalid_entries_and_missing_backups(_home: Path) ->
 def test_terminate_recorded_processes_filters_and_kills_stubborn_process(
     _home: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    current_pid = os.getpid()
+    unrelated_pid = current_pid + 1
+    stubborn_pid = current_pid + 2
+    exiting_pid = current_pid + 3
     state_file = _home / ".claude-tap" / "monitor-state.json"
     state_file.parent.mkdir(parents=True)
     state_file.write_text(
@@ -470,20 +474,20 @@ def test_terminate_recorded_processes_filters_and_kills_stubborn_process(
                 "processes": [
                     "invalid",
                     {"pid": -1},
-                    {"pid": os.getpid()},
-                    {"pid": 1111},
-                    {"pid": 2222},
-                    {"pid": 3333},
+                    {"pid": current_pid},
+                    {"pid": unrelated_pid},
+                    {"pid": stubborn_pid},
+                    {"pid": exiting_pid},
                 ],
             }
         )
     )
     commands = {
-        1111: "python unrelated.py",
-        2222: "python -m claude_tap dashboard",
-        3333: "python -m claude_tap --tap-no-launch",
+        unrelated_pid: "python unrelated.py",
+        stubborn_pid: "python -m claude_tap dashboard",
+        exiting_pid: "python -m claude_tap --tap-no-launch",
     }
-    alive_checks = {2222: [True, True, True], 3333: [True, False]}
+    alive_checks = {stubborn_pid: [True, True, True], exiting_pid: [True, False]}
     signals: list[tuple[int, signal.Signals]] = []
 
     def fake_pid_exists(pid: int) -> bool:
@@ -494,7 +498,7 @@ def test_terminate_recorded_processes_filters_and_kills_stubborn_process(
 
     def fake_kill(pid: int, sig: int) -> None:
         signals.append((pid, signal.Signals(sig)))
-        if pid == 3333:
+        if pid == exiting_pid:
             raise OSError("gone")
 
     monkeypatch.setattr(global_inject, "_monitor_process_command", lambda pid: commands[pid])
@@ -505,7 +509,11 @@ def test_terminate_recorded_processes_filters_and_kills_stubborn_process(
 
     global_inject.disable(terminate_processes=True)
 
-    assert signals == [(2222, signal.SIGTERM), (2222, signal.SIGKILL), (3333, signal.SIGTERM)]
+    assert signals == [
+        (stubborn_pid, signal.SIGTERM),
+        (stubborn_pid, signal.SIGKILL),
+        (exiting_pid, signal.SIGTERM),
+    ]
 
 
 def test_monitor_process_helpers_handle_failures(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Replace fixed fake PIDs in the monitor cleanup test with PIDs derived from the current pytest process.
- Keep the current-process safety case while ensuring the unrelated, stubborn, and exiting fake processes cannot accidentally reuse pytest's real PID.

## Problem

The release PR test matrix failed on Python 3.11, 3.12, and 3.13 because the runner assigned pytest PID `2222`, which was also hard-coded as the stubborn fake process. Production code correctly skipped that PID as the current process, so the test observed only the `3333` signal and failed. This blocks the automated v0.1.135 release in #386.

Failure: https://github.com/liaohch3/claude-tap/actions/runs/29186028941/job/86632160191

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv lock --check`
- `uv run pytest tests/test_global_inject.py::test_terminate_recorded_processes_filters_and_kills_stubborn_process -v` -> 1 passed
- `uv run --no-dev pytest tests/ -x --timeout=60 -q` -> 891 passed, 121 skipped
- Independent Codex review -> passed with no security concerns or logic errors

## Evidence

- Not required: this is a test-only stabilization change and does not modify runtime, client, viewer, or UI behavior.
