### PR TITLE
ci: run star history update at Beijing 3 AM

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -2,7 +2,8 @@ name: Update star history
 
 on:
   schedule:
-    - cron: "17 3 * * *"
+    # 03:00 Asia/Shanghai (19:00 UTC on the previous calendar day).
+    - cron: "0 19 * * *"
   workflow_dispatch:
 
 concurrency:

--- a/tests/test_update_star_history.py
+++ b/tests/test_update_star_history.py
@@ -77,7 +77,7 @@ def test_render_charts_persists_valid_light_and_dark_pngs(tmp_path, monkeypatch)
 def test_star_history_workflow_publishes_to_asset_branch():
     workflow = (Path(__file__).resolve().parent.parent / ".github" / "workflows" / "star-history.yml").read_text()
 
-    assert 'cron: "17 3 * * *"' in workflow
+    assert 'cron: "0 19 * * *"' in workflow
     assert workflow.count("contents: read") == 1
     assert workflow.count("contents: write") == 1
     assert "needs: generate" in workflow


### PR DESCRIPTION
## Summary

- run the daily Star History update at 03:00 Asia/Shanghai
- express the GitHub Actions cron as 19:00 UTC and document the timezone conversion
- update the workflow regression assertion

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -x --timeout=60` (`1005 passed, 26 skipped`)