### PR TITLE
ci: fetch star history through GraphQL

### DIFF
--- a/scripts/update_star_history.py
+++ b/scripts/update_star_history.py
@@ -12,8 +12,22 @@ from datetime import datetime
 from pathlib import Path
 from urllib.request import Request, urlopen
 
-GITHUB_API_VERSION = "2022-11-28"
-STARGAZER_ACCEPT = "application/vnd.github.star+json"
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+STARGAZERS_QUERY = """
+query StarHistory($owner: String!, $name: String!, $cursor: String) {
+  repository(owner: $owner, name: $name) {
+    stargazers(first: 100, after: $cursor, orderBy: {field: STARRED_AT, direction: ASC}) {
+      edges {
+        starredAt
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+"""
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
@@ -24,39 +38,62 @@ def _request_json(request: Request) -> object:
 
 def fetch_stargazer_timestamps(
     repo: str,
-    token: str | None = None,
+    token: str | None,
     request_json: Callable[[Request], object] = _request_json,
 ) -> list[datetime]:
     """Fetch every stargazer timestamp in chronological order."""
     if not REPO_PATTERN.fullmatch(repo) or any(part in {".", ".."} for part in repo.split("/")):
         raise ValueError("repo must use the OWNER/REPO format")
+    if not token:
+        raise RuntimeError("GITHUB_TOKEN is required to fetch stargazer timestamps")
 
+    owner, name = repo.split("/")
     timestamps: list[datetime] = []
-    page = 1
+    cursor = None
+    page = 0
     while True:
+        page += 1
         if page > 1000:
             raise RuntimeError("GitHub stargazers pagination exceeded 1000 pages")
         request = Request(
-            f"https://api.github.com/repos/{repo}/stargazers?per_page=100&page={page}",
+            GITHUB_GRAPHQL_URL,
+            data=json.dumps(
+                {
+                    "query": STARGAZERS_QUERY,
+                    "variables": {"owner": owner, "name": name, "cursor": cursor},
+                }
+            ).encode(),
             headers={
-                "Accept": STARGAZER_ACCEPT,
-                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
                 "User-Agent": "claude-tap-star-history",
-                **({"Authorization": f"Bearer {token}"} if token else {}),
             },
+            method="POST",
         )
         payload = request_json(request)
-        if not isinstance(payload, list):
-            raise RuntimeError("GitHub stargazers response was not a list")
+        if not isinstance(payload, dict) or payload.get("errors"):
+            raise RuntimeError("GitHub GraphQL stargazers request failed")
+        try:
+            stargazers = payload["data"]["repository"]["stargazers"]
+            edges = stargazers["edges"]
+            page_info = stargazers["pageInfo"]
+        except (KeyError, TypeError) as error:
+            raise RuntimeError("GitHub GraphQL response omitted stargazer data") from error
+        if not isinstance(edges, list):
+            raise RuntimeError("GitHub GraphQL stargazer edges were not a list")
 
-        for item in payload:
-            if not isinstance(item, dict) or not isinstance(item.get("starred_at"), str):
-                raise RuntimeError("GitHub stargazers response omitted starred_at")
-            timestamps.append(datetime.fromisoformat(item["starred_at"].replace("Z", "+00:00")))
+        for edge in edges:
+            if not isinstance(edge, dict) or not isinstance(edge.get("starredAt"), str):
+                raise RuntimeError("GitHub GraphQL response omitted starredAt")
+            timestamps.append(datetime.fromisoformat(edge["starredAt"].replace("Z", "+00:00")))
 
-        if len(payload) < 100:
+        if not isinstance(page_info, dict) or not isinstance(page_info.get("hasNextPage"), bool):
+            raise RuntimeError("GitHub GraphQL response omitted pagination data")
+        if not page_info["hasNextPage"]:
             break
-        page += 1
+        cursor = page_info.get("endCursor")
+        if not isinstance(cursor, str) or not cursor:
+            raise RuntimeError("GitHub GraphQL response omitted the next cursor")
 
     if not timestamps:
         raise RuntimeError(f"{repo} has no stargazer timestamps")

--- a/tests/test_update_star_history.py
+++ b/tests/test_update_star_history.py
@@ -1,8 +1,8 @@
 """Tests for the GitHub-native star-history chart updater."""
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -12,15 +12,31 @@ from scripts.update_star_history import fetch_stargazer_timestamps, render_chart
 
 def test_fetch_stargazer_timestamps_paginates_and_authenticates():
     requests = []
-    first_page = [{"starred_at": f"2026-01-01T00:{minute:02d}:00Z"} for minute in range(60)] + [
-        {"starred_at": f"2026-01-02T00:{minute:02d}:00Z"} for minute in range(40)
-    ]
-    second_page = [{"starred_at": "2026-01-03T00:00:00Z"}]
+    first_page = {
+        "data": {
+            "repository": {
+                "stargazers": {
+                    "edges": [{"starredAt": "2026-01-01T00:00:00Z"}],
+                    "pageInfo": {"hasNextPage": True, "endCursor": "next-page"},
+                }
+            }
+        }
+    }
+    second_page = {
+        "data": {
+            "repository": {
+                "stargazers": {
+                    "edges": [{"starredAt": "2026-01-03T00:00:00Z"}],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                }
+            }
+        }
+    }
 
     def request_json(request):
         requests.append(request)
-        page = parse_qs(urlparse(request.full_url).query)["page"][0]
-        return first_page if page == "1" else second_page
+        cursor = json.loads(request.data)["variables"]["cursor"]
+        return first_page if cursor is None else second_page
 
     timestamps = fetch_stargazer_timestamps(
         "liaohch3/claude-tap",
@@ -28,26 +44,45 @@ def test_fetch_stargazer_timestamps_paginates_and_authenticates():
         request_json=request_json,
     )
 
-    assert len(timestamps) == 101
+    assert len(timestamps) == 2
     assert timestamps[0] == datetime(2026, 1, 1, tzinfo=UTC)
     assert timestamps[-1] == datetime(2026, 1, 3, tzinfo=UTC)
-    assert [request.full_url.rsplit("=", 1)[-1] for request in requests] == ["1", "2"]
+    assert [json.loads(request.data)["variables"]["cursor"] for request in requests] == [
+        None,
+        "next-page",
+    ]
+    assert all(request.full_url == "https://api.github.com/graphql" for request in requests)
     assert requests[0].headers["Authorization"] == "Bearer test-token"
-    assert requests[0].headers["Accept"] == "application/vnd.github.star+json"
+    assert requests[0].headers["Content-type"] == "application/json"
 
 
 def test_fetch_stargazer_timestamps_rejects_malformed_payload():
-    with pytest.raises(RuntimeError, match="omitted starred_at"):
+    with pytest.raises(RuntimeError, match="omitted starredAt"):
         fetch_stargazer_timestamps(
             "liaohch3/claude-tap",
-            request_json=lambda _request: [{"user": {"login": "example"}}],
+            token="test-token",
+            request_json=lambda _request: {
+                "data": {
+                    "repository": {
+                        "stargazers": {
+                            "edges": [{"node": {"login": "example"}}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            },
         )
 
 
 @pytest.mark.parametrize("repo", ["claude-tap", "owner/repo/extra", "../repo"])
 def test_fetch_stargazer_timestamps_rejects_invalid_repo(repo):
     with pytest.raises(ValueError, match="OWNER/REPO"):
-        fetch_stargazer_timestamps(repo, request_json=lambda _request: [])
+        fetch_stargazer_timestamps(repo, token="test-token", request_json=lambda _request: {})
+
+
+def test_fetch_stargazer_timestamps_requires_token():
+    with pytest.raises(RuntimeError, match="GITHUB_TOKEN is required"):
+        fetch_stargazer_timestamps("liaohch3/claude-tap", token=None)
 
 
 def test_render_charts_persists_valid_light_and_dark_pngs(tmp_path, monkeypatch):
@@ -85,6 +120,8 @@ def test_star_history_workflow_publishes_to_asset_branch():
     assert "scripts/update_star_history.py" in workflow
     assert "scripts/check_screenshots.py" in workflow
     assert "matplotlib==3.11.1" in workflow
+    assert "secrets.RELEASE_BOT_TOKEN" not in workflow
+    assert "GITHUB_TOKEN: ${{ github.token }}" in workflow
     assert "actions/upload-artifact@v4" in workflow
     assert "actions/download-artifact@v4" in workflow
     assert workflow.index("contents: read") < workflow.index("matplotlib==3.11.1")


### PR DESCRIPTION
## Summary

- fetch the complete stargazer timeline through GitHub GraphQL cursor pagination
- use the workflow-scoped `${{ github.token }}` instead of the write-capable release bot secret
- keep the 03:00 Asia/Shanghai schedule and publish validated PNG charts without the duplicate title

## Validation

- `uv lock --check`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run pytest tests/ -x --timeout=60` (`1006 passed, 26 skipped`)
- [real workflow run](https://github.com/liaohch3/claude-tap/actions/runs/30241613857): GraphQL generation, PNG validation, artifact upload, and asset publication all passed