### PR TITLE
chore: update changelog for v0.1.137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.137] - 2026-07-21
+
+### Changed
+- feat: add Grok Build CLI support (#394)
 ## [0.1.136] - 2026-07-19
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.137.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
