### PR TITLE
chore: update changelog for v0.1.142

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.1.142] - 2026-08-06
+
+### Changed
+- [verified] test: wait for viewer image decoding (#411)
+- fix: allow deleting abandoned empty active sessions (#412)
+- [verified] fix(sse): retain streamed Responses tool payloads (#397)
+- feat: Cursor transcript-only live watch (#418)
 ## [0.1.141] - 2026-07-29
 
 ### Changed


### PR DESCRIPTION
## Summary

- Update CHANGELOG.md for v0.1.142.
- Continue the automated release after changelog bookkeeping.

## Validation

- Generated by the auto-release workflow.
- Release PR checks must pass before the workflow merges this changelog PR.

## Evidence

- Not required; changelog-only release PR.
