### PR TITLE
fix(ci): retain viewer coverage before navigation

### DIFF
--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -421,6 +421,10 @@ def _main_viewer_script(coverage: dict[str, Any], suffix: str) -> dict[str, Any]
     return max(candidates, key=lambda script: len(script.get("functions", [])))
 
 
+def _merge_precise_coverage(*snapshots: dict[str, Any]) -> dict[str, Any]:
+    return {"result": [script for snapshot in snapshots for script in snapshot.get("result", [])]}
+
+
 def _is_top_level_wrapper(function: dict[str, Any], script_end: int) -> bool:
     if function.get("functionName"):
         return False
@@ -709,6 +713,7 @@ def collect_viewer_js_coverage() -> tuple[float, set[str], int, int]:
                     }""",
                     index,
                 )
+            coverage_snapshots = [session.send("Profiler.takePreciseCoverage")]
             page.goto(compact_html_path.resolve().as_uri(), timeout=10000)
             page.wait_for_selector(".sidebar-item", timeout=5000)
             page.evaluate(
@@ -748,6 +753,7 @@ def collect_viewer_js_coverage() -> tuple[float, set[str], int, int]:
                 }""",
                 compact_bundle_path.read_text(encoding="utf-8"),
             )
+            coverage_snapshots.append(session.send("Profiler.takePreciseCoverage"))
             page.goto(remote_html_path.resolve().as_uri(), timeout=10000)
             page.wait_for_selector(".sidebar-item", timeout=5000)
             page.evaluate(
@@ -763,13 +769,16 @@ def collect_viewer_js_coverage() -> tuple[float, set[str], int, int]:
                 }"""
             )
             page.wait_for_selector("#detail .section", timeout=5000)
+            coverage_snapshots.append(session.send("Profiler.takePreciseCoverage"))
             page.goto(empty_html_path.resolve().as_uri(), timeout=10000)
             page.wait_for_selector(".empty-trace-state", timeout=5000)
             page.set_input_files("#file-input", str(compact_bundle_path))
             page.wait_for_selector(".sidebar-item", timeout=5000)
+            coverage_snapshots.append(session.send("Profiler.takePreciseCoverage"))
             page.goto(empty_html_path.resolve().as_uri(), timeout=10000)
             page.wait_for_selector(".empty-trace-state", timeout=5000)
-            coverage = session.send("Profiler.takePreciseCoverage")
+            coverage_snapshots.append(session.send("Profiler.takePreciseCoverage"))
+            coverage = _merge_precise_coverage(*coverage_snapshots)
             session.send("Profiler.stopPreciseCoverage")
             session.send("Profiler.disable")
             browser.close()

--- a/tests/test_check_coverage.py
+++ b/tests/test_check_coverage.py
@@ -176,6 +176,18 @@ def test_css_selector_ranges_and_changed_viewer_css_selectors_find_touched_rules
     ) == {".header"}
 
 
+def test_merge_precise_coverage_retains_scripts_from_each_snapshot() -> None:
+    first = {"result": [{"scriptId": "1", "url": "file:///v8_coverage.html", "functions": []}]}
+    second = {"result": [{"scriptId": "2", "url": "file:///empty_coverage.html", "functions": []}]}
+
+    merged = coverage_module._merge_precise_coverage(first, second)
+
+    assert [script["url"] for script in merged["result"]] == [
+        "file:///v8_coverage.html",
+        "file:///empty_coverage.html",
+    ]
+
+
 def test_viewer_script_functions_filters_top_level_wrapper_and_detects_coverage() -> None:
     script = {
         "functions": [


### PR DESCRIPTION
## Problem

The release PR coverage job failed after all browser suites passed because `Profiler.takePreciseCoverage` ran only after navigating through four generated viewer pages. Chrome may garbage-collect scripts from earlier documents, so the final snapshot intermittently omitted `v8_coverage.html` and raised `Could not find viewer.html main script in V8 coverage output`.

Failing run: https://github.com/liaohch3/claude-tap/actions/runs/30692188741/job/91506885775

## Summary

- take precise-coverage snapshots before each viewer navigation
- merge the snapshots before selecting each generated viewer script
- add a regression test proving scripts from separate snapshots are retained

## Validation

- `uv run pytest tests/test_check_coverage.py::test_merge_precise_coverage_retains_scripts_from_each_snapshot -v` — passed
- `uv run python scripts/check_coverage.py --skip-python --skip-viewer-css` — passed (`434/550`, 78.91% viewer JS functions)
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv lock --check` — passed
- `uv run pytest tests/ -x --timeout=60` — 1027 passed, 26 skipped
- independent staged-diff review — passed; no security concerns or logic errors

## Evidence

No runtime or viewer UI behavior changes. The linked GitHub Actions log is the real CI failure this change addresses; no screenshot evidence is applicable.