### PR TITLE
test: wait for viewer image decoding

### DIFF
--- a/tests/test_responses_browser.py
+++ b/tests/test_responses_browser.py
@@ -1326,6 +1326,7 @@ def test_viewer_renders_image_content_blocks(responses_page) -> None:
     assert "content-image" in image.first.get_attribute("class")
     assert image.first.get_attribute("src").startswith("data:image/png;base64,")
     assert image.first.get_attribute("alt") == "image"
+    responses_page.wait_for_function("image => image.complete", arg=image.first.element_handle())
     image_state = image.first.evaluate(
         """img => {
           const rect = img.getBoundingClientRect();


### PR DESCRIPTION
## Summary

- wait for the inline viewer image to finish decoding before asserting intrinsic and rendered dimensions
- keep the existing semantic checks for image completion, natural width, layout size, and CSS styling

## Problem

`test_viewer_renders_image_content_blocks` queried `HTMLImageElement.complete` immediately after `renderDetail()`. Chromium can create the `<img>` synchronously while decoding its data URI asynchronously, so the test deterministically failed in this environment with `complete == false` even though the viewer output was correct. The browser assertion should synchronize on the load state it verifies instead of racing it.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Test or tooling
- [ ] Maintenance

## Validation

- [x] Failure reproduced before the change: `uv run pytest tests/test_responses_browser.py::test_viewer_renders_image_content_blocks -vv --timeout=60` (`complete == false`)
- [x] Focused test passes after the change
- [x] `uv lock --check`
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run pytest tests/ -x --timeout=60` (`1006 passed, 26 skipped`)
- [x] `git diff --cached --check`
- [x] Independent `codex review --uncommitted` found no correctness issue

## Evidence

Not required: this is a test synchronization change and does not alter viewer UI or runtime behavior.

## Privacy

- [x] This PR contains no credentials, private traces, prompts, or generated viewer artifacts.
