### PR TITLE
refactor: enforce Pydantic schema boundaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       - run: pip install ruff
       - run: ruff check .
       - run: ruff format --check .
+      - run: python scripts/check_schema.py --base "${{ github.event_name == 'pull_request' && format('origin/{0}', github.base_ref) || 'HEAD~1' }}"
       - name: Collect changed files for PR policy
         if: github.event_name == 'pull_request'
         env:

--- a/claude_tap/bedrock.py
+++ b/claude_tap/bedrock.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
-from typing import Any
 from urllib.parse import unquote
+
+from claude_tap.models import Map
 
 BEDROCK_STREAM_SUFFIXES = ("/invoke-with-response-stream", "/converse-stream")
 BEDROCK_ERROR_EVENT_KEYS = frozenset(
@@ -35,9 +36,9 @@ def bedrock_model_from_path(path: str) -> str:
     return unquote(match.group(1)) if match else ""
 
 
-def bedrock_error_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def bedrock_error_events(events: list[Map[str, object]]) -> list[Map[str, object]]:
     """Return normalized Bedrock EventStream error events."""
-    errors: list[dict[str, Any]] = []
+    errors: list[Map[str, object]] = []
     for event in events:
         event_type = event.get("event")
         if not isinstance(event_type, str) or event_type not in BEDROCK_ERROR_EVENT_KEYS:
@@ -52,7 +53,7 @@ def bedrock_error_events(events: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return errors
 
 
-def attach_bedrock_errors(body: object, events: list[dict[str, Any]]) -> object:
+def attach_bedrock_errors(body: object, events: list[Map[str, object]]) -> object:
     """Persist Bedrock stream errors even when raw stream events are omitted."""
     errors = bedrock_error_events(events)
     if not errors:

--- a/claude_tap/bedrock.py
+++ b/claude_tap/bedrock.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from urllib.parse import unquote
 
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 
 BEDROCK_STREAM_SUFFIXES = ("/invoke-with-response-stream", "/converse-stream")
 BEDROCK_ERROR_EVENT_KEYS = frozenset(
@@ -36,9 +36,9 @@ def bedrock_model_from_path(path: str) -> str:
     return unquote(match.group(1)) if match else ""
 
 
-def bedrock_error_events(events: list[Map[str, object]]) -> list[Map[str, object]]:
+def bedrock_error_events(events: list[ProviderPayload]) -> list[ProviderPayload]:
     """Return normalized Bedrock EventStream error events."""
-    errors: list[Map[str, object]] = []
+    errors: list[ProviderPayload] = []
     for event in events:
         event_type = event.get("event")
         if not isinstance(event_type, str) or event_type not in BEDROCK_ERROR_EVENT_KEYS:
@@ -53,7 +53,7 @@ def bedrock_error_events(events: list[Map[str, object]]) -> list[Map[str, object
     return errors
 
 
-def attach_bedrock_errors(body: object, events: list[Map[str, object]]) -> object:
+def attach_bedrock_errors(body: ProviderPayload, events: list[ProviderPayload]) -> ProviderPayload:
     """Persist Bedrock stream errors even when raw stream events are omitted."""
     errors = bedrock_error_events(events)
     if not errors:

--- a/claude_tap/certs.py
+++ b/claude_tap/certs.py
@@ -19,8 +19,6 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
-from claude_tap.models import Map
-
 log = logging.getLogger("claude-tap")
 
 # Default directory for CA files
@@ -190,7 +188,7 @@ class CertificateAuthority:
 
     def __init__(self, ca_cert_path: Path, ca_key_path: Path) -> None:
         self._ca_cert, self._ca_key = _load_ca(ca_cert_path, ca_key_path)
-        self._host_cache: Map[str, tuple[bytes, bytes]] = {}
+        self._host_cache: dict[str, tuple[bytes, bytes]] = {}
 
     def get_host_cert_pem(self, hostname: str) -> tuple[bytes, bytes]:
         """Return (cert_pem, key_pem) for the given hostname.

--- a/claude_tap/certs.py
+++ b/claude_tap/certs.py
@@ -19,6 +19,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
 
+from claude_tap.models import Map
+
 log = logging.getLogger("claude-tap")
 
 # Default directory for CA files
@@ -188,7 +190,7 @@ class CertificateAuthority:
 
     def __init__(self, ca_cert_path: Path, ca_key_path: Path) -> None:
         self._ca_cert, self._ca_key = _load_ca(ca_cert_path, ca_key_path)
-        self._host_cache: dict[str, tuple[bytes, bytes]] = {}
+        self._host_cache: Map[str, tuple[bytes, bytes]] = {}
 
     def get_host_cert_pem(self, hostname: str) -> tuple[bytes, bytes]:
         """Return (cert_pem, key_pem) for the given hostname.

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -62,7 +62,7 @@ from claude_tap.cursor_transcript import CursorTranscriptWatcher, model_from_cur
 from claude_tap.forward_proxy import ForwardProxyServer
 from claude_tap.history import cleanup_trace_sessions, migrate_legacy_traces
 from claude_tap.live import LiveViewerServer
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.proxy import proxy_handler
 from claude_tap.shared_dashboard import (
     DEFAULT_DASHBOARD_PORT,
@@ -94,7 +94,7 @@ def _create_trace_writer(
     store: TraceStore,
     client: str,
     proxy_mode: str,
-    metadata: Map[str, str],
+    metadata: dict[str, str],
 ) -> TraceWriter:
     return create_trace_writer(store=store, client=client, proxy_mode=proxy_mode, metadata=metadata)
 
@@ -119,7 +119,7 @@ def _reverse_proxy_path_prefixes(
 class _LazyTraceWriter:
     """Create a trace session only when side-channel capture writes a record."""
 
-    def __init__(self, *, client: str, proxy_mode: str, metadata: Map[str, str]):
+    def __init__(self, *, client: str, proxy_mode: str, metadata: dict[str, str]):
         self._client = client
         self._proxy_mode = proxy_mode
         self._metadata = metadata
@@ -131,17 +131,17 @@ class _LazyTraceWriter:
     def count(self) -> int:
         return self._writer.count if self._writer is not None else 0
 
-    async def write(self, record: JsonObject) -> None:
+    async def write(self, record: ProviderPayload) -> None:
         await self._ensure_writer().write(record)
 
-    async def write_next_turn(self, record: JsonObject) -> None:
+    async def write_next_turn(self, record: ProviderPayload) -> None:
         await self._ensure_writer().write_next_turn(record)
 
     def close(self) -> None:
         if self._writer is not None:
             self._writer.close()
 
-    def get_summary(self) -> JsonObject:
+    def get_summary(self) -> ProviderPayload:
         if self._writer is not None:
             return self._writer.get_summary()
         return {

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -62,6 +62,7 @@ from claude_tap.cursor_transcript import CursorTranscriptWatcher, model_from_cur
 from claude_tap.forward_proxy import ForwardProxyServer
 from claude_tap.history import cleanup_trace_sessions, migrate_legacy_traces
 from claude_tap.live import LiveViewerServer
+from claude_tap.models import JsonObject, Map
 from claude_tap.proxy import proxy_handler
 from claude_tap.shared_dashboard import (
     DEFAULT_DASHBOARD_PORT,
@@ -93,7 +94,7 @@ def _create_trace_writer(
     store: TraceStore,
     client: str,
     proxy_mode: str,
-    metadata: dict[str, str],
+    metadata: Map[str, str],
 ) -> TraceWriter:
     return create_trace_writer(store=store, client=client, proxy_mode=proxy_mode, metadata=metadata)
 
@@ -118,7 +119,7 @@ def _reverse_proxy_path_prefixes(
 class _LazyTraceWriter:
     """Create a trace session only when side-channel capture writes a record."""
 
-    def __init__(self, *, client: str, proxy_mode: str, metadata: dict[str, str]):
+    def __init__(self, *, client: str, proxy_mode: str, metadata: Map[str, str]):
         self._client = client
         self._proxy_mode = proxy_mode
         self._metadata = metadata
@@ -130,17 +131,17 @@ class _LazyTraceWriter:
     def count(self) -> int:
         return self._writer.count if self._writer is not None else 0
 
-    async def write(self, record: dict) -> None:
+    async def write(self, record: JsonObject) -> None:
         await self._ensure_writer().write(record)
 
-    async def write_next_turn(self, record: dict) -> None:
+    async def write_next_turn(self, record: JsonObject) -> None:
         await self._ensure_writer().write_next_turn(record)
 
     def close(self) -> None:
         if self._writer is not None:
             self._writer.close()
 
-    def get_summary(self) -> dict:
+    def get_summary(self) -> JsonObject:
         if self._writer is not None:
             return self._writer.get_summary()
         return {

--- a/claude_tap/cli.py
+++ b/claude_tap/cli.py
@@ -667,7 +667,7 @@ def _export_prompt_from_session(store, session_id: str, output: str) -> int:
         return 1
 
     if output == "-":
-        _print(text, end="", file=_COMMAND_STDOUT.get())
+        _print(text, end="", file=_COMMAND_STDOUT.get() or sys.stdout)
         return 0
 
     path = Path(output).expanduser()

--- a/claude_tap/cli_clients.py
+++ b/claude_tap/cli_clients.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 from claude_tap.cli_output import print_status as _print
+from claude_tap.models import JsonObject, Map
 
 _BEDROCK_HOST_RE = re.compile(
     r"(^|\.)("
@@ -363,9 +364,9 @@ class ClientConfig:
             env_keys.append(env_key)
         return tuple(env_keys)
 
-    def reverse_base_url_env_map(self, port: int) -> dict[str, str]:
+    def reverse_base_url_env_map(self, port: int) -> Map[str, str]:
         base_url = self.reverse_base_url(port)
-        env_map: dict[str, str] = {}
+        env_map: Map[str, str] = {}
         for env_key in self.reverse_base_url_envs:
             if env_key in self.extra_base_url_envs and not _should_rewrite_extra_base_url_env(env_key):
                 continue
@@ -380,7 +381,7 @@ class ClientConfig:
         return self.strip_path_prefix
 
 
-CLIENT_CONFIGS: dict[str, ClientConfig] = {
+CLIENT_CONFIGS: Map[str, ClientConfig] = {
     "claude": ClientConfig(
         cmd="claude",
         label="Claude Code",
@@ -613,7 +614,7 @@ def _prefer_windows_command_shim(resolved_cmd: str) -> str:
     return resolved_cmd
 
 
-def _node_supports_env_proxy(env: dict[str, str]) -> bool:
+def _node_supports_env_proxy(env: Map[str, str]) -> bool:
     """Return whether the Node runtime on PATH supports ``--use-env-proxy``."""
     node_cmd = shutil.which("node", path=env.get("PATH"))
     if node_cmd is None:
@@ -736,7 +737,7 @@ async def run_client(
 
         if cfg.inject_settings_env:
             if not _has_settings_arg(cmd_args):
-                settings_payload: dict[str, dict[str, str]] = {
+                settings_payload: Map[str, Map[str, str]] = {
                     "env": {
                         "HTTP_PROXY": proxy_url,
                         "HTTPS_PROXY": proxy_url,
@@ -985,7 +986,7 @@ def _maybe_rewrite_hermes_gateway_start(client: str, cmd_args: list[str]) -> lis
     return cmd_args
 
 
-def _extend_no_proxy(env: dict[str, str], values: tuple[str, ...]) -> None:
+def _extend_no_proxy(env: Map[str, str], values: tuple[str, ...]) -> None:
     """Append local proxy bypasses without discarding existing settings."""
     existing: list[str] = []
     for key in ("NO_PROXY", "no_proxy"):
@@ -1073,7 +1074,7 @@ def _codex_home() -> Path:
     return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
 
 
-def _read_codex_config_file(config_path: Path) -> dict[str, object]:
+def _read_codex_config_file(config_path: Path) -> Map[str, object]:
     try:
         data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError, ValueError):
@@ -1081,11 +1082,11 @@ def _read_codex_config_file(config_path: Path) -> dict[str, object]:
     return data if isinstance(data, dict) else {}
 
 
-def _read_codex_config() -> dict[str, object]:
+def _read_codex_config() -> Map[str, object]:
     return _read_codex_config_file(_codex_home() / "config.toml")
 
 
-def _read_codex_profile_config(profile: str | None) -> dict[str, object]:
+def _read_codex_profile_config(profile: str | None) -> Map[str, object]:
     if not profile:
         return {}
     return _read_codex_config_file(_codex_home() / f"{profile}.config.toml")
@@ -1202,7 +1203,7 @@ def _has_settings_arg(args: list[str]) -> bool:
     return any(arg == "--settings" or arg.startswith("--settings=") for arg in args)
 
 
-def _settings_arg(env_values: dict[str, str]) -> list[str]:
+def _settings_arg(env_values: Map[str, str]) -> list[str]:
     settings_payload = {"env": env_values}
     return ["--settings", json.dumps(settings_payload, separators=(",", ":"))]
 
@@ -1274,7 +1275,7 @@ def _detect_claude_target() -> str:
     return CLIENT_CONFIGS["claude"].default_target
 
 
-def _reverse_proxy_trace_options(client: str, target: str) -> dict[str, object]:
+def _reverse_proxy_trace_options(client: str, target: str) -> Map[str, object]:
     cfg = CLIENT_CONFIGS[client]
     return {
         "strip_path_prefix": cfg.reverse_strip_path_prefix(target),
@@ -1432,7 +1433,7 @@ def _sync_kimi_code_migration_suppression(source_home: Path, sandbox: Path) -> N
         skip_target.write_text("", encoding="utf-8")
 
 
-def _read_kimi_code_config(home: Path | None = None, path: Path | None = None) -> dict[str, object]:
+def _read_kimi_code_config(home: Path | None = None, path: Path | None = None) -> Map[str, object]:
     config_path = path or (home or _kimi_code_home()) / "config.toml"
     try:
         text = config_path.read_text(encoding="utf-8")
@@ -1492,7 +1493,7 @@ def _kimi_code_inline_config_arg(cmd_args: Sequence[str] = ()) -> str | None:
     return _kimi_code_option_value(cmd_args, {"--config"})
 
 
-def _loads_kimi_code_inline_config(value: str) -> dict[str, object]:
+def _loads_kimi_code_inline_config(value: str) -> Map[str, object]:
     value = value.strip()
     if not value:
         return {}
@@ -1506,7 +1507,7 @@ def _loads_kimi_code_inline_config(value: str) -> dict[str, object]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _kimi_code_config_for_args(cmd_args: Sequence[str] = ()) -> dict[str, object]:
+def _kimi_code_config_for_args(cmd_args: Sequence[str] = ()) -> Map[str, object]:
     inline_config = _kimi_code_inline_config_arg(cmd_args)
     if inline_config:
         return _loads_kimi_code_inline_config(inline_config)
@@ -1531,7 +1532,7 @@ def _should_proxy_kimi_code_model_env() -> bool:
     return provider_type in {"", "kimi"}
 
 
-def _kimi_code_provider_base_url(provider: dict[str, object]) -> str | None:
+def _kimi_code_provider_base_url(provider: Map[str, object]) -> str | None:
     base_url = provider.get("base_url")
     if isinstance(base_url, str) and base_url.strip():
         return base_url.strip()
@@ -1543,7 +1544,7 @@ def _kimi_code_provider_base_url(provider: dict[str, object]) -> str | None:
     return None
 
 
-def _kimi_code_selected_provider_names(config: dict[str, object], cmd_args: Sequence[str] = ()) -> set[str]:
+def _kimi_code_selected_provider_names(config: Map[str, object], cmd_args: Sequence[str] = ()) -> set[str]:
     providers = config.get("providers")
     if not isinstance(providers, dict):
         return set()
@@ -1574,7 +1575,7 @@ def _kimi_code_selected_provider_names(config: dict[str, object], cmd_args: Sequ
     return set()
 
 
-def _collect_kimi_code_provider_urls(config: dict[str, object], provider_names: set[str] | None = None) -> list[str]:
+def _collect_kimi_code_provider_urls(config: Map[str, object], provider_names: set[str] | None = None) -> list[str]:
     urls: list[str] = []
     providers = config.get("providers")
     if not isinstance(providers, dict):
@@ -1591,8 +1592,8 @@ def _collect_kimi_code_provider_urls(config: dict[str, object], provider_names: 
 
 
 def _patch_kimi_code_config_dict(
-    config: dict[str, object], proxy_base: str, cmd_args: Sequence[str] = ()
-) -> tuple[dict[str, object], list[str]]:
+    config: Map[str, object], proxy_base: str, cmd_args: Sequence[str] = ()
+) -> tuple[Map[str, object], list[str]]:
     patched = json.loads(json.dumps(config))
     patched_providers: list[str] = []
     provider_names = _kimi_code_selected_provider_names(config, cmd_args)
@@ -1614,7 +1615,7 @@ def _patch_kimi_code_config_dict(
 
 
 def _kimi_code_config_url_replacements(
-    config: dict[str, object], proxy_base: str, provider_names: set[str]
+    config: Map[str, object], proxy_base: str, provider_names: set[str]
 ) -> list[tuple[str, str]]:
     replacements: list[tuple[str, str]] = []
     for old_url in _collect_kimi_code_provider_urls(config, provider_names):
@@ -1843,7 +1844,7 @@ def _translate_kimi_code_home_path(path: str, old_prefix: str, new_prefix: str) 
     return path
 
 
-def _iter_kimi_code_session_index_entries(path: Path) -> Iterable[dict[str, object]]:
+def _iter_kimi_code_session_index_entries(path: Path) -> Iterable[Map[str, object]]:
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
@@ -1888,7 +1889,7 @@ def _merge_kimi_code_session_index(source_home: Path, sandbox: Path) -> None:
     source_index = source_home / "session_index.jsonl"
     source_prefix = _normalize_kimi_code_fs_path(str(source_home))
     sandbox_prefix = _normalize_kimi_code_fs_path(str(sandbox))
-    entries: dict[str, dict[str, object]] = {}
+    entries: Map[str, Map[str, object]] = {}
 
     def ingest_index(path: Path, *, from_sandbox: bool) -> None:
         for entry in _iter_kimi_code_session_index_entries(path):
@@ -1962,7 +1963,7 @@ def _remap_kimi_code_sandbox_paths(source_home: Path, sandbox: Path) -> None:
             path.write_text(rewritten, encoding="utf-8")
 
 
-def _kimi_code_config_model_target(config: dict[str, object], model_name: str) -> str | None:
+def _kimi_code_config_model_target(config: Map[str, object], model_name: str) -> str | None:
     models = config.get("models")
     providers = config.get("providers")
     if not model_name.strip() or not isinstance(models, dict) or not isinstance(providers, dict):
@@ -2109,7 +2110,7 @@ def _detect_kimi_code_target(cmd_args: Sequence[str] = ()) -> str:
 _OPENCLAW_CLEANUP_ENV = "__CLAUDE_TAP_OPENCLAW_CONFIG__"
 
 
-def _read_openclaw_config(path: Path) -> dict | None:
+def _read_openclaw_config(path: Path) -> JsonObject | None:
     if not path.is_file():
         return None
     try:
@@ -2142,7 +2143,7 @@ def _openclaw_model_arg(cmd_args: Sequence[str]) -> str | None:
     return None
 
 
-def _openclaw_primary_model(cfg: dict, cmd_args: Sequence[str] = ()) -> str | None:
+def _openclaw_primary_model(cfg: JsonObject, cmd_args: Sequence[str] = ()) -> str | None:
     if model_arg := _openclaw_model_arg(cmd_args):
         return model_arg
     agents = cfg.get("agents")
@@ -2166,7 +2167,7 @@ def _openclaw_primary_model(cfg: dict, cmd_args: Sequence[str] = ()) -> str | No
     return None
 
 
-def _openclaw_provider_proxy_url(provider: dict, proxy_url: str) -> str:
+def _openclaw_provider_proxy_url(provider: JsonObject, proxy_url: str) -> str:
     api = provider.get("api")
     if not isinstance(api, str):
         return f"{proxy_url}/v1"
@@ -2175,14 +2176,14 @@ def _openclaw_provider_proxy_url(provider: dict, proxy_url: str) -> str:
     return proxy_url
 
 
-def _openclaw_provider_target_url(provider: dict, base_url: str) -> str:
+def _openclaw_provider_target_url(provider: JsonObject, base_url: str) -> str:
     target = base_url.strip().rstrip("/")
     if _openclaw_provider_proxy_url(provider, "http://127.0.0.1:0").endswith("/v1") and target.endswith("/v1"):
         return target[:-3].rstrip("/") or target
     return target
 
 
-def _openclaw_config_with_proxy(cfg: dict, proxy_url: str, cmd_args: Sequence[str] = ()) -> dict | None:
+def _openclaw_config_with_proxy(cfg: JsonObject, proxy_url: str, cmd_args: Sequence[str] = ()) -> JsonObject | None:
     model = _openclaw_primary_model(cfg, cmd_args)
     if not model or "/" not in model:
         return None
@@ -2203,7 +2204,7 @@ def _openclaw_config_with_proxy(cfg: dict, proxy_url: str, cmd_args: Sequence[st
     return patched
 
 
-def _openclaw_reverse_env(port: int, cmd_args: Sequence[str] = ()) -> dict[str, str]:
+def _openclaw_reverse_env(port: int, cmd_args: Sequence[str] = ()) -> Map[str, str]:
     proxy_url = f"http://127.0.0.1:{port}"
     cfg = _read_openclaw_config(_openclaw_config_path())
     if cfg:
@@ -2217,7 +2218,7 @@ def _openclaw_reverse_env(port: int, cmd_args: Sequence[str] = ()) -> dict[str, 
     return _openclaw_fallback_reverse_env(proxy_url, cmd_args)
 
 
-def _openclaw_fallback_reverse_env(proxy_url: str, cmd_args: Sequence[str] = ()) -> dict[str, str]:
+def _openclaw_fallback_reverse_env(proxy_url: str, cmd_args: Sequence[str] = ()) -> Map[str, str]:
     provider = _openclaw_fallback_provider(cmd_args)
     if provider == "anthropic":
         return {"ANTHROPIC_BASE_URL": proxy_url}
@@ -2244,7 +2245,7 @@ def _openclaw_fallback_provider(cmd_args: Sequence[str] = ()) -> str:
     return "openai"
 
 
-def _opencode_reverse_env(port: int) -> dict[str, str]:
+def _opencode_reverse_env(port: int) -> Map[str, str]:
     proxy_url = f"http://127.0.0.1:{port}"
     return {
         "ANTHROPIC_BASE_URL": proxy_url,
@@ -2253,7 +2254,7 @@ def _opencode_reverse_env(port: int) -> dict[str, str]:
     }
 
 
-def _multi_provider_reverse_env(port: int) -> dict[str, str]:
+def _multi_provider_reverse_env(port: int) -> Map[str, str]:
     proxy_url = f"http://127.0.0.1:{port}"
     return {
         "KIMI_BASE_URL": proxy_url,

--- a/claude_tap/cli_clients.py
+++ b/claude_tap/cli_clients.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Iterable, Sequence
 
 from claude_tap.cli_output import print_status as _print
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 
 _BEDROCK_HOST_RE = re.compile(
     r"(^|\.)("
@@ -364,9 +364,9 @@ class ClientConfig:
             env_keys.append(env_key)
         return tuple(env_keys)
 
-    def reverse_base_url_env_map(self, port: int) -> Map[str, str]:
+    def reverse_base_url_env_map(self, port: int) -> dict[str, str]:
         base_url = self.reverse_base_url(port)
-        env_map: Map[str, str] = {}
+        env_map: dict[str, str] = {}
         for env_key in self.reverse_base_url_envs:
             if env_key in self.extra_base_url_envs and not _should_rewrite_extra_base_url_env(env_key):
                 continue
@@ -381,7 +381,7 @@ class ClientConfig:
         return self.strip_path_prefix
 
 
-CLIENT_CONFIGS: Map[str, ClientConfig] = {
+CLIENT_CONFIGS: dict[str, ClientConfig] = {
     "claude": ClientConfig(
         cmd="claude",
         label="Claude Code",
@@ -614,7 +614,7 @@ def _prefer_windows_command_shim(resolved_cmd: str) -> str:
     return resolved_cmd
 
 
-def _node_supports_env_proxy(env: Map[str, str]) -> bool:
+def _node_supports_env_proxy(env: dict[str, str]) -> bool:
     """Return whether the Node runtime on PATH supports ``--use-env-proxy``."""
     node_cmd = shutil.which("node", path=env.get("PATH"))
     if node_cmd is None:
@@ -737,7 +737,7 @@ async def run_client(
 
         if cfg.inject_settings_env:
             if not _has_settings_arg(cmd_args):
-                settings_payload: Map[str, Map[str, str]] = {
+                settings_payload: dict[str, dict[str, str]] = {
                     "env": {
                         "HTTP_PROXY": proxy_url,
                         "HTTPS_PROXY": proxy_url,
@@ -986,7 +986,7 @@ def _maybe_rewrite_hermes_gateway_start(client: str, cmd_args: list[str]) -> lis
     return cmd_args
 
 
-def _extend_no_proxy(env: Map[str, str], values: tuple[str, ...]) -> None:
+def _extend_no_proxy(env: dict[str, str], values: tuple[str, ...]) -> None:
     """Append local proxy bypasses without discarding existing settings."""
     existing: list[str] = []
     for key in ("NO_PROXY", "no_proxy"):
@@ -1027,11 +1027,11 @@ def _codex_config_override_values(args: list[str]) -> list[str]:
     return values
 
 
-def _codex_config_override_value(args: list[str] | None, key: str) -> object | None:
+def _codex_config_override_value(args: list[str] | None, key: str) -> ProviderPayload | str | int | float | bool | None:
     if not args:
         return None
     prefix = f"{key}="
-    value: object | None = None
+    value: ProviderPayload | str | int | float | bool | None = None
     for override in _codex_config_override_values(args):
         if not override.startswith(prefix):
             continue
@@ -1074,7 +1074,7 @@ def _codex_home() -> Path:
     return Path(os.environ.get("CODEX_HOME") or Path.home() / ".codex")
 
 
-def _read_codex_config_file(config_path: Path) -> Map[str, object]:
+def _read_codex_config_file(config_path: Path) -> ProviderPayload:
     try:
         data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     except (OSError, tomllib.TOMLDecodeError, ValueError):
@@ -1082,11 +1082,11 @@ def _read_codex_config_file(config_path: Path) -> Map[str, object]:
     return data if isinstance(data, dict) else {}
 
 
-def _read_codex_config() -> Map[str, object]:
+def _read_codex_config() -> ProviderPayload:
     return _read_codex_config_file(_codex_home() / "config.toml")
 
 
-def _read_codex_profile_config(profile: str | None) -> Map[str, object]:
+def _read_codex_profile_config(profile: str | None) -> ProviderPayload:
     if not profile:
         return {}
     return _read_codex_config_file(_codex_home() / f"{profile}.config.toml")
@@ -1125,7 +1125,7 @@ def _selected_codex_provider_base_url(args: list[str] | None = None) -> tuple[st
     if isinstance(base_url_override, str) and base_url_override.strip():
         return provider, base_url_override.strip()
 
-    base_url: object | None = None
+    base_url: ProviderPayload | str | int | float | bool | None = None
     for config in (profile_data, data):
         providers = config.get("model_providers")
         if not isinstance(providers, dict):
@@ -1203,7 +1203,7 @@ def _has_settings_arg(args: list[str]) -> bool:
     return any(arg == "--settings" or arg.startswith("--settings=") for arg in args)
 
 
-def _settings_arg(env_values: Map[str, str]) -> list[str]:
+def _settings_arg(env_values: dict[str, str]) -> list[str]:
     settings_payload = {"env": env_values}
     return ["--settings", json.dumps(settings_payload, separators=(",", ":"))]
 
@@ -1275,7 +1275,7 @@ def _detect_claude_target() -> str:
     return CLIENT_CONFIGS["claude"].default_target
 
 
-def _reverse_proxy_trace_options(client: str, target: str) -> Map[str, object]:
+def _reverse_proxy_trace_options(client: str, target: str) -> ProviderPayload:
     cfg = CLIENT_CONFIGS[client]
     return {
         "strip_path_prefix": cfg.reverse_strip_path_prefix(target),
@@ -1433,7 +1433,7 @@ def _sync_kimi_code_migration_suppression(source_home: Path, sandbox: Path) -> N
         skip_target.write_text("", encoding="utf-8")
 
 
-def _read_kimi_code_config(home: Path | None = None, path: Path | None = None) -> Map[str, object]:
+def _read_kimi_code_config(home: Path | None = None, path: Path | None = None) -> ProviderPayload:
     config_path = path or (home or _kimi_code_home()) / "config.toml"
     try:
         text = config_path.read_text(encoding="utf-8")
@@ -1493,7 +1493,7 @@ def _kimi_code_inline_config_arg(cmd_args: Sequence[str] = ()) -> str | None:
     return _kimi_code_option_value(cmd_args, {"--config"})
 
 
-def _loads_kimi_code_inline_config(value: str) -> Map[str, object]:
+def _loads_kimi_code_inline_config(value: str) -> ProviderPayload:
     value = value.strip()
     if not value:
         return {}
@@ -1507,7 +1507,7 @@ def _loads_kimi_code_inline_config(value: str) -> Map[str, object]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _kimi_code_config_for_args(cmd_args: Sequence[str] = ()) -> Map[str, object]:
+def _kimi_code_config_for_args(cmd_args: Sequence[str] = ()) -> ProviderPayload:
     inline_config = _kimi_code_inline_config_arg(cmd_args)
     if inline_config:
         return _loads_kimi_code_inline_config(inline_config)
@@ -1532,7 +1532,7 @@ def _should_proxy_kimi_code_model_env() -> bool:
     return provider_type in {"", "kimi"}
 
 
-def _kimi_code_provider_base_url(provider: Map[str, object]) -> str | None:
+def _kimi_code_provider_base_url(provider: ProviderPayload) -> str | None:
     base_url = provider.get("base_url")
     if isinstance(base_url, str) and base_url.strip():
         return base_url.strip()
@@ -1544,7 +1544,7 @@ def _kimi_code_provider_base_url(provider: Map[str, object]) -> str | None:
     return None
 
 
-def _kimi_code_selected_provider_names(config: Map[str, object], cmd_args: Sequence[str] = ()) -> set[str]:
+def _kimi_code_selected_provider_names(config: ProviderPayload, cmd_args: Sequence[str] = ()) -> set[str]:
     providers = config.get("providers")
     if not isinstance(providers, dict):
         return set()
@@ -1575,7 +1575,7 @@ def _kimi_code_selected_provider_names(config: Map[str, object], cmd_args: Seque
     return set()
 
 
-def _collect_kimi_code_provider_urls(config: Map[str, object], provider_names: set[str] | None = None) -> list[str]:
+def _collect_kimi_code_provider_urls(config: ProviderPayload, provider_names: set[str] | None = None) -> list[str]:
     urls: list[str] = []
     providers = config.get("providers")
     if not isinstance(providers, dict):
@@ -1592,8 +1592,8 @@ def _collect_kimi_code_provider_urls(config: Map[str, object], provider_names: s
 
 
 def _patch_kimi_code_config_dict(
-    config: Map[str, object], proxy_base: str, cmd_args: Sequence[str] = ()
-) -> tuple[Map[str, object], list[str]]:
+    config: ProviderPayload, proxy_base: str, cmd_args: Sequence[str] = ()
+) -> tuple[ProviderPayload, list[str]]:
     patched = json.loads(json.dumps(config))
     patched_providers: list[str] = []
     provider_names = _kimi_code_selected_provider_names(config, cmd_args)
@@ -1615,7 +1615,7 @@ def _patch_kimi_code_config_dict(
 
 
 def _kimi_code_config_url_replacements(
-    config: Map[str, object], proxy_base: str, provider_names: set[str]
+    config: ProviderPayload, proxy_base: str, provider_names: set[str]
 ) -> list[tuple[str, str]]:
     replacements: list[tuple[str, str]] = []
     for old_url in _collect_kimi_code_provider_urls(config, provider_names):
@@ -1844,7 +1844,7 @@ def _translate_kimi_code_home_path(path: str, old_prefix: str, new_prefix: str) 
     return path
 
 
-def _iter_kimi_code_session_index_entries(path: Path) -> Iterable[Map[str, object]]:
+def _iter_kimi_code_session_index_entries(path: Path) -> Iterable[ProviderPayload]:
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except (OSError, UnicodeDecodeError):
@@ -1889,7 +1889,7 @@ def _merge_kimi_code_session_index(source_home: Path, sandbox: Path) -> None:
     source_index = source_home / "session_index.jsonl"
     source_prefix = _normalize_kimi_code_fs_path(str(source_home))
     sandbox_prefix = _normalize_kimi_code_fs_path(str(sandbox))
-    entries: Map[str, Map[str, object]] = {}
+    entries: dict[str, ProviderPayload] = {}
 
     def ingest_index(path: Path, *, from_sandbox: bool) -> None:
         for entry in _iter_kimi_code_session_index_entries(path):
@@ -1963,7 +1963,7 @@ def _remap_kimi_code_sandbox_paths(source_home: Path, sandbox: Path) -> None:
             path.write_text(rewritten, encoding="utf-8")
 
 
-def _kimi_code_config_model_target(config: Map[str, object], model_name: str) -> str | None:
+def _kimi_code_config_model_target(config: ProviderPayload, model_name: str) -> str | None:
     models = config.get("models")
     providers = config.get("providers")
     if not model_name.strip() or not isinstance(models, dict) or not isinstance(providers, dict):
@@ -2110,7 +2110,7 @@ def _detect_kimi_code_target(cmd_args: Sequence[str] = ()) -> str:
 _OPENCLAW_CLEANUP_ENV = "__CLAUDE_TAP_OPENCLAW_CONFIG__"
 
 
-def _read_openclaw_config(path: Path) -> JsonObject | None:
+def _read_openclaw_config(path: Path) -> ProviderPayload | None:
     if not path.is_file():
         return None
     try:
@@ -2143,7 +2143,7 @@ def _openclaw_model_arg(cmd_args: Sequence[str]) -> str | None:
     return None
 
 
-def _openclaw_primary_model(cfg: JsonObject, cmd_args: Sequence[str] = ()) -> str | None:
+def _openclaw_primary_model(cfg: ProviderPayload, cmd_args: Sequence[str] = ()) -> str | None:
     if model_arg := _openclaw_model_arg(cmd_args):
         return model_arg
     agents = cfg.get("agents")
@@ -2167,7 +2167,7 @@ def _openclaw_primary_model(cfg: JsonObject, cmd_args: Sequence[str] = ()) -> st
     return None
 
 
-def _openclaw_provider_proxy_url(provider: JsonObject, proxy_url: str) -> str:
+def _openclaw_provider_proxy_url(provider: ProviderPayload, proxy_url: str) -> str:
     api = provider.get("api")
     if not isinstance(api, str):
         return f"{proxy_url}/v1"
@@ -2176,14 +2176,16 @@ def _openclaw_provider_proxy_url(provider: JsonObject, proxy_url: str) -> str:
     return proxy_url
 
 
-def _openclaw_provider_target_url(provider: JsonObject, base_url: str) -> str:
+def _openclaw_provider_target_url(provider: ProviderPayload, base_url: str) -> str:
     target = base_url.strip().rstrip("/")
     if _openclaw_provider_proxy_url(provider, "http://127.0.0.1:0").endswith("/v1") and target.endswith("/v1"):
         return target[:-3].rstrip("/") or target
     return target
 
 
-def _openclaw_config_with_proxy(cfg: JsonObject, proxy_url: str, cmd_args: Sequence[str] = ()) -> JsonObject | None:
+def _openclaw_config_with_proxy(
+    cfg: ProviderPayload, proxy_url: str, cmd_args: Sequence[str] = ()
+) -> ProviderPayload | None:
     model = _openclaw_primary_model(cfg, cmd_args)
     if not model or "/" not in model:
         return None
@@ -2204,7 +2206,7 @@ def _openclaw_config_with_proxy(cfg: JsonObject, proxy_url: str, cmd_args: Seque
     return patched
 
 
-def _openclaw_reverse_env(port: int, cmd_args: Sequence[str] = ()) -> Map[str, str]:
+def _openclaw_reverse_env(port: int, cmd_args: Sequence[str] = ()) -> dict[str, str]:
     proxy_url = f"http://127.0.0.1:{port}"
     cfg = _read_openclaw_config(_openclaw_config_path())
     if cfg:
@@ -2218,7 +2220,7 @@ def _openclaw_reverse_env(port: int, cmd_args: Sequence[str] = ()) -> Map[str, s
     return _openclaw_fallback_reverse_env(proxy_url, cmd_args)
 
 
-def _openclaw_fallback_reverse_env(proxy_url: str, cmd_args: Sequence[str] = ()) -> Map[str, str]:
+def _openclaw_fallback_reverse_env(proxy_url: str, cmd_args: Sequence[str] = ()) -> dict[str, str]:
     provider = _openclaw_fallback_provider(cmd_args)
     if provider == "anthropic":
         return {"ANTHROPIC_BASE_URL": proxy_url}
@@ -2245,7 +2247,7 @@ def _openclaw_fallback_provider(cmd_args: Sequence[str] = ()) -> str:
     return "openai"
 
 
-def _opencode_reverse_env(port: int) -> Map[str, str]:
+def _opencode_reverse_env(port: int) -> dict[str, str]:
     proxy_url = f"http://127.0.0.1:{port}"
     return {
         "ANTHROPIC_BASE_URL": proxy_url,
@@ -2254,7 +2256,7 @@ def _opencode_reverse_env(port: int) -> Map[str, str]:
     }
 
 
-def _multi_provider_reverse_env(port: int) -> Map[str, str]:
+def _multi_provider_reverse_env(port: int) -> dict[str, str]:
     proxy_url = f"http://127.0.0.1:{port}"
     return {
         "KIMI_BASE_URL": proxy_url,

--- a/claude_tap/cli_output.py
+++ b/claude_tap/cli_output.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import builtins
 import sys
+from typing import TextIO
 
 
-def print_status(*values: object, **kwargs: object) -> None:
+def print_status(
+    *values: str | int | float | bool | None,
+    sep: str | None = " ",
+    end: str | None = "\n",
+    file: TextIO | None = None,
+    flush: bool = False,
+) -> None:
     """Print operational output to stderr unless a stream is explicit."""
-    kwargs.setdefault("file", sys.stderr)
-    builtins.print(*values, **kwargs)
+    builtins.print(*values, sep=sep, end=end, file=file or sys.stderr, flush=flush)

--- a/claude_tap/cli_output.py
+++ b/claude_tap/cli_output.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 import builtins
 import sys
-from typing import Any
 
 
-def print_status(*values: object, **kwargs: Any) -> None:
+def print_status(*values: object, **kwargs: object) -> None:
     """Print operational output to stderr unless a stream is explicit."""
     kwargs.setdefault("file", sys.stderr)
     builtins.print(*values, **kwargs)

--- a/claude_tap/compact_trace.py
+++ b/claude_tap/compact_trace.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from hashlib import sha256
-from typing import Any
+
+from claude_tap.models import JsonValue, Map
 
 COMPACT_TRACE_MARKER = "__claude_tap_compact_trace__"
 COMPACT_RECORD_MARKER = "__claude_tap_compact_record__"
@@ -26,14 +27,14 @@ COMPACT_ITEM_BLOB_PATHS = (
 )
 
 
-def dump_compact_trace(records: list[dict[str, Any]]) -> str:
+def dump_compact_trace(records: list[Map[str, object]]) -> str:
     """Serialize records into a portable compact trace bundle."""
     return json.dumps(build_compact_trace_bundle(records), ensure_ascii=False, separators=(",", ":")) + "\n"
 
 
-def build_compact_trace_bundle(records: list[dict[str, Any]]) -> dict[str, Any]:
+def build_compact_trace_bundle(records: list[Map[str, object]]) -> Map[str, object]:
     """Return a standalone compact trace bundle with inline blob dictionary."""
-    blobs: dict[str, dict[str, Any]] = {}
+    blobs: Map[str, Map[str, object]] = {}
     compact_records = [_encode_compact_record(record, blobs) for record in records]
     return {
         COMPACT_TRACE_MARKER: {
@@ -47,7 +48,7 @@ def build_compact_trace_bundle(records: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def load_compact_trace(text: str) -> list[dict[str, Any]] | None:
+def load_compact_trace(text: str) -> list[Map[str, object]] | None:
     """Materialize a compact trace bundle, or return None when text is not one."""
     try:
         value = json.loads(text)
@@ -58,14 +59,14 @@ def load_compact_trace(text: str) -> list[dict[str, Any]] | None:
     return materialize_compact_trace_bundle(value)
 
 
-def is_compact_trace_bundle(value: Any) -> bool:
+def is_compact_trace_bundle(value: object) -> bool:
     if not isinstance(value, dict):
         return False
     marker = value.get(COMPACT_TRACE_MARKER)
     return isinstance(marker, dict) and marker.get("version") == COMPACT_TRACE_VERSION
 
 
-def materialize_compact_trace_bundle(bundle: dict[str, Any]) -> list[dict[str, Any]]:
+def materialize_compact_trace_bundle(bundle: Map[str, object]) -> list[Map[str, object]]:
     """Materialize all records from a compact trace bundle."""
     if not is_compact_trace_bundle(bundle):
         raise ValueError("Unsupported compact trace bundle.")
@@ -74,8 +75,8 @@ def materialize_compact_trace_bundle(bundle: dict[str, Any]) -> list[dict[str, A
     if not isinstance(records, list) or not isinstance(blobs, dict):
         raise ValueError("Compact trace bundle must contain records and blobs.")
 
-    materialized: list[dict[str, Any]] = []
-    blob_cache: dict[str, Any] = {}
+    materialized: list[Map[str, object]] = []
+    blob_cache: Map[str, object] = {}
     for payload in records:
         record = decode_compact_record_payload(payload, lambda ref: _load_bundle_blob(ref, blobs, blob_cache))
         if isinstance(record, dict):
@@ -83,7 +84,7 @@ def materialize_compact_trace_bundle(bundle: dict[str, Any]) -> list[dict[str, A
     return materialized
 
 
-def decode_compact_record_payload(payload: Any, load_blob: Any) -> dict[str, Any] | None:
+def decode_compact_record_payload(payload: object, load_blob: object) -> Map[str, object] | None:
     """Decode one compact record payload using the supplied blob loader."""
     if not isinstance(payload, dict):
         return None
@@ -104,7 +105,7 @@ def decode_compact_record_payload(payload: Any, load_blob: Any) -> dict[str, Any
     return record if isinstance(record, dict) else None
 
 
-def make_blob_ref(hash_value: str, size_bytes: int) -> dict[str, Any]:
+def make_blob_ref(hash_value: str, size_bytes: int) -> Map[str, object]:
     return {
         BLOB_REF_MARKER: {
             "version": COMPACT_RECORD_VERSION,
@@ -115,13 +116,13 @@ def make_blob_ref(hash_value: str, size_bytes: int) -> dict[str, Any]:
     }
 
 
-def json_blob_payload(value: Any) -> tuple[str, int, str]:
+def json_blob_payload(value: object) -> tuple[str, int, str]:
     payload_json = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
     payload_bytes = payload_json.encode("utf-8")
     return payload_json, len(payload_bytes), "sha256:" + sha256(payload_bytes).hexdigest()
 
 
-def _encode_compact_record(record: dict[str, Any], blobs: dict[str, dict[str, Any]]) -> dict[str, Any]:
+def _encode_compact_record(record: Map[str, object], blobs: Map[str, Map[str, object]]) -> Map[str, object]:
     compact_record, refs = compact_record_blobs(record, lambda value: _store_bundle_blob(blobs, value))
     if not refs:
         return compact_record
@@ -136,12 +137,12 @@ def _encode_compact_record(record: dict[str, Any], blobs: dict[str, dict[str, An
 
 
 def compact_record_blobs(
-    record: dict[str, Any],
-    store_blob: Callable[[Any], dict[str, Any] | None],
-) -> tuple[dict[str, Any], list[dict[str, object]]]:
+    record: Map[str, object],
+    store_blob: Callable[[JsonValue], Map[str, object] | None],
+) -> tuple[Map[str, object], list[Map[str, object]]]:
     """Replace large repeated record fields and list items with blob refs."""
     compact_record = record
-    refs: list[dict[str, object]] = []
+    refs: list[Map[str, object]] = []
     for path in COMPACT_BLOB_PATHS:
         value = _get_path(compact_record, path)
         if value is None:
@@ -161,7 +162,7 @@ def compact_record_blobs(
         value = _get_path(compact_record, path)
         if not isinstance(value, list):
             continue
-        compact_items: list[Any] | None = None
+        compact_items: list[object] | None = None
         for index, item in enumerate(value):
             ref = store_blob(item)
             if ref is None:
@@ -181,7 +182,7 @@ def compact_record_blobs(
     return compact_record, refs
 
 
-def _store_bundle_blob(blobs: dict[str, dict[str, Any]], value: Any) -> dict[str, Any] | None:
+def _store_bundle_blob(blobs: Map[str, Map[str, object]], value: object) -> Map[str, object] | None:
     _payload_json, size_bytes, hash_value = json_blob_payload(value)
     if size_bytes < MIN_BLOB_BYTES:
         return None
@@ -189,7 +190,7 @@ def _store_bundle_blob(blobs: dict[str, dict[str, Any]], value: Any) -> dict[str
     return make_blob_ref(hash_value, size_bytes)
 
 
-def _load_bundle_blob(ref: dict[str, Any], blobs: dict[str, Any], blob_cache: dict[str, Any]) -> Any:
+def _load_bundle_blob(ref: Map[str, object], blobs: Map[str, object], blob_cache: Map[str, object]) -> object:
     hash_value = ref["hash"]
     if hash_value not in blob_cache:
         blob = blobs.get(hash_value)
@@ -199,13 +200,13 @@ def _load_bundle_blob(ref: dict[str, Any], blobs: dict[str, Any], blob_cache: di
     return blob_cache[hash_value]
 
 
-def _parse_ref_path(path: Any) -> tuple[str, ...] | None:
+def _parse_ref_path(path: object) -> tuple[str, ...] | None:
     if not isinstance(path, str) or not path.startswith("/"):
         return None
     return tuple(part.replace("~1", "/").replace("~0", "~") for part in path.removeprefix("/").split("/"))
 
 
-def _ref_paths_from_marker_refs(refs: Any) -> list[tuple[str, ...]]:
+def _ref_paths_from_marker_refs(refs: object) -> list[tuple[str, ...]]:
     if not isinstance(refs, list):
         return []
     paths: list[tuple[str, ...]] = []
@@ -218,7 +219,7 @@ def _ref_paths_from_marker_refs(refs: Any) -> list[tuple[str, ...]]:
     return paths
 
 
-def _legacy_compact_ref_paths(record: dict[str, Any]) -> list[tuple[str, ...]]:
+def _legacy_compact_ref_paths(record: Map[str, object]) -> list[tuple[str, ...]]:
     paths: list[tuple[str, ...]] = []
     for path in COMPACT_BLOB_PATHS:
         if is_blob_ref(_get_path(record, path)):
@@ -231,12 +232,12 @@ def _legacy_compact_ref_paths(record: dict[str, Any]) -> list[tuple[str, ...]]:
     return paths
 
 
-def _materialize_blob_ref_path(root: dict[str, Any], path: tuple[str, ...], load_blob: Any) -> dict[str, Any]:
+def _materialize_blob_ref_path(root: Map[str, object], path: tuple[str, ...], load_blob: object) -> Map[str, object]:
     value, changed = _replace_blob_ref_at_path(root, path, load_blob)
     return value if changed and isinstance(value, dict) else root
 
 
-def _replace_blob_ref_at_path(value: Any, path: tuple[str, ...], load_blob: Any) -> tuple[Any, bool]:
+def _replace_blob_ref_at_path(value: object, path: tuple[str, ...], load_blob: object) -> tuple[object, bool]:
     if not path:
         if is_blob_ref(value):
             return load_blob(value[BLOB_REF_MARKER]), True
@@ -270,8 +271,8 @@ def _replace_blob_ref_at_path(value: Any, path: tuple[str, ...], load_blob: Any)
     return value, False
 
 
-def _get_path(root: dict[str, Any], path: tuple[str, ...]) -> Any:
-    node: Any = root
+def _get_path(root: Map[str, object], path: tuple[str, ...]) -> object:
+    node: object = root
     for key in path:
         if not isinstance(node, dict) or key not in node:
             return None
@@ -279,12 +280,12 @@ def _get_path(root: dict[str, Any], path: tuple[str, ...]) -> Any:
     return node
 
 
-def _replace_path(root: dict[str, Any], path: tuple[str, ...], replacement: Any) -> dict[str, Any]:
+def _replace_path(root: Map[str, object], path: tuple[str, ...], replacement: object) -> Map[str, object]:
     if not path:
         return root
     new_root = dict(root)
-    old_node: Any = root
-    new_node: dict[str, Any] = new_root
+    old_node: object = root
+    new_node: Map[str, object] = new_root
     for key in path[:-1]:
         child = old_node.get(key) if isinstance(old_node, dict) else None
         if not isinstance(child, dict):
@@ -297,7 +298,7 @@ def _replace_path(root: dict[str, Any], path: tuple[str, ...], replacement: Any)
     return new_root
 
 
-def is_blob_ref(value: Any) -> bool:
+def is_blob_ref(value: object) -> bool:
     if not isinstance(value, dict) or set(value) != {BLOB_REF_MARKER}:
         return False
     ref = value[BLOB_REF_MARKER]

--- a/claude_tap/compact_trace.py
+++ b/claude_tap/compact_trace.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Callable
 from hashlib import sha256
 
-from claude_tap.models import JsonValue, Map
+from claude_tap.models import ProviderPayload
 
 COMPACT_TRACE_MARKER = "__claude_tap_compact_trace__"
 COMPACT_RECORD_MARKER = "__claude_tap_compact_record__"
@@ -27,14 +27,14 @@ COMPACT_ITEM_BLOB_PATHS = (
 )
 
 
-def dump_compact_trace(records: list[Map[str, object]]) -> str:
+def dump_compact_trace(records: list[ProviderPayload]) -> str:
     """Serialize records into a portable compact trace bundle."""
     return json.dumps(build_compact_trace_bundle(records), ensure_ascii=False, separators=(",", ":")) + "\n"
 
 
-def build_compact_trace_bundle(records: list[Map[str, object]]) -> Map[str, object]:
+def build_compact_trace_bundle(records: list[ProviderPayload]) -> ProviderPayload:
     """Return a standalone compact trace bundle with inline blob dictionary."""
-    blobs: Map[str, Map[str, object]] = {}
+    blobs: dict[str, ProviderPayload] = {}
     compact_records = [_encode_compact_record(record, blobs) for record in records]
     return {
         COMPACT_TRACE_MARKER: {
@@ -48,7 +48,7 @@ def build_compact_trace_bundle(records: list[Map[str, object]]) -> Map[str, obje
     }
 
 
-def load_compact_trace(text: str) -> list[Map[str, object]] | None:
+def load_compact_trace(text: str) -> list[ProviderPayload] | None:
     """Materialize a compact trace bundle, or return None when text is not one."""
     try:
         value = json.loads(text)
@@ -59,14 +59,14 @@ def load_compact_trace(text: str) -> list[Map[str, object]] | None:
     return materialize_compact_trace_bundle(value)
 
 
-def is_compact_trace_bundle(value: object) -> bool:
+def is_compact_trace_bundle(value: ProviderPayload) -> bool:
     if not isinstance(value, dict):
         return False
     marker = value.get(COMPACT_TRACE_MARKER)
     return isinstance(marker, dict) and marker.get("version") == COMPACT_TRACE_VERSION
 
 
-def materialize_compact_trace_bundle(bundle: Map[str, object]) -> list[Map[str, object]]:
+def materialize_compact_trace_bundle(bundle: ProviderPayload) -> list[ProviderPayload]:
     """Materialize all records from a compact trace bundle."""
     if not is_compact_trace_bundle(bundle):
         raise ValueError("Unsupported compact trace bundle.")
@@ -75,8 +75,8 @@ def materialize_compact_trace_bundle(bundle: Map[str, object]) -> list[Map[str, 
     if not isinstance(records, list) or not isinstance(blobs, dict):
         raise ValueError("Compact trace bundle must contain records and blobs.")
 
-    materialized: list[Map[str, object]] = []
-    blob_cache: Map[str, object] = {}
+    materialized: list[ProviderPayload] = []
+    blob_cache: ProviderPayload = {}
     for payload in records:
         record = decode_compact_record_payload(payload, lambda ref: _load_bundle_blob(ref, blobs, blob_cache))
         if isinstance(record, dict):
@@ -84,7 +84,9 @@ def materialize_compact_trace_bundle(bundle: Map[str, object]) -> list[Map[str, 
     return materialized
 
 
-def decode_compact_record_payload(payload: object, load_blob: object) -> Map[str, object] | None:
+def decode_compact_record_payload(
+    payload: ProviderPayload, load_blob: Callable[[ProviderPayload], ProviderPayload]
+) -> ProviderPayload | None:
     """Decode one compact record payload using the supplied blob loader."""
     if not isinstance(payload, dict):
         return None
@@ -105,7 +107,7 @@ def decode_compact_record_payload(payload: object, load_blob: object) -> Map[str
     return record if isinstance(record, dict) else None
 
 
-def make_blob_ref(hash_value: str, size_bytes: int) -> Map[str, object]:
+def make_blob_ref(hash_value: str, size_bytes: int) -> ProviderPayload:
     return {
         BLOB_REF_MARKER: {
             "version": COMPACT_RECORD_VERSION,
@@ -116,13 +118,13 @@ def make_blob_ref(hash_value: str, size_bytes: int) -> Map[str, object]:
     }
 
 
-def json_blob_payload(value: object) -> tuple[str, int, str]:
+def json_blob_payload(value: ProviderPayload) -> tuple[str, int, str]:
     payload_json = json.dumps(value, ensure_ascii=False, separators=(",", ":"))
     payload_bytes = payload_json.encode("utf-8")
     return payload_json, len(payload_bytes), "sha256:" + sha256(payload_bytes).hexdigest()
 
 
-def _encode_compact_record(record: Map[str, object], blobs: Map[str, Map[str, object]]) -> Map[str, object]:
+def _encode_compact_record(record: ProviderPayload, blobs: dict[str, ProviderPayload]) -> ProviderPayload:
     compact_record, refs = compact_record_blobs(record, lambda value: _store_bundle_blob(blobs, value))
     if not refs:
         return compact_record
@@ -137,12 +139,12 @@ def _encode_compact_record(record: Map[str, object], blobs: Map[str, Map[str, ob
 
 
 def compact_record_blobs(
-    record: Map[str, object],
-    store_blob: Callable[[JsonValue], Map[str, object] | None],
-) -> tuple[Map[str, object], list[Map[str, object]]]:
+    record: ProviderPayload,
+    store_blob: Callable[[ProviderPayload], ProviderPayload | None],
+) -> tuple[ProviderPayload, list[ProviderPayload]]:
     """Replace large repeated record fields and list items with blob refs."""
     compact_record = record
-    refs: list[Map[str, object]] = []
+    refs: list[ProviderPayload] = []
     for path in COMPACT_BLOB_PATHS:
         value = _get_path(compact_record, path)
         if value is None:
@@ -162,7 +164,7 @@ def compact_record_blobs(
         value = _get_path(compact_record, path)
         if not isinstance(value, list):
             continue
-        compact_items: list[object] | None = None
+        compact_items: list[ProviderPayload] | None = None
         for index, item in enumerate(value):
             ref = store_blob(item)
             if ref is None:
@@ -182,7 +184,7 @@ def compact_record_blobs(
     return compact_record, refs
 
 
-def _store_bundle_blob(blobs: Map[str, Map[str, object]], value: object) -> Map[str, object] | None:
+def _store_bundle_blob(blobs: dict[str, ProviderPayload], value: ProviderPayload) -> ProviderPayload | None:
     _payload_json, size_bytes, hash_value = json_blob_payload(value)
     if size_bytes < MIN_BLOB_BYTES:
         return None
@@ -190,7 +192,7 @@ def _store_bundle_blob(blobs: Map[str, Map[str, object]], value: object) -> Map[
     return make_blob_ref(hash_value, size_bytes)
 
 
-def _load_bundle_blob(ref: Map[str, object], blobs: Map[str, object], blob_cache: Map[str, object]) -> object:
+def _load_bundle_blob(ref: ProviderPayload, blobs: ProviderPayload, blob_cache: ProviderPayload) -> ProviderPayload:
     hash_value = ref["hash"]
     if hash_value not in blob_cache:
         blob = blobs.get(hash_value)
@@ -200,13 +202,13 @@ def _load_bundle_blob(ref: Map[str, object], blobs: Map[str, object], blob_cache
     return blob_cache[hash_value]
 
 
-def _parse_ref_path(path: object) -> tuple[str, ...] | None:
+def _parse_ref_path(path: str | None) -> tuple[str, ...] | None:
     if not isinstance(path, str) or not path.startswith("/"):
         return None
     return tuple(part.replace("~1", "/").replace("~0", "~") for part in path.removeprefix("/").split("/"))
 
 
-def _ref_paths_from_marker_refs(refs: object) -> list[tuple[str, ...]]:
+def _ref_paths_from_marker_refs(refs: list[ProviderPayload] | None) -> list[tuple[str, ...]]:
     if not isinstance(refs, list):
         return []
     paths: list[tuple[str, ...]] = []
@@ -219,7 +221,7 @@ def _ref_paths_from_marker_refs(refs: object) -> list[tuple[str, ...]]:
     return paths
 
 
-def _legacy_compact_ref_paths(record: Map[str, object]) -> list[tuple[str, ...]]:
+def _legacy_compact_ref_paths(record: ProviderPayload) -> list[tuple[str, ...]]:
     paths: list[tuple[str, ...]] = []
     for path in COMPACT_BLOB_PATHS:
         if is_blob_ref(_get_path(record, path)):
@@ -232,12 +234,20 @@ def _legacy_compact_ref_paths(record: Map[str, object]) -> list[tuple[str, ...]]
     return paths
 
 
-def _materialize_blob_ref_path(root: Map[str, object], path: tuple[str, ...], load_blob: object) -> Map[str, object]:
+def _materialize_blob_ref_path(
+    root: ProviderPayload,
+    path: tuple[str, ...],
+    load_blob: Callable[[ProviderPayload], ProviderPayload],
+) -> ProviderPayload:
     value, changed = _replace_blob_ref_at_path(root, path, load_blob)
     return value if changed and isinstance(value, dict) else root
 
 
-def _replace_blob_ref_at_path(value: object, path: tuple[str, ...], load_blob: object) -> tuple[object, bool]:
+def _replace_blob_ref_at_path(
+    value: ProviderPayload,
+    path: tuple[str, ...],
+    load_blob: Callable[[ProviderPayload], ProviderPayload],
+) -> tuple[ProviderPayload, bool]:
     if not path:
         if is_blob_ref(value):
             return load_blob(value[BLOB_REF_MARKER]), True
@@ -271,8 +281,8 @@ def _replace_blob_ref_at_path(value: object, path: tuple[str, ...], load_blob: o
     return value, False
 
 
-def _get_path(root: Map[str, object], path: tuple[str, ...]) -> object:
-    node: object = root
+def _get_path(root: ProviderPayload, path: tuple[str, ...]) -> ProviderPayload:
+    node: ProviderPayload = root
     for key in path:
         if not isinstance(node, dict) or key not in node:
             return None
@@ -280,12 +290,12 @@ def _get_path(root: Map[str, object], path: tuple[str, ...]) -> object:
     return node
 
 
-def _replace_path(root: Map[str, object], path: tuple[str, ...], replacement: object) -> Map[str, object]:
+def _replace_path(root: ProviderPayload, path: tuple[str, ...], replacement: ProviderPayload) -> ProviderPayload:
     if not path:
         return root
     new_root = dict(root)
-    old_node: object = root
-    new_node: Map[str, object] = new_root
+    old_node: ProviderPayload = root
+    new_node: ProviderPayload = new_root
     for key in path[:-1]:
         child = old_node.get(key) if isinstance(old_node, dict) else None
         if not isinstance(child, dict):
@@ -298,7 +308,7 @@ def _replace_path(root: Map[str, object], path: tuple[str, ...], replacement: ob
     return new_root
 
 
-def is_blob_ref(value: object) -> bool:
+def is_blob_ref(value: ProviderPayload) -> bool:
     if not isinstance(value, dict) or set(value) != {BLOB_REF_MARKER}:
         return False
     ref = value[BLOB_REF_MARKER]

--- a/claude_tap/cursor_metadata.py
+++ b/claude_tap/cursor_metadata.py
@@ -24,7 +24,7 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-from claude_tap.models import JsonObject
+from claude_tap.models import ProviderPayload
 
 log = logging.getLogger("claude-tap")
 
@@ -70,7 +70,7 @@ def _connect_readonly(path: Path) -> sqlite3.Connection | None:
         return None
 
 
-def _decode_maybe_hex_json(value: object) -> JsonObject | None:
+def _decode_maybe_hex_json(value: ProviderPayload) -> ProviderPayload | None:
     if isinstance(value, bytes):
         try:
             value = value.decode("utf-8")
@@ -170,7 +170,7 @@ def lookup_composer_meta(
     )
 
 
-def _message_text(content: object) -> str:
+def _message_text(content: ProviderPayload) -> str:
     if isinstance(content, str):
         return content.strip()
     if not isinstance(content, list):

--- a/claude_tap/cursor_metadata.py
+++ b/claude_tap/cursor_metadata.py
@@ -24,6 +24,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from claude_tap.models import JsonObject
+
 log = logging.getLogger("claude-tap")
 
 
@@ -68,7 +70,7 @@ def _connect_readonly(path: Path) -> sqlite3.Connection | None:
         return None
 
 
-def _decode_maybe_hex_json(value: object) -> dict | None:
+def _decode_maybe_hex_json(value: object) -> JsonObject | None:
     if isinstance(value, bytes):
         try:
             value = value.decode("utf-8")

--- a/claude_tap/cursor_transcript.py
+++ b/claude_tap/cursor_transcript.py
@@ -30,7 +30,7 @@ from claude_tap.cursor_metadata import (
     lookup_chat_store_system_prompt,
     resolve_cursor_conversation_meta,
 )
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.trace import TraceWriter, create_trace_writer
 from claude_tap.trace_store import SessionQuery, TraceStore, get_trace_store
 
@@ -69,13 +69,13 @@ def model_from_cursor_args(cmd_args: list[str] | tuple[str, ...] | None) -> str:
     return ""
 
 
-def _extract_content_blocks(message: object) -> list[JsonObject]:
+def _extract_content_blocks(message: ProviderPayload) -> list[ProviderPayload]:
     if not isinstance(message, dict):
         return []
     content = message.get("content")
     if not isinstance(content, list):
         return []
-    blocks: list[JsonObject] = []
+    blocks: list[ProviderPayload] = []
     for item in content:
         if not isinstance(item, dict):
             continue
@@ -98,7 +98,7 @@ def _extract_content_blocks(message: object) -> list[JsonObject]:
     return blocks
 
 
-def _text_from_blocks(blocks: list[JsonObject]) -> str:
+def _text_from_blocks(blocks: list[ProviderPayload]) -> str:
     return "\n".join(
         block["text"] for block in blocks if block.get("type") == "text" and isinstance(block.get("text"), str)
     ).strip()
@@ -112,8 +112,8 @@ def _strip_cursor_wrappers(text: str) -> str:
     return re.sub(r"<timestamp>.*?</timestamp>\s*", "", text, flags=re.DOTALL).strip()
 
 
-def _load_transcript(path: Path) -> list[tuple[str, list[JsonObject]]]:
-    messages: list[tuple[str, list[JsonObject]]] = []
+def _load_transcript(path: Path) -> list[tuple[str, list[ProviderPayload]]]:
+    messages: list[tuple[str, list[ProviderPayload]]] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError as exc:
@@ -143,8 +143,10 @@ def _load_transcript(path: Path) -> list[tuple[str, list[JsonObject]]]:
     return messages
 
 
-def _assistant_steps(messages: list[tuple[str, list[JsonObject]]]) -> list[tuple[str, list[JsonObject], int, int]]:
-    steps: list[tuple[str, list[JsonObject], int, int]] = []
+def _assistant_steps(
+    messages: list[tuple[str, list[ProviderPayload]]],
+) -> list[tuple[str, list[ProviderPayload], int, int]]:
+    steps: list[tuple[str, list[ProviderPayload], int, int]] = []
     pending_user: str | None = None
     cursor_turn = 0
     cursor_step = 0
@@ -160,7 +162,7 @@ def _assistant_steps(messages: list[tuple[str, list[JsonObject]]]) -> list[tuple
     return steps
 
 
-def _json_schema_type(value: object) -> str:
+def _json_schema_type(value: ProviderPayload) -> str:
     if isinstance(value, bool):
         return "boolean"
     if isinstance(value, int):
@@ -176,14 +178,14 @@ def _json_schema_type(value: object) -> str:
     return "string"
 
 
-def _tools_from_tool_use_blocks(block_lists: list[list[JsonObject]]) -> list[JsonObject]:
+def _tools_from_tool_use_blocks(block_lists: list[list[ProviderPayload]]) -> list[ProviderPayload]:
     """Reconstruct an Anthropic-shaped tools catalog from observed tool_use blocks.
 
     Cursor transcripts never include the original request tool definitions.
     Names and property keys come from assistant ``tool_use`` calls, which is the
     closest local approximation of the catalog that was sent to the model.
     """
-    properties_by_name: Map[str, Map[str, Map[str, str]]] = {}
+    properties_by_name: dict[str, dict[str, dict[str, str]]] = {}
     order: list[str] = []
     for blocks in block_lists:
         for block in blocks:
@@ -214,35 +216,35 @@ def _tools_from_tool_use_blocks(block_lists: list[list[JsonObject]]) -> list[Jso
     ]
 
 
-def _tools_from_steps(steps: list[tuple[str, list[JsonObject], int, int]]) -> list[JsonObject]:
+def _tools_from_steps(steps: list[tuple[str, list[ProviderPayload], int, int]]) -> list[ProviderPayload]:
     """Reconstruct a tools catalog from assistant steps in a Cursor transcript."""
     return _tools_from_tool_use_blocks([blocks for _user_text, blocks, _turn, _step in steps])
 
 
-def _response_content_blocks(record: JsonObject) -> list[JsonObject]:
+def _response_content_blocks(record: ProviderPayload) -> list[ProviderPayload]:
     content = ((record.get("response") or {}).get("body") or {}).get("content")
     if not isinstance(content, list):
         return []
     return [block for block in content if isinstance(block, dict)]
 
 
-def _tools_from_records(records: list[JsonObject]) -> list[JsonObject]:
+def _tools_from_records(records: list[ProviderPayload]) -> list[ProviderPayload]:
     return _tools_from_tool_use_blocks(
         [_response_content_blocks(record) for record in records if record.get("transport") == "cursor-transcript"]
     )
 
 
-def _has_request_tools(body: JsonObject) -> bool:
+def _has_request_tools(body: ProviderPayload) -> bool:
     tools = body.get("tools")
     return isinstance(tools, list) and any(isinstance(tool, dict) for tool in tools)
 
 
-def _has_request_system(body: JsonObject) -> bool:
+def _has_request_system(body: ProviderPayload) -> bool:
     system = body.get("system")
     return isinstance(system, str) and bool(system.strip())
 
 
-def _cursor_transcript_id_from_records(records: list[JsonObject]) -> str:
+def _cursor_transcript_id_from_records(records: list[ProviderPayload]) -> str:
     for record in records:
         capture = record.get("capture")
         if not isinstance(capture, dict):
@@ -275,7 +277,7 @@ def backfill_cursor_transcript_request_fields(
         conversation_id = _cursor_transcript_id_from_records(records)
         if conversation_id:
             system = lookup_chat_store_system_prompt(conversation_id, home=home)
-        rewritten: list[JsonObject] = []
+        rewritten: list[ProviderPayload] = []
         changed = False
         session_updated = 0
         for record in records:
@@ -308,8 +310,8 @@ def backfill_cursor_transcript_request_fields(
     return updated
 
 
-def _normalize_assistant_blocks(blocks: list[JsonObject], *, turn_index: int) -> list[JsonObject]:
-    normalized: list[JsonObject] = []
+def _normalize_assistant_blocks(blocks: list[ProviderPayload], *, turn_index: int) -> list[ProviderPayload]:
+    normalized: list[ProviderPayload] = []
     for index, block in enumerate(blocks, start=1):
         copied = dict(block)
         if copied.get("type") == "tool_use" and not copied.get("id"):
@@ -367,7 +369,7 @@ def build_cursor_transcript_records(
     model: str = "",
     conversation_meta: CursorConversationMeta | None = None,
     system: str = "",
-) -> tuple[int, list[JsonObject]]:
+) -> tuple[int, list[ProviderPayload]]:
     """Build Anthropic-shaped synthetic records from a Cursor transcript.
 
     Returns ``(total_assistant_steps, new_records)``. Turn numbers are assigned
@@ -378,7 +380,7 @@ def build_cursor_transcript_records(
     total_steps = len(all_steps)
     reconstructed_tools = _tools_from_steps(all_steps)
     steps = all_steps[skip_steps:] if skip_steps > 0 else all_steps
-    records: list[JsonObject] = []
+    records: list[ProviderPayload] = []
     timestamp = datetime.now(timezone.utc).isoformat()
     meta = conversation_meta or CursorConversationMeta()
     model_name = _launch_model_hint(model) or meta.model
@@ -386,7 +388,7 @@ def build_cursor_transcript_records(
     for index, (user_text, assistant_blocks, cursor_turn, cursor_step) in enumerate(steps, start=1):
         req_id = f"cursor_transcript_{uuid.uuid4().hex[:12]}"
         response_content = _normalize_assistant_blocks(assistant_blocks, turn_index=skip_steps + index)
-        body: JsonObject = {
+        body: ProviderPayload = {
             "cursor_turn": cursor_turn,
             "cursor_step": cursor_step,
             "messages": [{"role": "user", "content": user_text}],
@@ -404,7 +406,7 @@ def build_cursor_transcript_records(
             body["cursor_context_token_limit"] = meta.context_token_limit
         if meta.source:
             body["cursor_meta_source"] = meta.source
-        response_body: JsonObject = {
+        response_body: ProviderPayload = {
             "id": session_id,
             "type": "message",
             "role": "assistant",
@@ -467,7 +469,7 @@ class CursorTranscriptWatcher:
         store: TraceStore | None = None,
         client: str = "cursor",
         proxy_mode: str = "transcript",
-        metadata: Map[str, str] | None = None,
+        metadata: dict[str, str] | None = None,
     ) -> None:
         self._since = since
         self._home = home
@@ -477,12 +479,12 @@ class CursorTranscriptWatcher:
         self._client = client
         self._proxy_mode = proxy_mode
         self._metadata = dict(metadata or {})
-        self._writers: Map[str, TraceWriter] = {}
-        self._imported_steps: Map[str, int] = {}
+        self._writers: dict[str, TraceWriter] = {}
+        self._imported_steps: dict[str, int] = {}
         self._imported_paths: set[str] = set()
-        self._seen_sizes: Map[str, int] = {}
-        self._conversation_meta: Map[str, CursorConversationMeta] = {}
-        self._system_prompts: Map[str, str] = {}
+        self._seen_sizes: dict[str, int] = {}
+        self._conversation_meta: dict[str, CursorConversationMeta] = {}
+        self._system_prompts: dict[str, str] = {}
         self._request_fields_backfilled = False
         self._task: asyncio.Task[None] | None = None
         self._stop = asyncio.Event()
@@ -523,9 +525,9 @@ class CursorTranscriptWatcher:
         """Tap session ids created for observed Cursor transcripts, in discovery order."""
         return [writer.session_id for writer in self._writers.values() if writer.session_id]
 
-    def get_summary(self) -> JsonObject:
+    def get_summary(self) -> ProviderPayload:
         """Aggregate TraceWriter summaries across all Cursor conversations."""
-        stats: JsonObject = {
+        stats: ProviderPayload = {
             "api_calls": 0,
             "input_tokens": 0,
             "output_tokens": 0,
@@ -709,7 +711,7 @@ async def import_cursor_transcripts(
     store: TraceStore | None = None,
     client: str = "cursor",
     proxy_mode: str = "transcript",
-    metadata: Map[str, str] | None = None,
+    metadata: dict[str, str] | None = None,
 ) -> CursorTranscriptWatcher:
     """Import recent Cursor transcripts into one tap session per JSONL file.
 

--- a/claude_tap/cursor_transcript.py
+++ b/claude_tap/cursor_transcript.py
@@ -30,6 +30,7 @@ from claude_tap.cursor_metadata import (
     lookup_chat_store_system_prompt,
     resolve_cursor_conversation_meta,
 )
+from claude_tap.models import JsonObject, Map
 from claude_tap.trace import TraceWriter, create_trace_writer
 from claude_tap.trace_store import SessionQuery, TraceStore, get_trace_store
 
@@ -68,13 +69,13 @@ def model_from_cursor_args(cmd_args: list[str] | tuple[str, ...] | None) -> str:
     return ""
 
 
-def _extract_content_blocks(message: object) -> list[dict]:
+def _extract_content_blocks(message: object) -> list[JsonObject]:
     if not isinstance(message, dict):
         return []
     content = message.get("content")
     if not isinstance(content, list):
         return []
-    blocks: list[dict] = []
+    blocks: list[JsonObject] = []
     for item in content:
         if not isinstance(item, dict):
             continue
@@ -97,7 +98,7 @@ def _extract_content_blocks(message: object) -> list[dict]:
     return blocks
 
 
-def _text_from_blocks(blocks: list[dict]) -> str:
+def _text_from_blocks(blocks: list[JsonObject]) -> str:
     return "\n".join(
         block["text"] for block in blocks if block.get("type") == "text" and isinstance(block.get("text"), str)
     ).strip()
@@ -111,8 +112,8 @@ def _strip_cursor_wrappers(text: str) -> str:
     return re.sub(r"<timestamp>.*?</timestamp>\s*", "", text, flags=re.DOTALL).strip()
 
 
-def _load_transcript(path: Path) -> list[tuple[str, list[dict]]]:
-    messages: list[tuple[str, list[dict]]] = []
+def _load_transcript(path: Path) -> list[tuple[str, list[JsonObject]]]:
+    messages: list[tuple[str, list[JsonObject]]] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError as exc:
@@ -142,8 +143,8 @@ def _load_transcript(path: Path) -> list[tuple[str, list[dict]]]:
     return messages
 
 
-def _assistant_steps(messages: list[tuple[str, list[dict]]]) -> list[tuple[str, list[dict], int, int]]:
-    steps: list[tuple[str, list[dict], int, int]] = []
+def _assistant_steps(messages: list[tuple[str, list[JsonObject]]]) -> list[tuple[str, list[JsonObject], int, int]]:
+    steps: list[tuple[str, list[JsonObject], int, int]] = []
     pending_user: str | None = None
     cursor_turn = 0
     cursor_step = 0
@@ -175,14 +176,14 @@ def _json_schema_type(value: object) -> str:
     return "string"
 
 
-def _tools_from_tool_use_blocks(block_lists: list[list[dict]]) -> list[dict]:
+def _tools_from_tool_use_blocks(block_lists: list[list[JsonObject]]) -> list[JsonObject]:
     """Reconstruct an Anthropic-shaped tools catalog from observed tool_use blocks.
 
     Cursor transcripts never include the original request tool definitions.
     Names and property keys come from assistant ``tool_use`` calls, which is the
     closest local approximation of the catalog that was sent to the model.
     """
-    properties_by_name: dict[str, dict[str, dict[str, str]]] = {}
+    properties_by_name: Map[str, Map[str, Map[str, str]]] = {}
     order: list[str] = []
     for blocks in block_lists:
         for block in blocks:
@@ -213,35 +214,35 @@ def _tools_from_tool_use_blocks(block_lists: list[list[dict]]) -> list[dict]:
     ]
 
 
-def _tools_from_steps(steps: list[tuple[str, list[dict], int, int]]) -> list[dict]:
+def _tools_from_steps(steps: list[tuple[str, list[JsonObject], int, int]]) -> list[JsonObject]:
     """Reconstruct a tools catalog from assistant steps in a Cursor transcript."""
     return _tools_from_tool_use_blocks([blocks for _user_text, blocks, _turn, _step in steps])
 
 
-def _response_content_blocks(record: dict) -> list[dict]:
+def _response_content_blocks(record: JsonObject) -> list[JsonObject]:
     content = ((record.get("response") or {}).get("body") or {}).get("content")
     if not isinstance(content, list):
         return []
     return [block for block in content if isinstance(block, dict)]
 
 
-def _tools_from_records(records: list[dict]) -> list[dict]:
+def _tools_from_records(records: list[JsonObject]) -> list[JsonObject]:
     return _tools_from_tool_use_blocks(
         [_response_content_blocks(record) for record in records if record.get("transport") == "cursor-transcript"]
     )
 
 
-def _has_request_tools(body: dict) -> bool:
+def _has_request_tools(body: JsonObject) -> bool:
     tools = body.get("tools")
     return isinstance(tools, list) and any(isinstance(tool, dict) for tool in tools)
 
 
-def _has_request_system(body: dict) -> bool:
+def _has_request_system(body: JsonObject) -> bool:
     system = body.get("system")
     return isinstance(system, str) and bool(system.strip())
 
 
-def _cursor_transcript_id_from_records(records: list[dict]) -> str:
+def _cursor_transcript_id_from_records(records: list[JsonObject]) -> str:
     for record in records:
         capture = record.get("capture")
         if not isinstance(capture, dict):
@@ -274,7 +275,7 @@ def backfill_cursor_transcript_request_fields(
         conversation_id = _cursor_transcript_id_from_records(records)
         if conversation_id:
             system = lookup_chat_store_system_prompt(conversation_id, home=home)
-        rewritten: list[dict] = []
+        rewritten: list[JsonObject] = []
         changed = False
         session_updated = 0
         for record in records:
@@ -307,8 +308,8 @@ def backfill_cursor_transcript_request_fields(
     return updated
 
 
-def _normalize_assistant_blocks(blocks: list[dict], *, turn_index: int) -> list[dict]:
-    normalized: list[dict] = []
+def _normalize_assistant_blocks(blocks: list[JsonObject], *, turn_index: int) -> list[JsonObject]:
+    normalized: list[JsonObject] = []
     for index, block in enumerate(blocks, start=1):
         copied = dict(block)
         if copied.get("type") == "tool_use" and not copied.get("id"):
@@ -366,7 +367,7 @@ def build_cursor_transcript_records(
     model: str = "",
     conversation_meta: CursorConversationMeta | None = None,
     system: str = "",
-) -> tuple[int, list[dict]]:
+) -> tuple[int, list[JsonObject]]:
     """Build Anthropic-shaped synthetic records from a Cursor transcript.
 
     Returns ``(total_assistant_steps, new_records)``. Turn numbers are assigned
@@ -377,7 +378,7 @@ def build_cursor_transcript_records(
     total_steps = len(all_steps)
     reconstructed_tools = _tools_from_steps(all_steps)
     steps = all_steps[skip_steps:] if skip_steps > 0 else all_steps
-    records: list[dict] = []
+    records: list[JsonObject] = []
     timestamp = datetime.now(timezone.utc).isoformat()
     meta = conversation_meta or CursorConversationMeta()
     model_name = _launch_model_hint(model) or meta.model
@@ -385,7 +386,7 @@ def build_cursor_transcript_records(
     for index, (user_text, assistant_blocks, cursor_turn, cursor_step) in enumerate(steps, start=1):
         req_id = f"cursor_transcript_{uuid.uuid4().hex[:12]}"
         response_content = _normalize_assistant_blocks(assistant_blocks, turn_index=skip_steps + index)
-        body: dict = {
+        body: JsonObject = {
             "cursor_turn": cursor_turn,
             "cursor_step": cursor_step,
             "messages": [{"role": "user", "content": user_text}],
@@ -403,7 +404,7 @@ def build_cursor_transcript_records(
             body["cursor_context_token_limit"] = meta.context_token_limit
         if meta.source:
             body["cursor_meta_source"] = meta.source
-        response_body: dict = {
+        response_body: JsonObject = {
             "id": session_id,
             "type": "message",
             "role": "assistant",
@@ -466,7 +467,7 @@ class CursorTranscriptWatcher:
         store: TraceStore | None = None,
         client: str = "cursor",
         proxy_mode: str = "transcript",
-        metadata: dict[str, str] | None = None,
+        metadata: Map[str, str] | None = None,
     ) -> None:
         self._since = since
         self._home = home
@@ -476,12 +477,12 @@ class CursorTranscriptWatcher:
         self._client = client
         self._proxy_mode = proxy_mode
         self._metadata = dict(metadata or {})
-        self._writers: dict[str, TraceWriter] = {}
-        self._imported_steps: dict[str, int] = {}
+        self._writers: Map[str, TraceWriter] = {}
+        self._imported_steps: Map[str, int] = {}
         self._imported_paths: set[str] = set()
-        self._seen_sizes: dict[str, int] = {}
-        self._conversation_meta: dict[str, CursorConversationMeta] = {}
-        self._system_prompts: dict[str, str] = {}
+        self._seen_sizes: Map[str, int] = {}
+        self._conversation_meta: Map[str, CursorConversationMeta] = {}
+        self._system_prompts: Map[str, str] = {}
         self._request_fields_backfilled = False
         self._task: asyncio.Task[None] | None = None
         self._stop = asyncio.Event()
@@ -522,9 +523,9 @@ class CursorTranscriptWatcher:
         """Tap session ids created for observed Cursor transcripts, in discovery order."""
         return [writer.session_id for writer in self._writers.values() if writer.session_id]
 
-    def get_summary(self) -> dict:
+    def get_summary(self) -> JsonObject:
         """Aggregate TraceWriter summaries across all Cursor conversations."""
-        stats: dict = {
+        stats: JsonObject = {
             "api_calls": 0,
             "input_tokens": 0,
             "output_tokens": 0,
@@ -708,7 +709,7 @@ async def import_cursor_transcripts(
     store: TraceStore | None = None,
     client: str = "cursor",
     proxy_mode: str = "transcript",
-    metadata: dict[str, str] | None = None,
+    metadata: Map[str, str] | None = None,
 ) -> CursorTranscriptWatcher:
     """Import recent Cursor transcripts into one tap session per JSONL file.
 

--- a/claude_tap/dashboard.py
+++ b/claude_tap/dashboard.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 from claude_tap.bedrock import bedrock_model_from_path
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 from claude_tap.trace_encoding import (
     content_type_from_headers,
     is_encoded_blob_body,
@@ -100,7 +100,7 @@ def list_trace_sessions(
     offset: int = 0,
     query: SessionQuery | None = None,
     repair_stale_summaries: bool = True,
-) -> list[Map[str, object]]:
+) -> list[ProviderPayload]:
     """Return trace sessions sorted by most recent activity."""
     store = ensure_trace_store()
     try:
@@ -108,7 +108,7 @@ def list_trace_sessions(
     except (OSError, sqlite3.Error, ValueError):
         return []
 
-    sessions: list[Map[str, object]] = []
+    sessions: list[ProviderPayload] = []
     for row in rows:
         try:
             summary = _session_summary_from_row(
@@ -153,9 +153,9 @@ def list_trace_agents(
     current_session_id: str | None = None,
     *,
     live_record_count: int | None = None,
-) -> list[Map[str, object]]:
+) -> list[ProviderPayload]:
     """Return agent buckets for the dashboard sidebar."""
-    buckets: Map[str, Map[str, object]] = {}
+    buckets: dict[str, ProviderPayload] = {}
     try:
         rows = ensure_trace_store().list_agent_buckets()
     except (OSError, sqlite3.Error, ValueError):
@@ -180,7 +180,7 @@ def list_trace_agents(
     return sorted(buckets.values(), key=lambda item: (item["label"].lower(), item["key"]))
 
 
-def dashboard_trace_snapshot() -> Map[str, tuple[int, str]]:
+def dashboard_trace_snapshot() -> dict[str, tuple[int, str]]:
     """Return a cheap SQLite snapshot for dashboard refresh detection."""
     store = ensure_trace_store()
     return store.dashboard_snapshot()
@@ -193,7 +193,7 @@ def load_trace_session(
     record_offset: int = 0,
     *,
     live_record_count: int | None = None,
-) -> Map[str, object] | None:
+) -> ProviderPayload | None:
     """Load one session summary and its records by session id."""
     store = ensure_trace_store()
     row = store.load_session_row(session_id)
@@ -213,23 +213,23 @@ def load_trace_session(
     return {"session": summary, "records": records}
 
 
-def redact_dashboard_records(records: list[Map[str, object]]) -> list[Map[str, object]]:
+def redact_dashboard_records(records: list[ProviderPayload]) -> list[ProviderPayload]:
     """Return records safe for dashboard rendering without mutating stored traces."""
     return [_redact_sensitive_value(record) for record in records]
 
 
-def redact_dashboard_summary(summary: Map[str, object]) -> Map[str, object]:
+def redact_dashboard_summary(summary: ProviderPayload) -> ProviderPayload:
     """Return a session summary safe for dashboard rendering."""
     return _redact_sensitive_value(summary)
 
 
 def merge_record_into_summary(
-    summary: Map[str, object] | None,
+    summary: ProviderPayload | None,
     *,
     row: sqlite3.Row,
-    record: Map[str, object],
+    record: ProviderPayload,
     record_count: int,
-) -> Map[str, object]:
+) -> ProviderPayload:
     """Update a session summary incrementally after appending one record."""
     manifest_entry = {
         "client": row["client"] or "",
@@ -299,7 +299,7 @@ def merge_record_into_summary(
     return redact_dashboard_summary(summary)
 
 
-def is_dashboard_summary_current(summary: object, session_id: str) -> bool:
+def is_dashboard_summary_current(summary: ProviderPayload, session_id: str) -> bool:
     return (
         isinstance(summary, dict)
         and summary.get("id") == session_id
@@ -307,7 +307,7 @@ def is_dashboard_summary_current(summary: object, session_id: str) -> bool:
     )
 
 
-def build_stored_session_summary(row: sqlite3.Row, records: list[Map[str, object]]) -> Map[str, object]:
+def build_stored_session_summary(row: sqlite3.Row, records: list[ProviderPayload]) -> ProviderPayload:
     manifest_entry = {
         "client": row["client"] or "",
         "proxy_mode": row["proxy_mode"] or "",
@@ -328,9 +328,9 @@ def build_stored_session_summary(row: sqlite3.Row, records: list[Map[str, object
 
 def build_imported_session_summary(
     row: sqlite3.Row,
-    records: list[Map[str, object]],
-    manifest_entry: Map[str, object],
-) -> Map[str, object]:
+    records: list[ProviderPayload],
+    manifest_entry: ProviderPayload,
+) -> ProviderPayload:
     """Build and cache a summary for a legacy import."""
     return _summarize_session(
         session_id=row["id"],
@@ -352,7 +352,7 @@ def _session_summary_from_row(
     *,
     allow_record_scan: bool = False,
     repair_stale_summary: bool = True,
-) -> Map[str, object]:
+) -> ProviderPayload:
     summary_json = row["summary_json"]
     if summary_json:
         try:
@@ -435,7 +435,7 @@ def _session_summary_from_row(
     return redact_dashboard_summary(summary)
 
 
-def _minimal_session_summary_from_row(row: sqlite3.Row) -> Map[str, object]:
+def _minimal_session_summary_from_row(row: sqlite3.Row) -> ProviderPayload:
     record_count = int(row["record_count"] or 0)
     manifest_entry = {
         "client": row["client"] or "",
@@ -460,9 +460,9 @@ def _minimal_session_summary_from_row(row: sqlite3.Row) -> Map[str, object]:
 
 def _summary_from_boundary_records(
     row: sqlite3.Row,
-    records: list[Map[str, object]],
-    cached: Map[str, object],
-) -> Map[str, object]:
+    records: list[ProviderPayload],
+    cached: ProviderPayload,
+) -> ProviderPayload:
     summary = build_stored_session_summary(row, records)
     for key in (
         "input_tokens",
@@ -483,7 +483,7 @@ def _summary_from_boundary_records(
     return redact_dashboard_summary(summary)
 
 
-def _normalize_cached_session_summary(row: sqlite3.Row, cached: Map[str, object]) -> Map[str, object]:
+def _normalize_cached_session_summary(row: sqlite3.Row, cached: ProviderPayload) -> ProviderPayload:
     summary = _minimal_session_summary_from_row(row)
     summary.update(cached)
     summary["id"] = row["id"]
@@ -520,11 +520,11 @@ def _normalize_cached_session_summary(row: sqlite3.Row, cached: Map[str, object]
 
 
 def _apply_current_session_state(
-    session: Map[str, object],
+    session: ProviderPayload,
     current_session_id: str | None,
     *,
     live_record_count: int | None = None,
-) -> Map[str, object]:
+) -> ProviderPayload:
     session = dict(session)
     is_current = bool(current_session_id and session.get("id") == current_session_id)
     session["live"] = is_current
@@ -545,21 +545,21 @@ def _summarize_session(
     session_id: str,
     date_key: str,
     legacy_rel_path: str | None,
-    records: list[Map[str, object]],
-    manifest_entry: Map[str, object],
+    records: list[ProviderPayload],
+    manifest_entry: ProviderPayload,
     status: str,
     started_at: str,
     updated_at: str,
     is_current: bool,
     record_count: int | None = None,
-) -> Map[str, object]:
+) -> ProviderPayload:
     first_record = records[0] if records else {}
     last_record = records[-1] if records else {}
     started_at = _timestamp_from_record(first_record) or started_at or _iso_now()
     updated_at = _timestamp_from_record(last_record) or updated_at or started_at
     agent = _infer_agent(records, manifest_entry)
     input_tokens = output_tokens = cache_read_tokens = cache_create_tokens = 0
-    models: Map[str, int] = {}
+    models: dict[str, int] = {}
     duration_ms = 0
     turns: set[int] = set()
 
@@ -627,7 +627,7 @@ def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _timestamp_sort_value(value: object) -> float:
+def _timestamp_sort_value(value: str | int | float | None) -> float:
     if not isinstance(value, str) or not value:
         return 0.0
     try:
@@ -639,12 +639,12 @@ def _timestamp_sort_value(value: object) -> float:
     return parsed.astimezone(timezone.utc).timestamp()
 
 
-def _timestamp_from_record(record: Map[str, object]) -> str | None:
+def _timestamp_from_record(record: ProviderPayload) -> str | None:
     value = record.get("timestamp")
     return value if isinstance(value, str) and value else None
 
 
-def _record_usage(record: Map[str, object]) -> Map[str, int]:
+def _record_usage(record: ProviderPayload) -> dict[str, int]:
     response = record.get("response")
     body = response.get("body") if isinstance(response, dict) else {}
     usage = body.get("usage", {}) if isinstance(body, dict) else {}
@@ -658,7 +658,7 @@ def _record_usage(record: Map[str, object]) -> Map[str, int]:
                 usage = candidate
                 break
     if not usage:
-        merged_usage: Map[str, int] = {}
+        merged_usage: dict[str, int] = {}
         for event in _bedrock_events(record):
             payload = event.get("data", {}) if isinstance(event, dict) else {}
             candidate = payload.get("usage", {}) if isinstance(payload, dict) else {}
@@ -677,7 +677,7 @@ def _record_usage(record: Map[str, object]) -> Map[str, int]:
     return normalize_usage(usage)
 
 
-def _record_model(record: Map[str, object]) -> str:
+def _record_model(record: ProviderPayload) -> str:
     request = record.get("request")
     req_body = request.get("body") if isinstance(request, dict) else None
     if isinstance(req_body, dict):
@@ -714,18 +714,18 @@ def _record_model(record: Map[str, object]) -> str:
     return ""
 
 
-def _response_status(record: Map[str, object]) -> int:
+def _response_status(record: ProviderPayload) -> int:
     response = record.get("response")
     status = response.get("status") if isinstance(response, dict) else None
     return status if isinstance(status, int) else 0
 
 
-def _duration_ms(record: Map[str, object]) -> int:
+def _duration_ms(record: ProviderPayload) -> int:
     value = record.get("duration_ms")
     return value if isinstance(value, int) else 0
 
 
-def _record_error(record: Map[str, object]) -> str:
+def _record_error(record: ProviderPayload) -> str:
     response = record.get("response")
     if not isinstance(response, dict):
         return ""
@@ -733,7 +733,7 @@ def _record_error(record: Map[str, object]) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _first_error(records: list[Map[str, object]]) -> str:
+def _first_error(records: list[ProviderPayload]) -> str:
     for record in records:
         error = _record_error(record)
         if error:
@@ -751,13 +751,13 @@ def _first_error(records: list[Map[str, object]]) -> str:
     return ""
 
 
-def _top_key(values: Map[str, int]) -> str:
+def _top_key(values: dict[str, int]) -> str:
     if not values:
         return ""
     return max(values.items(), key=lambda item: item[1])[0]
 
 
-def _infer_agent(records: list[Map[str, object]], manifest_entry: Map[str, object]) -> str:
+def _infer_agent(records: list[ProviderPayload], manifest_entry: ProviderPayload) -> str:
     client = manifest_entry.get("client")
     if not client and isinstance(manifest_entry.get("metadata"), dict):
         client = manifest_entry["metadata"].get("client")
@@ -803,7 +803,7 @@ def _infer_agent(records: list[Map[str, object]], manifest_entry: Map[str, objec
     return "Unknown"
 
 
-def _record_host(record: Map[str, object]) -> str:
+def _record_host(record: ProviderPayload) -> str:
     request = record.get("request")
     headers = request.get("headers") if isinstance(request, dict) else {}
     if isinstance(headers, dict):
@@ -817,7 +817,7 @@ def _record_host(record: Map[str, object]) -> str:
     return ""
 
 
-def _record_path(record: Map[str, object]) -> str:
+def _record_path(record: ProviderPayload) -> str:
     request = record.get("request")
     value = request.get("path") if isinstance(request, dict) else ""
     return value if isinstance(value, str) else ""
@@ -859,7 +859,7 @@ def _agent_filter_values(agent_key: str) -> tuple[tuple[str, ...], tuple[str, ..
     return tuple(sorted(clients)), tuple(sorted(labels))
 
 
-def _preview_records(records: list[Map[str, object]]) -> list[Map[str, object]]:
+def _preview_records(records: list[ProviderPayload]) -> list[ProviderPayload]:
     transcripts = [record for record in records if _is_cursor_transcript_record(record)]
     if transcripts:
         return transcripts
@@ -869,7 +869,7 @@ def _preview_records(records: list[Map[str, object]]) -> list[Map[str, object]]:
     return [record for record in records if not _is_auxiliary_record(record) and not _is_protobuf_noise_record(record)]
 
 
-def _redact_sensitive_value(value: object, key: str = "") -> object:
+def _redact_sensitive_value(value: ProviderPayload, key: str = "") -> ProviderPayload:
     if key and _is_sensitive_key(key):
         return None if value is None else _REDACTED_VALUE
     if isinstance(value, dict):
@@ -981,7 +981,7 @@ def _is_sensitive_key(key: str) -> bool:
     )
 
 
-def _is_primary_model_record(record: Map[str, object]) -> bool:
+def _is_primary_model_record(record: ProviderPayload) -> bool:
     if _is_cursor_transcript_record(record):
         return True
     path = _record_path(record).lower()
@@ -1003,13 +1003,13 @@ def _is_primary_model_record(record: Map[str, object]) -> bool:
     return any(fragment in path for fragment in primary_fragments)
 
 
-def _is_cursor_transcript_record(record: Map[str, object]) -> bool:
+def _is_cursor_transcript_record(record: ProviderPayload) -> bool:
     if str(record.get("transport") or "") == "cursor-transcript":
         return True
     return _record_path(record).startswith("/cursor/transcript/")
 
 
-def _is_protobuf_noise_record(record: Map[str, object]) -> bool:
+def _is_protobuf_noise_record(record: ProviderPayload) -> bool:
     if _is_cursor_transcript_record(record):
         return False
     request = record.get("request")
@@ -1024,7 +1024,7 @@ def _is_protobuf_noise_record(record: Map[str, object]) -> bool:
     return isinstance(body, str) and looks_like_binary_text(body)
 
 
-def _is_auxiliary_record(record: Map[str, object]) -> bool:
+def _is_auxiliary_record(record: ProviderPayload) -> bool:
     if _is_protobuf_noise_record(record):
         return True
     path = _record_path(record).lower()
@@ -1059,24 +1059,24 @@ def _is_model_probe_path(path: str) -> bool:
     return match is not None
 
 
-def _is_session_error_record(record: Map[str, object]) -> bool:
+def _is_session_error_record(record: ProviderPayload) -> bool:
     if _record_error(record):
         return True
     status_code = _response_status(record)
     return status_code >= 400 and not _is_auxiliary_record(record)
 
 
-def _is_auxiliary_status_error_record(record: Map[str, object]) -> bool:
+def _is_auxiliary_status_error_record(record: ProviderPayload) -> bool:
     status_code = _response_status(record)
     return status_code >= 400 and _is_auxiliary_record(record)
 
 
-def _is_successful_primary_record(record: Map[str, object]) -> bool:
+def _is_successful_primary_record(record: ProviderPayload) -> bool:
     status_code = _response_status(record)
     return 200 <= status_code < 400 and not _is_auxiliary_record(record)
 
 
-def _first_user_preview(records: list[Map[str, object]]) -> str:
+def _first_user_preview(records: list[ProviderPayload]) -> str:
     ordered = sorted(
         records,
         key=lambda record: 0 if _is_cursor_transcript_record(record) else 1,
@@ -1094,7 +1094,7 @@ def _first_user_preview(records: list[Map[str, object]]) -> str:
     return ""
 
 
-def _last_response_preview(records: list[Map[str, object]]) -> str:
+def _last_response_preview(records: list[ProviderPayload]) -> str:
     for record in reversed(records):
         text = _record_response_text(record)
         if text:
@@ -1102,7 +1102,7 @@ def _last_response_preview(records: list[Map[str, object]]) -> str:
     return ""
 
 
-def _record_response_text(record: Map[str, object]) -> str:
+def _record_response_text(record: ProviderPayload) -> str:
     response = record.get("response")
     body = response.get("body") if isinstance(response, dict) else None
     text = _response_text(body)
@@ -1124,7 +1124,7 @@ def _record_response_text(record: Map[str, object]) -> str:
     return ""
 
 
-def _response_events(record: Map[str, object]) -> list[Map[str, object]]:
+def _response_events(record: ProviderPayload) -> list[ProviderPayload]:
     response = record.get("response")
     if not isinstance(response, dict):
         return []
@@ -1137,7 +1137,7 @@ def _response_events(record: Map[str, object]) -> list[Map[str, object]]:
     return []
 
 
-def _bedrock_events(record: Map[str, object]) -> list[Map[str, object]]:
+def _bedrock_events(record: ProviderPayload) -> list[ProviderPayload]:
     """Decode AWS Bedrock EventStream binary body into structured events."""
     response = record.get("response")
     if not isinstance(response, dict):
@@ -1146,7 +1146,7 @@ def _bedrock_events(record: Map[str, object]) -> list[Map[str, object]]:
     return _decode_bedrock_eventstream_events(body)
 
 
-def _event_payload(event: Map[str, object]) -> Map[str, object]:
+def _event_payload(event: ProviderPayload) -> ProviderPayload:
     data = event.get("data", event)
     if isinstance(data, str):
         try:
@@ -1161,7 +1161,7 @@ def _event_payload(event: Map[str, object]) -> Map[str, object]:
     return {}
 
 
-def _request_user_text(body: object, *, headers: object = None) -> str:
+def _request_user_text(body: ProviderPayload, *, headers: ProviderPayload = None) -> str:
     header_map = headers if isinstance(headers, dict) else None
     if is_protobuf_content_type(content_type_from_headers(header_map)):
         return ""
@@ -1205,7 +1205,7 @@ def _request_user_text(body: object, *, headers: object = None) -> str:
     return _clean_user_prompt_text(prompt) if isinstance(prompt, str) else ""
 
 
-def _input_user_text(value: object) -> str:
+def _input_user_text(value: ProviderPayload) -> str:
     if isinstance(value, str):
         return _clean_user_prompt_text(value)
     if isinstance(value, dict):
@@ -1239,7 +1239,7 @@ def _input_user_text(value: object) -> str:
     return ""
 
 
-def _clean_user_content_text(value: object) -> str:
+def _clean_user_content_text(value: ProviderPayload) -> str:
     if isinstance(value, list):
         parts = []
         for item in value:
@@ -1257,7 +1257,7 @@ def _clean_user_content_text(value: object) -> str:
     return _clean_user_prompt_text(_content_text(value))
 
 
-def _is_auxiliary_user_content_block(value: object) -> bool:
+def _is_auxiliary_user_content_block(value: ProviderPayload) -> bool:
     if not isinstance(value, dict):
         return False
     block_type = str(value.get("type") or "").lower()
@@ -1304,7 +1304,7 @@ def _clean_user_prompt_text(text: str) -> str:
     return text
 
 
-def _response_text(body: object) -> str:
+def _response_text(body: ProviderPayload) -> str:
     if isinstance(body, str):
         return body
     if not isinstance(body, dict):
@@ -1356,7 +1356,7 @@ def _response_text(body: object) -> str:
     return _content_text(value)
 
 
-def _content_text(value: object) -> str:
+def _content_text(value: ProviderPayload) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, list):
@@ -1385,7 +1385,7 @@ def _content_text(value: object) -> str:
     return ""
 
 
-def _parts_text(value: object) -> str:
+def _parts_text(value: ProviderPayload) -> str:
     if not isinstance(value, list):
         return ""
     parts = []

--- a/claude_tap/dashboard.py
+++ b/claude_tap/dashboard.py
@@ -7,10 +7,10 @@ import re
 import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
 from claude_tap.bedrock import bedrock_model_from_path
+from claude_tap.models import Map
 from claude_tap.trace_encoding import (
     content_type_from_headers,
     is_encoded_blob_body,
@@ -100,7 +100,7 @@ def list_trace_sessions(
     offset: int = 0,
     query: SessionQuery | None = None,
     repair_stale_summaries: bool = True,
-) -> list[dict[str, Any]]:
+) -> list[Map[str, object]]:
     """Return trace sessions sorted by most recent activity."""
     store = ensure_trace_store()
     try:
@@ -108,7 +108,7 @@ def list_trace_sessions(
     except (OSError, sqlite3.Error, ValueError):
         return []
 
-    sessions: list[dict[str, Any]] = []
+    sessions: list[Map[str, object]] = []
     for row in rows:
         try:
             summary = _session_summary_from_row(
@@ -153,9 +153,9 @@ def list_trace_agents(
     current_session_id: str | None = None,
     *,
     live_record_count: int | None = None,
-) -> list[dict[str, Any]]:
+) -> list[Map[str, object]]:
     """Return agent buckets for the dashboard sidebar."""
-    buckets: dict[str, dict[str, Any]] = {}
+    buckets: Map[str, Map[str, object]] = {}
     try:
         rows = ensure_trace_store().list_agent_buckets()
     except (OSError, sqlite3.Error, ValueError):
@@ -180,7 +180,7 @@ def list_trace_agents(
     return sorted(buckets.values(), key=lambda item: (item["label"].lower(), item["key"]))
 
 
-def dashboard_trace_snapshot() -> dict[str, tuple[int, str]]:
+def dashboard_trace_snapshot() -> Map[str, tuple[int, str]]:
     """Return a cheap SQLite snapshot for dashboard refresh detection."""
     store = ensure_trace_store()
     return store.dashboard_snapshot()
@@ -193,7 +193,7 @@ def load_trace_session(
     record_offset: int = 0,
     *,
     live_record_count: int | None = None,
-) -> dict[str, Any] | None:
+) -> Map[str, object] | None:
     """Load one session summary and its records by session id."""
     store = ensure_trace_store()
     row = store.load_session_row(session_id)
@@ -213,23 +213,23 @@ def load_trace_session(
     return {"session": summary, "records": records}
 
 
-def redact_dashboard_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def redact_dashboard_records(records: list[Map[str, object]]) -> list[Map[str, object]]:
     """Return records safe for dashboard rendering without mutating stored traces."""
     return [_redact_sensitive_value(record) for record in records]
 
 
-def redact_dashboard_summary(summary: dict[str, Any]) -> dict[str, Any]:
+def redact_dashboard_summary(summary: Map[str, object]) -> Map[str, object]:
     """Return a session summary safe for dashboard rendering."""
     return _redact_sensitive_value(summary)
 
 
 def merge_record_into_summary(
-    summary: dict[str, Any] | None,
+    summary: Map[str, object] | None,
     *,
     row: sqlite3.Row,
-    record: dict[str, Any],
+    record: Map[str, object],
     record_count: int,
-) -> dict[str, Any]:
+) -> Map[str, object]:
     """Update a session summary incrementally after appending one record."""
     manifest_entry = {
         "client": row["client"] or "",
@@ -299,7 +299,7 @@ def merge_record_into_summary(
     return redact_dashboard_summary(summary)
 
 
-def is_dashboard_summary_current(summary: Any, session_id: str) -> bool:
+def is_dashboard_summary_current(summary: object, session_id: str) -> bool:
     return (
         isinstance(summary, dict)
         and summary.get("id") == session_id
@@ -307,7 +307,7 @@ def is_dashboard_summary_current(summary: Any, session_id: str) -> bool:
     )
 
 
-def build_stored_session_summary(row: sqlite3.Row, records: list[dict[str, Any]]) -> dict[str, Any]:
+def build_stored_session_summary(row: sqlite3.Row, records: list[Map[str, object]]) -> Map[str, object]:
     manifest_entry = {
         "client": row["client"] or "",
         "proxy_mode": row["proxy_mode"] or "",
@@ -328,9 +328,9 @@ def build_stored_session_summary(row: sqlite3.Row, records: list[dict[str, Any]]
 
 def build_imported_session_summary(
     row: sqlite3.Row,
-    records: list[dict[str, Any]],
-    manifest_entry: dict[str, Any],
-) -> dict[str, Any]:
+    records: list[Map[str, object]],
+    manifest_entry: Map[str, object],
+) -> Map[str, object]:
     """Build and cache a summary for a legacy import."""
     return _summarize_session(
         session_id=row["id"],
@@ -352,7 +352,7 @@ def _session_summary_from_row(
     *,
     allow_record_scan: bool = False,
     repair_stale_summary: bool = True,
-) -> dict[str, Any]:
+) -> Map[str, object]:
     summary_json = row["summary_json"]
     if summary_json:
         try:
@@ -435,7 +435,7 @@ def _session_summary_from_row(
     return redact_dashboard_summary(summary)
 
 
-def _minimal_session_summary_from_row(row: sqlite3.Row) -> dict[str, Any]:
+def _minimal_session_summary_from_row(row: sqlite3.Row) -> Map[str, object]:
     record_count = int(row["record_count"] or 0)
     manifest_entry = {
         "client": row["client"] or "",
@@ -460,9 +460,9 @@ def _minimal_session_summary_from_row(row: sqlite3.Row) -> dict[str, Any]:
 
 def _summary_from_boundary_records(
     row: sqlite3.Row,
-    records: list[dict[str, Any]],
-    cached: dict[str, Any],
-) -> dict[str, Any]:
+    records: list[Map[str, object]],
+    cached: Map[str, object],
+) -> Map[str, object]:
     summary = build_stored_session_summary(row, records)
     for key in (
         "input_tokens",
@@ -483,7 +483,7 @@ def _summary_from_boundary_records(
     return redact_dashboard_summary(summary)
 
 
-def _normalize_cached_session_summary(row: sqlite3.Row, cached: dict[str, Any]) -> dict[str, Any]:
+def _normalize_cached_session_summary(row: sqlite3.Row, cached: Map[str, object]) -> Map[str, object]:
     summary = _minimal_session_summary_from_row(row)
     summary.update(cached)
     summary["id"] = row["id"]
@@ -520,11 +520,11 @@ def _normalize_cached_session_summary(row: sqlite3.Row, cached: dict[str, Any]) 
 
 
 def _apply_current_session_state(
-    session: dict[str, Any],
+    session: Map[str, object],
     current_session_id: str | None,
     *,
     live_record_count: int | None = None,
-) -> dict[str, Any]:
+) -> Map[str, object]:
     session = dict(session)
     is_current = bool(current_session_id and session.get("id") == current_session_id)
     session["live"] = is_current
@@ -545,21 +545,21 @@ def _summarize_session(
     session_id: str,
     date_key: str,
     legacy_rel_path: str | None,
-    records: list[dict[str, Any]],
-    manifest_entry: dict[str, Any],
+    records: list[Map[str, object]],
+    manifest_entry: Map[str, object],
     status: str,
     started_at: str,
     updated_at: str,
     is_current: bool,
     record_count: int | None = None,
-) -> dict[str, Any]:
+) -> Map[str, object]:
     first_record = records[0] if records else {}
     last_record = records[-1] if records else {}
     started_at = _timestamp_from_record(first_record) or started_at or _iso_now()
     updated_at = _timestamp_from_record(last_record) or updated_at or started_at
     agent = _infer_agent(records, manifest_entry)
     input_tokens = output_tokens = cache_read_tokens = cache_create_tokens = 0
-    models: dict[str, int] = {}
+    models: Map[str, int] = {}
     duration_ms = 0
     turns: set[int] = set()
 
@@ -639,12 +639,12 @@ def _timestamp_sort_value(value: object) -> float:
     return parsed.astimezone(timezone.utc).timestamp()
 
 
-def _timestamp_from_record(record: dict[str, Any]) -> str | None:
+def _timestamp_from_record(record: Map[str, object]) -> str | None:
     value = record.get("timestamp")
     return value if isinstance(value, str) and value else None
 
 
-def _record_usage(record: dict[str, Any]) -> dict[str, int]:
+def _record_usage(record: Map[str, object]) -> Map[str, int]:
     response = record.get("response")
     body = response.get("body") if isinstance(response, dict) else {}
     usage = body.get("usage", {}) if isinstance(body, dict) else {}
@@ -658,7 +658,7 @@ def _record_usage(record: dict[str, Any]) -> dict[str, int]:
                 usage = candidate
                 break
     if not usage:
-        merged_usage: dict[str, int] = {}
+        merged_usage: Map[str, int] = {}
         for event in _bedrock_events(record):
             payload = event.get("data", {}) if isinstance(event, dict) else {}
             candidate = payload.get("usage", {}) if isinstance(payload, dict) else {}
@@ -677,7 +677,7 @@ def _record_usage(record: dict[str, Any]) -> dict[str, int]:
     return normalize_usage(usage)
 
 
-def _record_model(record: dict[str, Any]) -> str:
+def _record_model(record: Map[str, object]) -> str:
     request = record.get("request")
     req_body = request.get("body") if isinstance(request, dict) else None
     if isinstance(req_body, dict):
@@ -714,18 +714,18 @@ def _record_model(record: dict[str, Any]) -> str:
     return ""
 
 
-def _response_status(record: dict[str, Any]) -> int:
+def _response_status(record: Map[str, object]) -> int:
     response = record.get("response")
     status = response.get("status") if isinstance(response, dict) else None
     return status if isinstance(status, int) else 0
 
 
-def _duration_ms(record: dict[str, Any]) -> int:
+def _duration_ms(record: Map[str, object]) -> int:
     value = record.get("duration_ms")
     return value if isinstance(value, int) else 0
 
 
-def _record_error(record: dict[str, Any]) -> str:
+def _record_error(record: Map[str, object]) -> str:
     response = record.get("response")
     if not isinstance(response, dict):
         return ""
@@ -733,7 +733,7 @@ def _record_error(record: dict[str, Any]) -> str:
     return value if isinstance(value, str) else ""
 
 
-def _first_error(records: list[dict[str, Any]]) -> str:
+def _first_error(records: list[Map[str, object]]) -> str:
     for record in records:
         error = _record_error(record)
         if error:
@@ -751,13 +751,13 @@ def _first_error(records: list[dict[str, Any]]) -> str:
     return ""
 
 
-def _top_key(values: dict[str, int]) -> str:
+def _top_key(values: Map[str, int]) -> str:
     if not values:
         return ""
     return max(values.items(), key=lambda item: item[1])[0]
 
 
-def _infer_agent(records: list[dict[str, Any]], manifest_entry: dict[str, Any]) -> str:
+def _infer_agent(records: list[Map[str, object]], manifest_entry: Map[str, object]) -> str:
     client = manifest_entry.get("client")
     if not client and isinstance(manifest_entry.get("metadata"), dict):
         client = manifest_entry["metadata"].get("client")
@@ -803,7 +803,7 @@ def _infer_agent(records: list[dict[str, Any]], manifest_entry: dict[str, Any]) 
     return "Unknown"
 
 
-def _record_host(record: dict[str, Any]) -> str:
+def _record_host(record: Map[str, object]) -> str:
     request = record.get("request")
     headers = request.get("headers") if isinstance(request, dict) else {}
     if isinstance(headers, dict):
@@ -817,7 +817,7 @@ def _record_host(record: dict[str, Any]) -> str:
     return ""
 
 
-def _record_path(record: dict[str, Any]) -> str:
+def _record_path(record: Map[str, object]) -> str:
     request = record.get("request")
     value = request.get("path") if isinstance(request, dict) else ""
     return value if isinstance(value, str) else ""
@@ -859,7 +859,7 @@ def _agent_filter_values(agent_key: str) -> tuple[tuple[str, ...], tuple[str, ..
     return tuple(sorted(clients)), tuple(sorted(labels))
 
 
-def _preview_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+def _preview_records(records: list[Map[str, object]]) -> list[Map[str, object]]:
     transcripts = [record for record in records if _is_cursor_transcript_record(record)]
     if transcripts:
         return transcripts
@@ -869,7 +869,7 @@ def _preview_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     return [record for record in records if not _is_auxiliary_record(record) and not _is_protobuf_noise_record(record)]
 
 
-def _redact_sensitive_value(value: Any, key: str = "") -> Any:
+def _redact_sensitive_value(value: object, key: str = "") -> object:
     if key and _is_sensitive_key(key):
         return None if value is None else _REDACTED_VALUE
     if isinstance(value, dict):
@@ -981,7 +981,7 @@ def _is_sensitive_key(key: str) -> bool:
     )
 
 
-def _is_primary_model_record(record: dict[str, Any]) -> bool:
+def _is_primary_model_record(record: Map[str, object]) -> bool:
     if _is_cursor_transcript_record(record):
         return True
     path = _record_path(record).lower()
@@ -1003,13 +1003,13 @@ def _is_primary_model_record(record: dict[str, Any]) -> bool:
     return any(fragment in path for fragment in primary_fragments)
 
 
-def _is_cursor_transcript_record(record: dict[str, Any]) -> bool:
+def _is_cursor_transcript_record(record: Map[str, object]) -> bool:
     if str(record.get("transport") or "") == "cursor-transcript":
         return True
     return _record_path(record).startswith("/cursor/transcript/")
 
 
-def _is_protobuf_noise_record(record: dict[str, Any]) -> bool:
+def _is_protobuf_noise_record(record: Map[str, object]) -> bool:
     if _is_cursor_transcript_record(record):
         return False
     request = record.get("request")
@@ -1024,7 +1024,7 @@ def _is_protobuf_noise_record(record: dict[str, Any]) -> bool:
     return isinstance(body, str) and looks_like_binary_text(body)
 
 
-def _is_auxiliary_record(record: dict[str, Any]) -> bool:
+def _is_auxiliary_record(record: Map[str, object]) -> bool:
     if _is_protobuf_noise_record(record):
         return True
     path = _record_path(record).lower()
@@ -1059,24 +1059,24 @@ def _is_model_probe_path(path: str) -> bool:
     return match is not None
 
 
-def _is_session_error_record(record: dict[str, Any]) -> bool:
+def _is_session_error_record(record: Map[str, object]) -> bool:
     if _record_error(record):
         return True
     status_code = _response_status(record)
     return status_code >= 400 and not _is_auxiliary_record(record)
 
 
-def _is_auxiliary_status_error_record(record: dict[str, Any]) -> bool:
+def _is_auxiliary_status_error_record(record: Map[str, object]) -> bool:
     status_code = _response_status(record)
     return status_code >= 400 and _is_auxiliary_record(record)
 
 
-def _is_successful_primary_record(record: dict[str, Any]) -> bool:
+def _is_successful_primary_record(record: Map[str, object]) -> bool:
     status_code = _response_status(record)
     return 200 <= status_code < 400 and not _is_auxiliary_record(record)
 
 
-def _first_user_preview(records: list[dict[str, Any]]) -> str:
+def _first_user_preview(records: list[Map[str, object]]) -> str:
     ordered = sorted(
         records,
         key=lambda record: 0 if _is_cursor_transcript_record(record) else 1,
@@ -1094,7 +1094,7 @@ def _first_user_preview(records: list[dict[str, Any]]) -> str:
     return ""
 
 
-def _last_response_preview(records: list[dict[str, Any]]) -> str:
+def _last_response_preview(records: list[Map[str, object]]) -> str:
     for record in reversed(records):
         text = _record_response_text(record)
         if text:
@@ -1102,7 +1102,7 @@ def _last_response_preview(records: list[dict[str, Any]]) -> str:
     return ""
 
 
-def _record_response_text(record: dict[str, Any]) -> str:
+def _record_response_text(record: Map[str, object]) -> str:
     response = record.get("response")
     body = response.get("body") if isinstance(response, dict) else None
     text = _response_text(body)
@@ -1124,7 +1124,7 @@ def _record_response_text(record: dict[str, Any]) -> str:
     return ""
 
 
-def _response_events(record: dict[str, Any]) -> list[dict[str, Any]]:
+def _response_events(record: Map[str, object]) -> list[Map[str, object]]:
     response = record.get("response")
     if not isinstance(response, dict):
         return []
@@ -1137,7 +1137,7 @@ def _response_events(record: dict[str, Any]) -> list[dict[str, Any]]:
     return []
 
 
-def _bedrock_events(record: dict[str, Any]) -> list[dict[str, Any]]:
+def _bedrock_events(record: Map[str, object]) -> list[Map[str, object]]:
     """Decode AWS Bedrock EventStream binary body into structured events."""
     response = record.get("response")
     if not isinstance(response, dict):
@@ -1146,7 +1146,7 @@ def _bedrock_events(record: dict[str, Any]) -> list[dict[str, Any]]:
     return _decode_bedrock_eventstream_events(body)
 
 
-def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
+def _event_payload(event: Map[str, object]) -> Map[str, object]:
     data = event.get("data", event)
     if isinstance(data, str):
         try:
@@ -1161,7 +1161,7 @@ def _event_payload(event: dict[str, Any]) -> dict[str, Any]:
     return {}
 
 
-def _request_user_text(body: Any, *, headers: Any = None) -> str:
+def _request_user_text(body: object, *, headers: object = None) -> str:
     header_map = headers if isinstance(headers, dict) else None
     if is_protobuf_content_type(content_type_from_headers(header_map)):
         return ""
@@ -1205,7 +1205,7 @@ def _request_user_text(body: Any, *, headers: Any = None) -> str:
     return _clean_user_prompt_text(prompt) if isinstance(prompt, str) else ""
 
 
-def _input_user_text(value: Any) -> str:
+def _input_user_text(value: object) -> str:
     if isinstance(value, str):
         return _clean_user_prompt_text(value)
     if isinstance(value, dict):
@@ -1239,7 +1239,7 @@ def _input_user_text(value: Any) -> str:
     return ""
 
 
-def _clean_user_content_text(value: Any) -> str:
+def _clean_user_content_text(value: object) -> str:
     if isinstance(value, list):
         parts = []
         for item in value:
@@ -1257,7 +1257,7 @@ def _clean_user_content_text(value: Any) -> str:
     return _clean_user_prompt_text(_content_text(value))
 
 
-def _is_auxiliary_user_content_block(value: Any) -> bool:
+def _is_auxiliary_user_content_block(value: object) -> bool:
     if not isinstance(value, dict):
         return False
     block_type = str(value.get("type") or "").lower()
@@ -1304,7 +1304,7 @@ def _clean_user_prompt_text(text: str) -> str:
     return text
 
 
-def _response_text(body: Any) -> str:
+def _response_text(body: object) -> str:
     if isinstance(body, str):
         return body
     if not isinstance(body, dict):
@@ -1356,7 +1356,7 @@ def _response_text(body: Any) -> str:
     return _content_text(value)
 
 
-def _content_text(value: Any) -> str:
+def _content_text(value: object) -> str:
     if isinstance(value, str):
         return value
     if isinstance(value, list):
@@ -1385,7 +1385,7 @@ def _content_text(value: Any) -> str:
     return ""
 
 
-def _parts_text(value: Any) -> str:
+def _parts_text(value: object) -> str:
     if not isinstance(value, list):
         return ""
     parts = []

--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -8,16 +8,17 @@ import sys
 from pathlib import Path
 
 from claude_tap.compact_trace import build_compact_trace_bundle, dump_compact_trace, is_compact_trace_bundle
+from claude_tap.models import JsonObject
 from claude_tap.prompt_snapshot import render_prompt_markdown, snapshot_from_records
 from claude_tap.usage import normalize_usage
 from claude_tap.viewer import _generate_html_viewer_from_compact_bundle, _normalize_record_for_viewer
 
 
-def _as_dict(value: object) -> dict:
+def _as_dict(value: object) -> JsonObject:
     return value if isinstance(value, dict) else {}
 
 
-def _normalize_record_for_export(record: object) -> dict | None:
+def _normalize_record_for_export(record: object) -> JsonObject | None:
     if not isinstance(record, dict):
         return None
     try:
@@ -27,8 +28,8 @@ def _normalize_record_for_export(record: object) -> dict | None:
     return normalized if isinstance(normalized, dict) else record
 
 
-def _normalize_records_for_export(records: list[dict]) -> list[dict]:
-    normalized_records: list[dict] = []
+def _normalize_records_for_export(records: list[JsonObject]) -> list[JsonObject]:
+    normalized_records: list[JsonObject] = []
     for record in records:
         normalized = _normalize_record_for_export(record)
         if normalized is not None:
@@ -36,24 +37,24 @@ def _normalize_records_for_export(records: list[dict]) -> list[dict]:
     return normalized_records
 
 
-def _request_body(record: dict) -> dict:
+def _request_body(record: JsonObject) -> JsonObject:
     return _as_dict(_as_dict(record.get("request")).get("body"))
 
 
-def _response_body(record: dict) -> dict:
+def _response_body(record: JsonObject) -> JsonObject:
     return _as_dict(_as_dict(record.get("response")).get("body"))
 
 
-def _usage_from(record: dict) -> dict:
+def _usage_from(record: JsonObject) -> JsonObject:
     return normalize_usage(_response_body(record).get("usage"))
 
 
-def _turn_sort_key(record: dict) -> int:
+def _turn_sort_key(record: JsonObject) -> int:
     turn = record.get("turn")
     return turn if isinstance(turn, int) else 0
 
 
-def _load_records_from_text(text: str) -> tuple[list[dict], dict | None]:
+def _load_records_from_text(text: str) -> tuple[list[JsonObject], JsonObject | None]:
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError:
@@ -63,7 +64,7 @@ def _load_records_from_text(text: str) -> tuple[list[dict], dict | None]:
 
         return materialize_compact_trace_bundle(parsed), parsed
 
-    records: list[dict] = []
+    records: list[JsonObject] = []
     for line in text.splitlines():
         line = line.strip()
         if not line:
@@ -104,11 +105,11 @@ def export_main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    records: list[dict] = []
+    records: list[JsonObject] = []
     html_source_path: Path | None = None
     source_session_id = args.session_id
     store = None
-    compact_bundle: dict | None = None
+    compact_bundle: JsonObject | None = None
 
     if source_session_id is None and args.source:
         trace_file = Path(args.source)
@@ -225,7 +226,7 @@ def _is_prompt_markdown_output(path: Path) -> bool:
     return name.endswith((".prompt.md", ".prompt.markdown", ".system.md", ".system.markdown"))
 
 
-def _export_markdown(records: list[dict]) -> str:
+def _export_markdown(records: list[JsonObject]) -> str:
     """Export records as Markdown."""
     lines: list[str] = []
     lines.append("# Claude Trace Export\n")
@@ -332,7 +333,7 @@ def _export_markdown(records: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _export_json(records: list[dict]) -> str:
+def _export_json(records: list[JsonObject]) -> str:
     """Export records as cleaned-up JSON."""
     cleaned = []
     for r in records:

--- a/claude_tap/export.py
+++ b/claude_tap/export.py
@@ -8,17 +8,17 @@ import sys
 from pathlib import Path
 
 from claude_tap.compact_trace import build_compact_trace_bundle, dump_compact_trace, is_compact_trace_bundle
-from claude_tap.models import JsonObject
+from claude_tap.models import ProviderPayload
 from claude_tap.prompt_snapshot import render_prompt_markdown, snapshot_from_records
 from claude_tap.usage import normalize_usage
 from claude_tap.viewer import _generate_html_viewer_from_compact_bundle, _normalize_record_for_viewer
 
 
-def _as_dict(value: object) -> JsonObject:
+def _as_dict(value: ProviderPayload) -> ProviderPayload:
     return value if isinstance(value, dict) else {}
 
 
-def _normalize_record_for_export(record: object) -> JsonObject | None:
+def _normalize_record_for_export(record: ProviderPayload) -> ProviderPayload | None:
     if not isinstance(record, dict):
         return None
     try:
@@ -28,8 +28,8 @@ def _normalize_record_for_export(record: object) -> JsonObject | None:
     return normalized if isinstance(normalized, dict) else record
 
 
-def _normalize_records_for_export(records: list[JsonObject]) -> list[JsonObject]:
-    normalized_records: list[JsonObject] = []
+def _normalize_records_for_export(records: list[ProviderPayload]) -> list[ProviderPayload]:
+    normalized_records: list[ProviderPayload] = []
     for record in records:
         normalized = _normalize_record_for_export(record)
         if normalized is not None:
@@ -37,24 +37,24 @@ def _normalize_records_for_export(records: list[JsonObject]) -> list[JsonObject]
     return normalized_records
 
 
-def _request_body(record: JsonObject) -> JsonObject:
+def _request_body(record: ProviderPayload) -> ProviderPayload:
     return _as_dict(_as_dict(record.get("request")).get("body"))
 
 
-def _response_body(record: JsonObject) -> JsonObject:
+def _response_body(record: ProviderPayload) -> ProviderPayload:
     return _as_dict(_as_dict(record.get("response")).get("body"))
 
 
-def _usage_from(record: JsonObject) -> JsonObject:
+def _usage_from(record: ProviderPayload) -> ProviderPayload:
     return normalize_usage(_response_body(record).get("usage"))
 
 
-def _turn_sort_key(record: JsonObject) -> int:
+def _turn_sort_key(record: ProviderPayload) -> int:
     turn = record.get("turn")
     return turn if isinstance(turn, int) else 0
 
 
-def _load_records_from_text(text: str) -> tuple[list[JsonObject], JsonObject | None]:
+def _load_records_from_text(text: str) -> tuple[list[ProviderPayload], ProviderPayload | None]:
     try:
         parsed = json.loads(text)
     except json.JSONDecodeError:
@@ -64,7 +64,7 @@ def _load_records_from_text(text: str) -> tuple[list[JsonObject], JsonObject | N
 
         return materialize_compact_trace_bundle(parsed), parsed
 
-    records: list[JsonObject] = []
+    records: list[ProviderPayload] = []
     for line in text.splitlines():
         line = line.strip()
         if not line:
@@ -105,11 +105,11 @@ def export_main(argv: list[str] | None = None) -> int:
 
     args = parser.parse_args(argv)
 
-    records: list[JsonObject] = []
+    records: list[ProviderPayload] = []
     html_source_path: Path | None = None
     source_session_id = args.session_id
     store = None
-    compact_bundle: JsonObject | None = None
+    compact_bundle: ProviderPayload | None = None
 
     if source_session_id is None and args.source:
         trace_file = Path(args.source)
@@ -226,7 +226,7 @@ def _is_prompt_markdown_output(path: Path) -> bool:
     return name.endswith((".prompt.md", ".prompt.markdown", ".system.md", ".system.markdown"))
 
 
-def _export_markdown(records: list[JsonObject]) -> str:
+def _export_markdown(records: list[ProviderPayload]) -> str:
     """Export records as Markdown."""
     lines: list[str] = []
     lines.append("# Claude Trace Export\n")
@@ -333,7 +333,7 @@ def _export_markdown(records: list[JsonObject]) -> str:
     return "\n".join(lines)
 
 
-def _export_json(records: list[JsonObject]) -> str:
+def _export_json(records: list[ProviderPayload]) -> str:
     """Export records as cleaned-up JSON."""
     cleaned = []
     for r in records:

--- a/claude_tap/forward_proxy.py
+++ b/claude_tap/forward_proxy.py
@@ -26,7 +26,6 @@ import time
 import uuid
 import zlib
 from collections import deque
-from collections.abc import Mapping
 from urllib.parse import urlparse
 
 import aiohttp
@@ -34,6 +33,8 @@ from aiohttp import WSMessage, WSMsgType
 from aiohttp._websocket.reader import WebSocketDataQueue, WebSocketReader
 from aiohttp.http_websocket import WS_KEY, WebSocketWriter
 from yarl import URL
+
+from claude_tap.models import JsonObject, Map
 
 try:
     from compression import zstd
@@ -127,7 +128,7 @@ def _matches_path_suffix(path: str, suffixes: tuple[str, ...]) -> bool:
     return any(clean.endswith(suffix.lower()) for suffix in suffixes)
 
 
-def _header_value(headers: Mapping[str, str], name: str) -> str:
+def _header_value(headers: Map[str, str], name: str) -> str:
     if value := headers.get(name):
         return value
     lower_name = name.lower()
@@ -137,7 +138,7 @@ def _header_value(headers: Mapping[str, str], name: str) -> str:
     return ""
 
 
-def _decode_request_body_for_trace(body: bytes, headers: Mapping[str, str]) -> bytes:
+def _decode_request_body_for_trace(body: bytes, headers: Map[str, str]) -> bytes:
     """Decode supported request content encodings without mutating upstream bytes.
 
     Forward proxy reads raw HTTP frames, so unlike the MITM aiohttp path the
@@ -160,7 +161,7 @@ def _decode_request_body_for_trace(body: bytes, headers: Mapping[str, str]) -> b
     return body
 
 
-def _has_package_manager_user_agent(headers: Mapping[str, str] | None) -> bool:
+def _has_package_manager_user_agent(headers: Map[str, str] | None) -> bool:
     if headers is None:
         return False
     user_agent = _header_value(headers, "User-Agent").lower()
@@ -170,8 +171,8 @@ def _has_package_manager_user_agent(headers: Mapping[str, str] | None) -> bool:
 def _should_skip_trace_record(
     upstream_url: str,
     path: str,
-    response_headers: Mapping[str, str],
-    request_headers: Mapping[str, str] | None = None,
+    response_headers: Map[str, str],
+    request_headers: Map[str, str] | None = None,
     method: str = "GET",
 ) -> bool:
     """Return whether a non-model upstream response should be forwarded without persisting."""
@@ -220,7 +221,7 @@ async def _read_chunked_body(reader: asyncio.StreamReader) -> bytes:
     return b"".join(chunks)
 
 
-async def _read_http_body(reader: asyncio.StreamReader, headers: dict[str, str]) -> bytes:
+async def _read_http_body(reader: asyncio.StreamReader, headers: Map[str, str]) -> bytes:
     content_length = headers.get("Content-Length") or headers.get("content-length")
     if content_length:
         try:
@@ -251,7 +252,7 @@ class _RawWSProtocol:
         return
 
 
-def _is_websocket_upgrade(headers: dict[str, str]) -> bool:
+def _is_websocket_upgrade(headers: Map[str, str]) -> bool:
     upgrade = headers.get("Upgrade", headers.get("upgrade", "")).lower()
     if upgrade != "websocket":
         return False
@@ -522,7 +523,7 @@ class ForwardProxyServer:
             method, path, _http_version = parts
 
             # Read headers
-            headers: dict[str, str] = {}
+            headers: Map[str, str] = {}
             while True:
                 header_line = await asyncio.wait_for(reader.readline(), timeout=30)
                 if header_line in (b"\r\n", b"\n", b""):
@@ -553,7 +554,7 @@ class ForwardProxyServer:
         self,
         method: str,
         path: str,
-        headers: dict[str, str],
+        headers: Map[str, str],
         body: bytes,
         upstream_url: str,
         client_writer: asyncio.StreamWriter,
@@ -697,8 +698,8 @@ class ForwardProxyServer:
         t0: float,
         method: str,
         path: str,
-        req_headers: dict[str, str],
-        req_body: dict | None,
+        req_headers: Map[str, str],
+        req_body: JsonObject | None,
         log_prefix: str,
         upstream_base_url: str,
     ) -> None:
@@ -788,8 +789,8 @@ class ForwardProxyServer:
         t0: float,
         method: str,
         path: str,
-        req_headers: dict[str, str],
-        req_body: dict | None,
+        req_headers: Map[str, str],
+        req_body: JsonObject | None,
         log_prefix: str,
         upstream_url: str,
         upstream_base_url: str,
@@ -899,7 +900,7 @@ class ForwardProxyServer:
         hostname: str,
         port: int,
         path: str,
-        headers: dict[str, str],
+        headers: Map[str, str],
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
@@ -945,7 +946,7 @@ class ForwardProxyServer:
             )
             return
 
-        ws_connect_kwargs: dict[str, object] = {}
+        ws_connect_kwargs: Map[str, object] = {}
         proxy_settings = _get_ws_proxy_settings(upstream_ws_url) if self._session.trust_env else None
         if proxy_settings:
             proxy_url, proxy_auth = proxy_settings
@@ -1206,7 +1207,7 @@ class ForwardProxyServer:
         turn: int,
         t0: float,
         path: str,
-        headers: dict[str, str],
+        headers: Map[str, str],
         protocols: tuple[str, ...],
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
@@ -1330,7 +1331,7 @@ class ForwardProxyServer:
         For absolute URL requests like GET http://example.com/path HTTP/1.1
         """
         # Read headers
-        headers: dict[str, str] = {}
+        headers: Map[str, str] = {}
         while True:
             line = await asyncio.wait_for(reader.readline(), timeout=10)
             if line in (b"\r\n", b"\n", b""):

--- a/claude_tap/forward_proxy.py
+++ b/claude_tap/forward_proxy.py
@@ -34,7 +34,7 @@ from aiohttp._websocket.reader import WebSocketDataQueue, WebSocketReader
 from aiohttp.http_websocket import WS_KEY, WebSocketWriter
 from yarl import URL
 
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 
 try:
     from compression import zstd
@@ -128,7 +128,7 @@ def _matches_path_suffix(path: str, suffixes: tuple[str, ...]) -> bool:
     return any(clean.endswith(suffix.lower()) for suffix in suffixes)
 
 
-def _header_value(headers: Map[str, str], name: str) -> str:
+def _header_value(headers: dict[str, str], name: str) -> str:
     if value := headers.get(name):
         return value
     lower_name = name.lower()
@@ -138,7 +138,7 @@ def _header_value(headers: Map[str, str], name: str) -> str:
     return ""
 
 
-def _decode_request_body_for_trace(body: bytes, headers: Map[str, str]) -> bytes:
+def _decode_request_body_for_trace(body: bytes, headers: dict[str, str]) -> bytes:
     """Decode supported request content encodings without mutating upstream bytes.
 
     Forward proxy reads raw HTTP frames, so unlike the MITM aiohttp path the
@@ -161,7 +161,7 @@ def _decode_request_body_for_trace(body: bytes, headers: Map[str, str]) -> bytes
     return body
 
 
-def _has_package_manager_user_agent(headers: Map[str, str] | None) -> bool:
+def _has_package_manager_user_agent(headers: dict[str, str] | None) -> bool:
     if headers is None:
         return False
     user_agent = _header_value(headers, "User-Agent").lower()
@@ -171,8 +171,8 @@ def _has_package_manager_user_agent(headers: Map[str, str] | None) -> bool:
 def _should_skip_trace_record(
     upstream_url: str,
     path: str,
-    response_headers: Map[str, str],
-    request_headers: Map[str, str] | None = None,
+    response_headers: dict[str, str],
+    request_headers: dict[str, str] | None = None,
     method: str = "GET",
 ) -> bool:
     """Return whether a non-model upstream response should be forwarded without persisting."""
@@ -221,7 +221,7 @@ async def _read_chunked_body(reader: asyncio.StreamReader) -> bytes:
     return b"".join(chunks)
 
 
-async def _read_http_body(reader: asyncio.StreamReader, headers: Map[str, str]) -> bytes:
+async def _read_http_body(reader: asyncio.StreamReader, headers: dict[str, str]) -> bytes:
     content_length = headers.get("Content-Length") or headers.get("content-length")
     if content_length:
         try:
@@ -252,7 +252,7 @@ class _RawWSProtocol:
         return
 
 
-def _is_websocket_upgrade(headers: Map[str, str]) -> bool:
+def _is_websocket_upgrade(headers: dict[str, str]) -> bool:
     upgrade = headers.get("Upgrade", headers.get("upgrade", "")).lower()
     if upgrade != "websocket":
         return False
@@ -523,7 +523,7 @@ class ForwardProxyServer:
             method, path, _http_version = parts
 
             # Read headers
-            headers: Map[str, str] = {}
+            headers: dict[str, str] = {}
             while True:
                 header_line = await asyncio.wait_for(reader.readline(), timeout=30)
                 if header_line in (b"\r\n", b"\n", b""):
@@ -554,7 +554,7 @@ class ForwardProxyServer:
         self,
         method: str,
         path: str,
-        headers: Map[str, str],
+        headers: dict[str, str],
         body: bytes,
         upstream_url: str,
         client_writer: asyncio.StreamWriter,
@@ -698,8 +698,8 @@ class ForwardProxyServer:
         t0: float,
         method: str,
         path: str,
-        req_headers: Map[str, str],
-        req_body: JsonObject | None,
+        req_headers: dict[str, str],
+        req_body: ProviderPayload | None,
         log_prefix: str,
         upstream_base_url: str,
     ) -> None:
@@ -789,8 +789,8 @@ class ForwardProxyServer:
         t0: float,
         method: str,
         path: str,
-        req_headers: Map[str, str],
-        req_body: JsonObject | None,
+        req_headers: dict[str, str],
+        req_body: ProviderPayload | None,
         log_prefix: str,
         upstream_url: str,
         upstream_base_url: str,
@@ -900,7 +900,7 @@ class ForwardProxyServer:
         hostname: str,
         port: int,
         path: str,
-        headers: Map[str, str],
+        headers: dict[str, str],
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
     ) -> None:
@@ -946,7 +946,7 @@ class ForwardProxyServer:
             )
             return
 
-        ws_connect_kwargs: Map[str, object] = {}
+        ws_connect_kwargs: ProviderPayload = {}
         proxy_settings = _get_ws_proxy_settings(upstream_ws_url) if self._session.trust_env else None
         if proxy_settings:
             proxy_url, proxy_auth = proxy_settings
@@ -1207,7 +1207,7 @@ class ForwardProxyServer:
         turn: int,
         t0: float,
         path: str,
-        headers: Map[str, str],
+        headers: dict[str, str],
         protocols: tuple[str, ...],
         reader: asyncio.StreamReader,
         writer: asyncio.StreamWriter,
@@ -1331,7 +1331,7 @@ class ForwardProxyServer:
         For absolute URL requests like GET http://example.com/path HTTP/1.1
         """
         # Read headers
-        headers: Map[str, str] = {}
+        headers: dict[str, str] = {}
         while True:
             line = await asyncio.wait_for(reader.readline(), timeout=10)
             if line in (b"\r\n", b"\n", b""):

--- a/claude_tap/global_inject.py
+++ b/claude_tap/global_inject.py
@@ -21,7 +21,7 @@ import time
 from pathlib import Path
 
 from claude_tap.cli_clients import CLIENT_CONFIGS, _codex_selected_provider_base_url_key
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 
 _BACKUP_SUFFIX = ".tap-backup"
 
@@ -124,7 +124,7 @@ def enable(
     *,
     claude_port: int | None = None,
     codex_port: int | None = None,
-    processes: list[Map[str, object]] | None = None,
+    processes: list[ProviderPayload] | None = None,
 ) -> None:
     """Inject reverse-proxy base URLs for the given clients.
 
@@ -134,7 +134,7 @@ def enable(
     if is_active():
         disable()
 
-    files: list[Map[str, object]] = []
+    files: list[ProviderPayload] = []
     state_file = _state_file()
     try:
         if claude_port is not None:
@@ -159,7 +159,7 @@ def disable(*, terminate_processes: bool = False) -> None:
     state_file = _state_file()
     if not state_file.exists():
         return
-    state: object = {}
+    state: ProviderPayload = {}
     try:
         state = json.loads(state_file.read_text(encoding="utf-8"))
         entries = state.get("files", []) if isinstance(state, dict) else []
@@ -174,7 +174,7 @@ def disable(*, terminate_processes: bool = False) -> None:
     state_file.unlink(missing_ok=True)
 
 
-def _restore_files(entries: list[object]) -> None:
+def _restore_files(entries: list[ProviderPayload]) -> None:
     for entry in entries:
         if not isinstance(entry, dict):
             continue
@@ -189,7 +189,7 @@ def _restore_files(entries: list[object]) -> None:
             path.unlink()
 
 
-def _record_backup(path: Path, files: list[Map[str, object]]) -> bool:
+def _record_backup(path: Path, files: list[ProviderPayload]) -> bool:
     """Back up ``path`` if it exists, append a restore record, return existed."""
     existed = path.exists()
     backup = path.with_name(path.name + _BACKUP_SUFFIX)
@@ -199,9 +199,9 @@ def _record_backup(path: Path, files: list[Map[str, object]]) -> bool:
     return existed
 
 
-def _inject_claude(path: Path, port: int, files: list[Map[str, object]]) -> None:
+def _inject_claude(path: Path, port: int, files: list[ProviderPayload]) -> None:
     existed = _record_backup(path, files)
-    data: object = {}
+    data: ProviderPayload = {}
     if existed:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
@@ -218,7 +218,7 @@ def _inject_claude(path: Path, port: int, files: list[Map[str, object]]) -> None
     _write_text_atomic(path, json.dumps(data, indent=2) + "\n", mode=_write_mode(path, existed))
 
 
-def _inject_codex(path: Path, port: int, files: list[Map[str, object]]) -> None:
+def _inject_codex(path: Path, port: int, files: list[ProviderPayload]) -> None:
     existed = _record_backup(path, files)
     text = path.read_text(encoding="utf-8") if existed else ""
     new_text = _set_toml_top_level_string(text, "openai_base_url", f"http://127.0.0.1:{port}/v1")
@@ -297,7 +297,7 @@ def _write_text_atomic(path: Path, text: str, *, mode: int) -> None:
         tmp.unlink(missing_ok=True)
 
 
-def _terminate_recorded_processes(processes: list[object]) -> None:
+def _terminate_recorded_processes(processes: list[ProviderPayload]) -> None:
     for entry in processes:
         if not isinstance(entry, dict):
             continue

--- a/claude_tap/global_inject.py
+++ b/claude_tap/global_inject.py
@@ -21,6 +21,7 @@ import time
 from pathlib import Path
 
 from claude_tap.cli_clients import CLIENT_CONFIGS, _codex_selected_provider_base_url_key
+from claude_tap.models import Map
 
 _BACKUP_SUFFIX = ".tap-backup"
 
@@ -123,7 +124,7 @@ def enable(
     *,
     claude_port: int | None = None,
     codex_port: int | None = None,
-    processes: list[dict[str, object]] | None = None,
+    processes: list[Map[str, object]] | None = None,
 ) -> None:
     """Inject reverse-proxy base URLs for the given clients.
 
@@ -133,7 +134,7 @@ def enable(
     if is_active():
         disable()
 
-    files: list[dict[str, object]] = []
+    files: list[Map[str, object]] = []
     state_file = _state_file()
     try:
         if claude_port is not None:
@@ -188,7 +189,7 @@ def _restore_files(entries: list[object]) -> None:
             path.unlink()
 
 
-def _record_backup(path: Path, files: list[dict[str, object]]) -> bool:
+def _record_backup(path: Path, files: list[Map[str, object]]) -> bool:
     """Back up ``path`` if it exists, append a restore record, return existed."""
     existed = path.exists()
     backup = path.with_name(path.name + _BACKUP_SUFFIX)
@@ -198,7 +199,7 @@ def _record_backup(path: Path, files: list[dict[str, object]]) -> bool:
     return existed
 
 
-def _inject_claude(path: Path, port: int, files: list[dict[str, object]]) -> None:
+def _inject_claude(path: Path, port: int, files: list[Map[str, object]]) -> None:
     existed = _record_backup(path, files)
     data: object = {}
     if existed:
@@ -217,7 +218,7 @@ def _inject_claude(path: Path, port: int, files: list[dict[str, object]]) -> Non
     _write_text_atomic(path, json.dumps(data, indent=2) + "\n", mode=_write_mode(path, existed))
 
 
-def _inject_codex(path: Path, port: int, files: list[dict[str, object]]) -> None:
+def _inject_codex(path: Path, port: int, files: list[Map[str, object]]) -> None:
     existed = _record_backup(path, files)
     text = path.read_text(encoding="utf-8") if existed else ""
     new_text = _set_toml_top_level_string(text, "openai_base_url", f"http://127.0.0.1:{port}/v1")

--- a/claude_tap/history.py
+++ b/claude_tap/history.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from claude_tap.models import Map
 from claude_tap.trace_store import get_trace_store
 
 
@@ -11,7 +12,7 @@ def delete_trace_history(
     date_key: str,
     *,
     protected_session_ids: set[str] | None = None,
-) -> dict[str, int | str]:
+) -> Map[str, int | str]:
     """Delete stored trace sessions for a date key."""
     store = get_trace_store()
     try:

--- a/claude_tap/history.py
+++ b/claude_tap/history.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from claude_tap.models import Map
 from claude_tap.trace_store import get_trace_store
 
 
@@ -12,7 +11,7 @@ def delete_trace_history(
     date_key: str,
     *,
     protected_session_ids: set[str] | None = None,
-) -> Map[str, int | str]:
+) -> dict[str, int | str]:
     """Delete stored trace sessions for a date key."""
     store = get_trace_store()
     try:

--- a/claude_tap/live.py
+++ b/claude_tap/live.py
@@ -26,6 +26,7 @@ from claude_tap.dashboard import (
     redact_dashboard_summary,
 )
 from claude_tap.history import delete_trace_history, migrate_legacy_traces
+from claude_tap.models import JsonObject, Map
 from claude_tap.shared_dashboard import CLAUDE_TAP_VERSION, dashboard_url
 from claude_tap.trace_store import get_trace_store, resolve_db_path
 from claude_tap.viewer import (
@@ -198,7 +199,7 @@ class LiveViewerServer:
         self.dashboard_mode = dashboard_mode
         self._sse_clients: list[web.StreamResponse] = []
         self._dashboard_clients: list[web.StreamResponse] = []
-        self._records: list[dict] = []
+        self._records: list[JsonObject] = []
         self._current_date: str = date.today().isoformat()
         self._lock = asyncio.Lock()
         self._runner: web.AppRunner | None = None
@@ -206,7 +207,7 @@ class LiveViewerServer:
         self._shutdown_event = asyncio.Event()
         self._stop_lock = asyncio.Lock()
         self._dashboard_watch_task: asyncio.Task | None = None
-        self._dashboard_snapshot: dict[str, tuple[int, str]] = {}
+        self._dashboard_snapshot: Map[str, tuple[int, str]] = {}
         self._dashboard_quit_token = secrets.token_urlsafe(32)
 
     async def start(self) -> int:
@@ -293,7 +294,7 @@ class LiveViewerServer:
         """Wait until the server shutdown event is set."""
         await self._shutdown_event.wait()
 
-    async def broadcast(self, record: dict) -> None:
+    async def broadcast(self, record: JsonObject) -> None:
         """Broadcast a new record to all connected SSE clients."""
         async with self._lock:
             today = date.today().isoformat()
@@ -751,7 +752,7 @@ class LiveViewerServer:
                 self._dashboard_snapshot = snapshot
                 await self._broadcast_dashboard_event({"type": "refresh"})
 
-    async def _broadcast_dashboard_event(self, payload: dict) -> None:
+    async def _broadcast_dashboard_event(self, payload: JsonObject) -> None:
         if not self._dashboard_clients:
             return
         disconnected = []
@@ -764,7 +765,7 @@ class LiveViewerServer:
             if client in self._dashboard_clients:
                 self._dashboard_clients.remove(client)
 
-    async def _write_dashboard_event(self, client: web.StreamResponse, payload: dict) -> None:
+    async def _write_dashboard_event(self, client: web.StreamResponse, payload: JsonObject) -> None:
         event_name = payload.get("type", "message")
         data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         await client.write(f"event: {event_name}\ndata: {data}\n\n".encode("utf-8"))

--- a/claude_tap/live.py
+++ b/claude_tap/live.py
@@ -26,7 +26,7 @@ from claude_tap.dashboard import (
     redact_dashboard_summary,
 )
 from claude_tap.history import delete_trace_history, migrate_legacy_traces
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.shared_dashboard import CLAUDE_TAP_VERSION, dashboard_url
 from claude_tap.trace_store import get_trace_store, resolve_db_path
 from claude_tap.viewer import (
@@ -199,7 +199,7 @@ class LiveViewerServer:
         self.dashboard_mode = dashboard_mode
         self._sse_clients: list[web.StreamResponse] = []
         self._dashboard_clients: list[web.StreamResponse] = []
-        self._records: list[JsonObject] = []
+        self._records: list[ProviderPayload] = []
         self._current_date: str = date.today().isoformat()
         self._lock = asyncio.Lock()
         self._runner: web.AppRunner | None = None
@@ -207,7 +207,7 @@ class LiveViewerServer:
         self._shutdown_event = asyncio.Event()
         self._stop_lock = asyncio.Lock()
         self._dashboard_watch_task: asyncio.Task | None = None
-        self._dashboard_snapshot: Map[str, tuple[int, str]] = {}
+        self._dashboard_snapshot: dict[str, tuple[int, str]] = {}
         self._dashboard_quit_token = secrets.token_urlsafe(32)
 
     async def start(self) -> int:
@@ -294,7 +294,7 @@ class LiveViewerServer:
         """Wait until the server shutdown event is set."""
         await self._shutdown_event.wait()
 
-    async def broadcast(self, record: JsonObject) -> None:
+    async def broadcast(self, record: ProviderPayload) -> None:
         """Broadcast a new record to all connected SSE clients."""
         async with self._lock:
             today = date.today().isoformat()
@@ -752,7 +752,7 @@ class LiveViewerServer:
                 self._dashboard_snapshot = snapshot
                 await self._broadcast_dashboard_event({"type": "refresh"})
 
-    async def _broadcast_dashboard_event(self, payload: JsonObject) -> None:
+    async def _broadcast_dashboard_event(self, payload: ProviderPayload) -> None:
         if not self._dashboard_clients:
             return
         disconnected = []
@@ -765,7 +765,7 @@ class LiveViewerServer:
             if client in self._dashboard_clients:
                 self._dashboard_clients.remove(client)
 
-    async def _write_dashboard_event(self, client: web.StreamResponse, payload: JsonObject) -> None:
+    async def _write_dashboard_event(self, client: web.StreamResponse, payload: ProviderPayload) -> None:
         event_name = payload.get("type", "message")
         data = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
         await client.write(f"event: {event_name}\ndata: {data}\n\n".encode("utf-8"))

--- a/claude_tap/macos_app.py
+++ b/claude_tap/macos_app.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from claude_tap import global_inject
 from claude_tap.dashboard import list_trace_sessions
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 from claude_tap.shared_dashboard import (
     _sync_dashboard_healthy_for_current_db as _dashboard_is_healthy,
 )
@@ -29,7 +29,7 @@ _NS_ALERT_FIRST_BUTTON_RETURN = 1000
 _NS_TERMINATE_NOW = 1
 # Absolute default so the app works when launched from Finder (cwd is "/").
 _DEFAULT_OUTPUT_DIR = Path.home() / ".claude-tap" / "traces"
-_CALLBACKS: list[object] = []
+_CALLBACKS: list[ctypes._CFuncPtr] = []
 _ACTIVE_APP: MacOSMenuApp | None = None
 
 # Bump this string whenever the menu-bar logic changes so a debug log immediately
@@ -137,7 +137,7 @@ class DashboardMonitorController:
         python_executable: str = sys.executable,
         popen: Callable[..., subprocess.Popen[bytes]] = subprocess.Popen,
         is_healthy: Callable[[str, int], bool] = _dashboard_is_healthy,
-        open_browser: Callable[[str], object] = webbrowser.open,
+        open_browser: Callable[[str], bool] = webbrowser.open,
         enable_injection: Callable[..., None] = global_inject.enable,
         disable_injection: Callable[[], None] = global_inject.disable,
         injection_is_active: Callable[[], bool] = global_inject.is_active,
@@ -146,7 +146,7 @@ class DashboardMonitorController:
         terminate_proxies_on_ports: Callable[..., None] = global_inject.terminate_proxies_on_ports,
         stop_incompatible_dashboard: Callable[[str, int, str], None] | None = None,
         startup_check_delay: float = 0.15,
-        sleep: Callable[[float], object] = time.sleep,
+        sleep: Callable[[float], None] = time.sleep,
     ) -> None:
         self.host = host
         self.port = port
@@ -177,7 +177,7 @@ class DashboardMonitorController:
     def _debug_state(self) -> str:
         """Snapshot every signal the running-state logic depends on, for debugging."""
 
-        def _safe(fn: Callable[[], object]) -> object:
+        def _safe(fn: Callable[[], ProviderPayload]) -> ProviderPayload:
             try:
                 return fn()
             except Exception as exc:  # noqa: BLE001 - debug snapshot must never raise
@@ -186,14 +186,14 @@ class DashboardMonitorController:
         owned_process = self._process.poll() if self._process is not None else "none"
         owned_proxies = [getattr(p, "pid", None) for p in self._proxy_processes]
         owned_proxy_polls = [p.poll() for p in self._proxy_processes]
-        listeners: Map[str, object] = {}
+        listeners: ProviderPayload = {}
         for label, port in (
             ("dashboard", self.port),
             ("claude", self.claude_proxy_port),
             ("codex", self.codex_proxy_port),
         ):
 
-            def _port_listeners(port: int = port) -> object:
+            def _port_listeners(port: int = port) -> dict[int, str]:
                 return {
                     pid: global_inject._monitor_process_command(pid)
                     for pid in global_inject._listening_pids_for_port(port)
@@ -351,8 +351,8 @@ class DashboardMonitorController:
         self._proxy_processes.append(self._popen(cmd, **self._subprocess_kwargs()))
         self._proxy_process_names.append(client)
 
-    def _monitor_process_records(self) -> list[Map[str, object]]:
-        records: list[Map[str, object]] = []
+    def _monitor_process_records(self) -> list[ProviderPayload]:
+        records: list[ProviderPayload] = []
         if self._process is not None and self._process.poll() is None:
             pid = getattr(self._process, "pid", None)
             if isinstance(pid, int):
@@ -394,8 +394,8 @@ class DashboardMonitorController:
         self._proxy_process_names = []
 
     @staticmethod
-    def _subprocess_kwargs() -> Map[str, object]:
-        kwargs: Map[str, object] = {
+    def _subprocess_kwargs() -> ProviderPayload:
+        kwargs: ProviderPayload = {
             "stdin": subprocess.DEVNULL,
             "stdout": subprocess.DEVNULL,
             "stderr": subprocess.DEVNULL,
@@ -647,10 +647,10 @@ class _ObjC:
         self,
         receiver: int,
         selector: str,
-        restype: object = ctypes.c_void_p,
-        argtypes: list[object] | None = None,
-        *args: object,
-    ) -> object:
+        restype: type[ctypes._SimpleCData] = ctypes.c_void_p,
+        argtypes: list[type[ctypes._SimpleCData]] | None = None,
+        *args: int | bytes,
+    ) -> int:
         send = self.objc.objc_msgSend
         send.restype = restype
         send.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *(argtypes or [])]
@@ -709,14 +709,14 @@ def _new_app_delegate(objc: _ObjC) -> int:
     return objc.msg(delegate, "init")
 
 
-def _callback(fn: Callable[[int, int, int], None]) -> object:
+def _callback(fn: Callable[[int, int, int], None]) -> ctypes._CFuncPtr:
     callback_type = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     wrapped = callback_type(fn)
     _CALLBACKS.append(wrapped)
     return wrapped
 
 
-def _terminate_callback(fn: Callable[[int, int, int], int]) -> object:
+def _terminate_callback(fn: Callable[[int, int, int], int]) -> ctypes._CFuncPtr:
     callback_type = ctypes.CFUNCTYPE(ctypes.c_long, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     wrapped = callback_type(fn)
     _CALLBACKS.append(wrapped)
@@ -760,14 +760,14 @@ def _quit_callback(_self: int, _cmd: int, _sender: int) -> None:
         _ACTIVE_APP.quit()
 
 
-def _menu_sessions() -> list[Map[str, object]]:
+def _menu_sessions() -> list[ProviderPayload]:
     try:
         return list_trace_sessions()
     except Exception:
         return []
 
 
-def _latest_session_text(session: Map[str, object] | None) -> str:
+def _latest_session_text(session: ProviderPayload | None) -> str:
     if not session:
         return "Latest: No traces yet"
     agent = str(session.get("agent") or "Unknown")

--- a/claude_tap/macos_app.py
+++ b/claude_tap/macos_app.py
@@ -13,10 +13,10 @@ import webbrowser
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import Any
 
 from claude_tap import global_inject
 from claude_tap.dashboard import list_trace_sessions
+from claude_tap.models import Map
 from claude_tap.shared_dashboard import (
     _sync_dashboard_healthy_for_current_db as _dashboard_is_healthy,
 )
@@ -29,7 +29,7 @@ _NS_ALERT_FIRST_BUTTON_RETURN = 1000
 _NS_TERMINATE_NOW = 1
 # Absolute default so the app works when launched from Finder (cwd is "/").
 _DEFAULT_OUTPUT_DIR = Path.home() / ".claude-tap" / "traces"
-_CALLBACKS: list[Any] = []
+_CALLBACKS: list[object] = []
 _ACTIVE_APP: MacOSMenuApp | None = None
 
 # Bump this string whenever the menu-bar logic changes so a debug log immediately
@@ -186,7 +186,7 @@ class DashboardMonitorController:
         owned_process = self._process.poll() if self._process is not None else "none"
         owned_proxies = [getattr(p, "pid", None) for p in self._proxy_processes]
         owned_proxy_polls = [p.poll() for p in self._proxy_processes]
-        listeners: dict[str, object] = {}
+        listeners: Map[str, object] = {}
         for label, port in (
             ("dashboard", self.port),
             ("claude", self.claude_proxy_port),
@@ -351,8 +351,8 @@ class DashboardMonitorController:
         self._proxy_processes.append(self._popen(cmd, **self._subprocess_kwargs()))
         self._proxy_process_names.append(client)
 
-    def _monitor_process_records(self) -> list[dict[str, object]]:
-        records: list[dict[str, object]] = []
+    def _monitor_process_records(self) -> list[Map[str, object]]:
+        records: list[Map[str, object]] = []
         if self._process is not None and self._process.poll() is None:
             pid = getattr(self._process, "pid", None)
             if isinstance(pid, int):
@@ -394,8 +394,8 @@ class DashboardMonitorController:
         self._proxy_process_names = []
 
     @staticmethod
-    def _subprocess_kwargs() -> dict[str, object]:
-        kwargs: dict[str, object] = {
+    def _subprocess_kwargs() -> Map[str, object]:
+        kwargs: Map[str, object] = {
             "stdin": subprocess.DEVNULL,
             "stdout": subprocess.DEVNULL,
             "stderr": subprocess.DEVNULL,
@@ -647,10 +647,10 @@ class _ObjC:
         self,
         receiver: int,
         selector: str,
-        restype: Any = ctypes.c_void_p,
-        argtypes: list[Any] | None = None,
+        restype: object = ctypes.c_void_p,
+        argtypes: list[object] | None = None,
         *args: object,
-    ) -> Any:
+    ) -> object:
         send = self.objc.objc_msgSend
         send.restype = restype
         send.argtypes = [ctypes.c_void_p, ctypes.c_void_p, *(argtypes or [])]
@@ -709,14 +709,14 @@ def _new_app_delegate(objc: _ObjC) -> int:
     return objc.msg(delegate, "init")
 
 
-def _callback(fn: Callable[[int, int, int], None]) -> Any:
+def _callback(fn: Callable[[int, int, int], None]) -> object:
     callback_type = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     wrapped = callback_type(fn)
     _CALLBACKS.append(wrapped)
     return wrapped
 
 
-def _terminate_callback(fn: Callable[[int, int, int], int]) -> Any:
+def _terminate_callback(fn: Callable[[int, int, int], int]) -> object:
     callback_type = ctypes.CFUNCTYPE(ctypes.c_long, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)
     wrapped = callback_type(fn)
     _CALLBACKS.append(wrapped)
@@ -760,14 +760,14 @@ def _quit_callback(_self: int, _cmd: int, _sender: int) -> None:
         _ACTIVE_APP.quit()
 
 
-def _menu_sessions() -> list[dict[str, Any]]:
+def _menu_sessions() -> list[Map[str, object]]:
     try:
         return list_trace_sessions()
     except Exception:
         return []
 
 
-def _latest_session_text(session: dict[str, Any] | None) -> str:
+def _latest_session_text(session: Map[str, object] | None) -> str:
     if not session:
         return "Latest: No traces yet"
     agent = str(session.get("agent") or "Unknown")

--- a/claude_tap/models.py
+++ b/claude_tap/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import TypeAlias, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import TypeAliasType
@@ -10,6 +10,9 @@ from typing_extensions import TypeAliasType
 JsonScalar: TypeAlias = None | bool | int | float | str
 JsonValue = TypeAliasType("JsonValue", JsonScalar | list["JsonValue"] | dict[str, "JsonValue"])
 JsonObject: TypeAlias = dict[str, JsonValue]
+MapKey = TypeVar("MapKey")
+MapValue = TypeVar("MapValue")
+Map: TypeAlias = dict[MapKey, MapValue]
 
 
 class PromptToolModel(BaseModel):

--- a/claude_tap/models.py
+++ b/claude_tap/models.py
@@ -2,17 +2,70 @@
 
 from __future__ import annotations
 
-from typing import TypeAlias, TypeVar
+from collections.abc import ItemsView, Iterator, KeysView, Mapping, MutableMapping, ValuesView
 
-from pydantic import BaseModel, ConfigDict, Field
-from typing_extensions import TypeAliasType
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import JsonValue as _JsonValue
 
-JsonScalar: TypeAlias = None | bool | int | float | str
-JsonValue = TypeAliasType("JsonValue", JsonScalar | list["JsonValue"] | dict[str, "JsonValue"])
-JsonObject: TypeAlias = dict[str, JsonValue]
-MapKey = TypeVar("MapKey")
-MapValue = TypeVar("MapValue")
-Map: TypeAlias = dict[MapKey, MapValue]
+_JSON_VALUE_ADAPTER = TypeAdapter(_JsonValue)
+
+
+class ProviderPayload(BaseModel, MutableMapping[str, _JsonValue]):
+    """Validated provider payload boundary with explicit mapping semantics.
+
+    Provider APIs evolve independently of this project.  The model validates
+    the top-level object and preserves unknown provider fields, while callers
+    still interact through a normal mapping interface at protocol boundaries.
+    Business code must convert payloads into a concrete domain model before
+    relying on provider-specific fields.
+    """
+
+    model_config = ConfigDict(extra="allow")
+    __pydantic_extra__: dict[str, _JsonValue] = Field(init=False)
+
+    def __getitem__(self, key: str) -> _JsonValue:
+        return self.__pydantic_extra__[key]
+
+    def __setitem__(self, key: str, value: _JsonValue) -> None:
+        if self.__pydantic_extra__ is None:
+            object.__setattr__(self, "__pydantic_extra__", {})
+        self.__pydantic_extra__[key] = _JSON_VALUE_ADAPTER.validate_python(value)
+
+    def __delitem__(self, key: str) -> None:
+        if self.__pydantic_extra__ is None:
+            raise KeyError(key)
+        del self.__pydantic_extra__[key]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self.__pydantic_extra__ or {})
+
+    def __len__(self) -> int:
+        return len(self.__pydantic_extra__ or {})
+
+    def get(self, key: str, default: _JsonValue = None) -> _JsonValue:
+        return (self.__pydantic_extra__ or {}).get(key, default)
+
+    def items(self) -> ItemsView[str, _JsonValue]:
+        return (self.__pydantic_extra__ or {}).items()
+
+    def keys(self) -> KeysView[str]:
+        return (self.__pydantic_extra__ or {}).keys()
+
+    def values(self) -> ValuesView[_JsonValue]:
+        return (self.__pydantic_extra__ or {}).values()
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ProviderPayload):
+            return dict(self.items()) == dict(other.items())
+        if isinstance(other, Mapping):
+            return dict(self.items()) == dict(other)
+        return NotImplemented
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, _JsonValue] | "ProviderPayload") -> "ProviderPayload":
+        if isinstance(value, cls):
+            return value
+        return cls.model_validate(dict(value))
 
 
 class PromptToolModel(BaseModel):
@@ -22,11 +75,11 @@ class PromptToolModel(BaseModel):
 
     name: str
     description: str = ""
-    schema_: JsonObject = Field(default_factory=dict, alias="schema")
-    raw: JsonObject = Field(default_factory=dict)
+    schema_: ProviderPayload = Field(default_factory=ProviderPayload, alias="schema")
+    raw: ProviderPayload = Field(default_factory=ProviderPayload)
 
     @property
-    def schema(self) -> JsonObject:
+    def schema(self) -> ProviderPayload:
         """Return the provider tool schema without shadowing Pydantic internals."""
         return self.schema_
 
@@ -47,4 +100,4 @@ class PromptSnapshotModel(BaseModel):
     path: str = ""
     upstream_base_url: str = ""
     captured_at: str = ""
-    raw_request_body: JsonObject = Field(default_factory=dict)
+    raw_request_body: ProviderPayload = Field(default_factory=ProviderPayload)

--- a/claude_tap/models.py
+++ b/claude_tap/models.py
@@ -1,0 +1,47 @@
+"""Application-owned Pydantic models and explicit dynamic JSON boundaries."""
+
+from __future__ import annotations
+
+from typing import TypeAlias
+
+from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import TypeAliasType
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue = TypeAliasType("JsonValue", JsonScalar | list["JsonValue"] | dict[str, "JsonValue"])
+JsonObject: TypeAlias = dict[str, JsonValue]
+
+
+class PromptToolModel(BaseModel):
+    """Normalized tool metadata owned by the prompt snapshot feature."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str = ""
+    schema_: JsonObject = Field(default_factory=dict, alias="schema")
+    raw: JsonObject = Field(default_factory=dict)
+
+    @property
+    def schema(self) -> JsonObject:
+        """Return the provider tool schema without shadowing Pydantic internals."""
+        return self.schema_
+
+
+class PromptSnapshotModel(BaseModel):
+    """Stable, serialized representation of a provider prompt snapshot."""
+
+    model_config = ConfigDict(frozen=True)
+
+    provider: str
+    model: str
+    system_prompt: str = ""
+    developer_prompt: str = ""
+    user_message: str = ""
+    tools: tuple[PromptToolModel, ...] = ()
+    turn: int | None = None
+    request_id: str = ""
+    path: str = ""
+    upstream_base_url: str = ""
+    captured_at: str = ""
+    raw_request_body: JsonObject = Field(default_factory=dict)

--- a/claude_tap/process_utils.py
+++ b/claude_tap/process_utils.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import subprocess
 import sys
-from typing import Any
+
+from claude_tap.models import Map
 
 _CREATE_NO_WINDOW = 0x08000000
 _CREATE_NEW_PROCESS_GROUP = 0x00000200
@@ -12,12 +13,12 @@ _STARTF_USESHOWWINDOW = 0x00000001
 _SW_HIDE = 0
 
 
-def windows_no_console_subprocess_kwargs() -> dict[str, Any]:
+def windows_no_console_subprocess_kwargs() -> Map[str, object]:
     """Return Windows-only Popen kwargs for hidden background processes."""
     if sys.platform != "win32":
         return {}
 
-    kwargs: dict[str, Any] = {
+    kwargs: Map[str, object] = {
         "stdin": subprocess.DEVNULL,
         "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", _CREATE_NO_WINDOW)
         | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", _CREATE_NEW_PROCESS_GROUP),

--- a/claude_tap/process_utils.py
+++ b/claude_tap/process_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import subprocess
 import sys
 
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 
 _CREATE_NO_WINDOW = 0x08000000
 _CREATE_NEW_PROCESS_GROUP = 0x00000200
@@ -13,12 +13,12 @@ _STARTF_USESHOWWINDOW = 0x00000001
 _SW_HIDE = 0
 
 
-def windows_no_console_subprocess_kwargs() -> Map[str, object]:
+def windows_no_console_subprocess_kwargs() -> ProviderPayload:
     """Return Windows-only Popen kwargs for hidden background processes."""
     if sys.platform != "win32":
         return {}
 
-    kwargs: Map[str, object] = {
+    kwargs: ProviderPayload = {
         "stdin": subprocess.DEVNULL,
         "creationflags": getattr(subprocess, "CREATE_NO_WINDOW", _CREATE_NO_WINDOW)
         | getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", _CREATE_NEW_PROCESS_GROUP),

--- a/claude_tap/prompt_snapshot.py
+++ b/claude_tap/prompt_snapshot.py
@@ -8,32 +8,12 @@ prompt surface rather than the full traffic trace.
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, field
 from typing import Any
 
+from claude_tap.models import PromptSnapshotModel, PromptToolModel
 
-@dataclass(frozen=True)
-class PromptTool:
-    name: str
-    description: str = ""
-    schema: dict[str, Any] = field(default_factory=dict)
-    raw: dict[str, Any] = field(default_factory=dict)
-
-
-@dataclass(frozen=True)
-class PromptSnapshot:
-    provider: str
-    model: str
-    system_prompt: str = ""
-    developer_prompt: str = ""
-    user_message: str = ""
-    tools: tuple[PromptTool, ...] = ()
-    turn: int | None = None
-    request_id: str = ""
-    path: str = ""
-    upstream_base_url: str = ""
-    captured_at: str = ""
-    raw_request_body: dict[str, Any] = field(default_factory=dict)
+PromptTool = PromptToolModel
+PromptSnapshot = PromptSnapshotModel
 
 
 def snapshot_from_records(records: list[dict[str, Any]]) -> PromptSnapshot:

--- a/claude_tap/prompt_snapshot.py
+++ b/claude_tap/prompt_snapshot.py
@@ -8,15 +8,14 @@ prompt surface rather than the full traffic trace.
 from __future__ import annotations
 
 import json
-from typing import Any
 
-from claude_tap.models import PromptSnapshotModel, PromptToolModel
+from claude_tap.models import Map, PromptSnapshotModel, PromptToolModel
 
 PromptTool = PromptToolModel
 PromptSnapshot = PromptSnapshotModel
 
 
-def snapshot_from_records(records: list[dict[str, Any]]) -> PromptSnapshot:
+def snapshot_from_records(records: list[Map[str, object]]) -> PromptSnapshot:
     """Select the best prompt-bearing request and normalize it.
 
     Preference is intentionally simple and explainable: choose generation
@@ -25,7 +24,7 @@ def snapshot_from_records(records: list[dict[str, Any]]) -> PromptSnapshot:
     `/v1/responses` call while ignoring lightweight probes.
     """
 
-    candidates: list[tuple[int, dict[str, Any]]] = []
+    candidates: list[tuple[int, Map[str, object]]] = []
     for record in records:
         body = _request_body(record)
         if not body:
@@ -49,7 +48,7 @@ def snapshot_from_records(records: list[dict[str, Any]]) -> PromptSnapshot:
     raise ValueError("no prompt-bearing request found in trace")
 
 
-def infer_provider(record: dict[str, Any]) -> str:
+def infer_provider(record: Map[str, object]) -> str:
     """Infer provider protocol from the trace path and request body."""
 
     req = record.get("request") if isinstance(record.get("request"), dict) else {}
@@ -118,7 +117,7 @@ def _indent_markdown_headers(text: str, *, levels: int = 1) -> str:
     return "\n".join(f"{prefix}{line}" if line.startswith("#") else line for line in text.splitlines())
 
 
-def _score_record(record: dict[str, Any], provider: str) -> int:
+def _score_record(record: Map[str, object], provider: str) -> int:
     body = _request_body(record)
     tools = _tools_for_provider(provider, body)
     system_text, developer_text, user_text = _prompt_text_for_provider(provider, body)
@@ -136,7 +135,7 @@ def _score_record(record: dict[str, Any], provider: str) -> int:
     return score
 
 
-def _anthropic_snapshot(record: dict[str, Any]) -> PromptSnapshot:
+def _anthropic_snapshot(record: Map[str, object]) -> PromptSnapshot:
     body = _request_body(record)
     system_prompt, _developer_prompt, user_message = _prompt_text_for_provider("anthropic", body)
     tools = tuple(_anthropic_tools_from_body(body))
@@ -150,7 +149,7 @@ def _anthropic_snapshot(record: dict[str, Any]) -> PromptSnapshot:
     )
 
 
-def _openai_snapshot(record: dict[str, Any]) -> PromptSnapshot:
+def _openai_snapshot(record: Map[str, object]) -> PromptSnapshot:
     body = _request_body(record)
     system_prompt, developer_prompt, user_message = _prompt_text_for_provider("openai", body)
     tools = tuple(_openai_tools(body.get("tools")))
@@ -165,7 +164,7 @@ def _openai_snapshot(record: dict[str, Any]) -> PromptSnapshot:
     )
 
 
-def _gemini_snapshot(record: dict[str, Any]) -> PromptSnapshot:
+def _gemini_snapshot(record: Map[str, object]) -> PromptSnapshot:
     body = _request_body(record)
     system_prompt, developer_prompt, user_message = _prompt_text_for_provider("gemini", body)
     tools = tuple(_gemini_tools(body.get("tools")))
@@ -182,7 +181,7 @@ def _gemini_snapshot(record: dict[str, Any]) -> PromptSnapshot:
 
 
 def _base_snapshot(
-    record: dict[str, Any],
+    record: Map[str, object],
     *,
     provider: str,
     model: str,
@@ -208,9 +207,9 @@ def _base_snapshot(
     )
 
 
-def _request_body(record: dict[str, Any]) -> dict[str, Any]:
+def _request_body(record: Map[str, object]) -> Map[str, object]:
     req = record.get("request") if isinstance(record.get("request"), dict) else {}
-    candidates: list[dict[str, Any]] = []
+    candidates: list[Map[str, object]] = []
     body = req.get("body")
     if isinstance(body, dict):
         candidates.append(body)
@@ -223,14 +222,14 @@ def _request_body(record: dict[str, Any]) -> dict[str, Any]:
     return max((_prompt_body(candidate) for candidate in candidates), key=_prompt_body_score)
 
 
-def _prompt_body(body: dict[str, Any]) -> dict[str, Any]:
+def _prompt_body(body: Map[str, object]) -> Map[str, object]:
     nested = body.get("request")
     if isinstance(nested, dict) and _looks_like_gemini_body(nested):
         return nested
     return body
 
 
-def _prompt_body_score(body: dict[str, Any]) -> int:
+def _prompt_body_score(body: Map[str, object]) -> int:
     score = 0
     for key, weight in (
         ("system", 100),
@@ -251,11 +250,11 @@ def _prompt_body_score(body: dict[str, Any]) -> int:
     return score
 
 
-def _looks_like_gemini_body(body: dict[str, Any]) -> bool:
+def _looks_like_gemini_body(body: Map[str, object]) -> bool:
     return any(key in body for key in ("contents", "system_instruction", "systemInstruction"))
 
 
-def _tools_for_provider(provider: str, body: dict[str, Any]) -> list[PromptTool]:
+def _tools_for_provider(provider: str, body: Map[str, object]) -> list[PromptTool]:
     if provider == "anthropic":
         return _anthropic_tools_from_body(body)
     if provider == "openai":
@@ -265,7 +264,7 @@ def _tools_for_provider(provider: str, body: dict[str, Any]) -> list[PromptTool]
     return []
 
 
-def _prompt_text_for_provider(provider: str, body: dict[str, Any]) -> tuple[str, str, str]:
+def _prompt_text_for_provider(provider: str, body: Map[str, object]) -> tuple[str, str, str]:
     legacy_prompt = body.get("prompt") if isinstance(body.get("prompt"), str) else ""
     if provider == "anthropic":
         return (
@@ -306,7 +305,7 @@ def _prompt_text_for_provider(provider: str, body: dict[str, Any]) -> tuple[str,
     return ("", "", "")
 
 
-def _anthropic_system_text(system: Any) -> str:
+def _anthropic_system_text(system: object) -> str:
     if isinstance(system, str):
         return system
     if isinstance(system, list):
@@ -314,7 +313,7 @@ def _anthropic_system_text(system: Any) -> str:
     return ""
 
 
-def _messages_text(messages: Any, roles: set[str]) -> str:
+def _messages_text(messages: object, roles: set[str]) -> str:
     if not isinstance(messages, list):
         return ""
     parts = []
@@ -324,7 +323,7 @@ def _messages_text(messages: Any, roles: set[str]) -> str:
     return _join_text(parts)
 
 
-def _input_text(input_value: Any, roles: set[str]) -> str:
+def _input_text(input_value: object, roles: set[str]) -> str:
     if isinstance(input_value, str):
         return input_value if "user" in roles else ""
     if not isinstance(input_value, list):
@@ -337,7 +336,7 @@ def _input_text(input_value: Any, roles: set[str]) -> str:
     return _join_text(parts)
 
 
-def _contents_text(contents: Any, roles: set[str]) -> str:
+def _contents_text(contents: object, roles: set[str]) -> str:
     if not isinstance(contents, list):
         return ""
     parts: list[str] = []
@@ -351,7 +350,7 @@ def _contents_text(contents: Any, roles: set[str]) -> str:
     return _join_text(parts)
 
 
-def _content_text(content: Any) -> str:
+def _content_text(content: object) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, dict):
@@ -383,7 +382,7 @@ def _content_text(content: Any) -> str:
     return _join_text(parts)
 
 
-def _gemini_parts_text(value: Any) -> str:
+def _gemini_parts_text(value: object) -> str:
     if not isinstance(value, dict):
         return ""
     parts = value.get("parts")
@@ -394,7 +393,7 @@ def _gemini_parts_text(value: Any) -> str:
     )
 
 
-def _anthropic_tools_from_body(body: dict[str, Any]) -> list[PromptTool]:
+def _anthropic_tools_from_body(body: Map[str, object]) -> list[PromptTool]:
     tools = _anthropic_tools(body.get("tools"))
     tool_config = body.get("toolConfig")
     if isinstance(tool_config, dict):
@@ -402,7 +401,7 @@ def _anthropic_tools_from_body(body: dict[str, Any]) -> list[PromptTool]:
     return tools
 
 
-def _anthropic_tools(tools: Any) -> list[PromptTool]:
+def _anthropic_tools(tools: object) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -420,7 +419,7 @@ def _anthropic_tools(tools: Any) -> list[PromptTool]:
     return out
 
 
-def _bedrock_tool_config_tools(tools: Any) -> list[PromptTool]:
+def _bedrock_tool_config_tools(tools: object) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -443,7 +442,7 @@ def _bedrock_tool_config_tools(tools: Any) -> list[PromptTool]:
     return out
 
 
-def _openai_tools(tools: Any) -> list[PromptTool]:
+def _openai_tools(tools: object) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -470,7 +469,7 @@ def _openai_tools(tools: Any) -> list[PromptTool]:
     return out
 
 
-def _gemini_tools(tools: Any) -> list[PromptTool]:
+def _gemini_tools(tools: object) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -504,7 +503,7 @@ def _gemini_model_from_path(path: str) -> str:
     return tail.split(":", 1)[0]
 
 
-def _join_text(parts: Any) -> str:
+def _join_text(parts: object) -> str:
     return "\n\n".join(str(part).strip() for part in parts if isinstance(part, str) and part.strip())
 
 

--- a/claude_tap/prompt_snapshot.py
+++ b/claude_tap/prompt_snapshot.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 
 import json
 
-from claude_tap.models import Map, PromptSnapshotModel, PromptToolModel
+from claude_tap.models import PromptSnapshotModel, PromptToolModel, ProviderPayload
 
 PromptTool = PromptToolModel
 PromptSnapshot = PromptSnapshotModel
 
 
-def snapshot_from_records(records: list[Map[str, object]]) -> PromptSnapshot:
+def snapshot_from_records(records: list[ProviderPayload]) -> PromptSnapshot:
     """Select the best prompt-bearing request and normalize it.
 
     Preference is intentionally simple and explainable: choose generation
@@ -24,7 +24,7 @@ def snapshot_from_records(records: list[Map[str, object]]) -> PromptSnapshot:
     `/v1/responses` call while ignoring lightweight probes.
     """
 
-    candidates: list[tuple[int, Map[str, object]]] = []
+    candidates: list[tuple[int, ProviderPayload]] = []
     for record in records:
         body = _request_body(record)
         if not body:
@@ -48,7 +48,7 @@ def snapshot_from_records(records: list[Map[str, object]]) -> PromptSnapshot:
     raise ValueError("no prompt-bearing request found in trace")
 
 
-def infer_provider(record: Map[str, object]) -> str:
+def infer_provider(record: ProviderPayload) -> str:
     """Infer provider protocol from the trace path and request body."""
 
     req = record.get("request") if isinstance(record.get("request"), dict) else {}
@@ -103,7 +103,8 @@ def render_prompt_markdown(snapshot: PromptSnapshot) -> str:
         if tool.description:
             lines.append(_indent_markdown_headers(tool.description, levels=2))
             lines.append("")
-        schema = tool.schema if tool.schema else tool.raw
+        schema_model = tool.schema if tool.schema else tool.raw
+        schema = schema_model.model_dump() if isinstance(schema_model, ProviderPayload) else schema_model
         lines.append("```json")
         lines.append(json.dumps(schema, indent=2, ensure_ascii=False))
         lines.append("```")
@@ -117,7 +118,7 @@ def _indent_markdown_headers(text: str, *, levels: int = 1) -> str:
     return "\n".join(f"{prefix}{line}" if line.startswith("#") else line for line in text.splitlines())
 
 
-def _score_record(record: Map[str, object], provider: str) -> int:
+def _score_record(record: ProviderPayload, provider: str) -> int:
     body = _request_body(record)
     tools = _tools_for_provider(provider, body)
     system_text, developer_text, user_text = _prompt_text_for_provider(provider, body)
@@ -135,7 +136,7 @@ def _score_record(record: Map[str, object], provider: str) -> int:
     return score
 
 
-def _anthropic_snapshot(record: Map[str, object]) -> PromptSnapshot:
+def _anthropic_snapshot(record: ProviderPayload) -> PromptSnapshot:
     body = _request_body(record)
     system_prompt, _developer_prompt, user_message = _prompt_text_for_provider("anthropic", body)
     tools = tuple(_anthropic_tools_from_body(body))
@@ -149,7 +150,7 @@ def _anthropic_snapshot(record: Map[str, object]) -> PromptSnapshot:
     )
 
 
-def _openai_snapshot(record: Map[str, object]) -> PromptSnapshot:
+def _openai_snapshot(record: ProviderPayload) -> PromptSnapshot:
     body = _request_body(record)
     system_prompt, developer_prompt, user_message = _prompt_text_for_provider("openai", body)
     tools = tuple(_openai_tools(body.get("tools")))
@@ -164,7 +165,7 @@ def _openai_snapshot(record: Map[str, object]) -> PromptSnapshot:
     )
 
 
-def _gemini_snapshot(record: Map[str, object]) -> PromptSnapshot:
+def _gemini_snapshot(record: ProviderPayload) -> PromptSnapshot:
     body = _request_body(record)
     system_prompt, developer_prompt, user_message = _prompt_text_for_provider("gemini", body)
     tools = tuple(_gemini_tools(body.get("tools")))
@@ -181,7 +182,7 @@ def _gemini_snapshot(record: Map[str, object]) -> PromptSnapshot:
 
 
 def _base_snapshot(
-    record: Map[str, object],
+    record: ProviderPayload,
     *,
     provider: str,
     model: str,
@@ -207,9 +208,9 @@ def _base_snapshot(
     )
 
 
-def _request_body(record: Map[str, object]) -> Map[str, object]:
+def _request_body(record: ProviderPayload) -> ProviderPayload:
     req = record.get("request") if isinstance(record.get("request"), dict) else {}
-    candidates: list[Map[str, object]] = []
+    candidates: list[ProviderPayload] = []
     body = req.get("body")
     if isinstance(body, dict):
         candidates.append(body)
@@ -222,14 +223,14 @@ def _request_body(record: Map[str, object]) -> Map[str, object]:
     return max((_prompt_body(candidate) for candidate in candidates), key=_prompt_body_score)
 
 
-def _prompt_body(body: Map[str, object]) -> Map[str, object]:
+def _prompt_body(body: ProviderPayload) -> ProviderPayload:
     nested = body.get("request")
     if isinstance(nested, dict) and _looks_like_gemini_body(nested):
         return nested
     return body
 
 
-def _prompt_body_score(body: Map[str, object]) -> int:
+def _prompt_body_score(body: ProviderPayload) -> int:
     score = 0
     for key, weight in (
         ("system", 100),
@@ -250,11 +251,11 @@ def _prompt_body_score(body: Map[str, object]) -> int:
     return score
 
 
-def _looks_like_gemini_body(body: Map[str, object]) -> bool:
+def _looks_like_gemini_body(body: ProviderPayload) -> bool:
     return any(key in body for key in ("contents", "system_instruction", "systemInstruction"))
 
 
-def _tools_for_provider(provider: str, body: Map[str, object]) -> list[PromptTool]:
+def _tools_for_provider(provider: str, body: ProviderPayload) -> list[PromptTool]:
     if provider == "anthropic":
         return _anthropic_tools_from_body(body)
     if provider == "openai":
@@ -264,7 +265,7 @@ def _tools_for_provider(provider: str, body: Map[str, object]) -> list[PromptToo
     return []
 
 
-def _prompt_text_for_provider(provider: str, body: Map[str, object]) -> tuple[str, str, str]:
+def _prompt_text_for_provider(provider: str, body: ProviderPayload) -> tuple[str, str, str]:
     legacy_prompt = body.get("prompt") if isinstance(body.get("prompt"), str) else ""
     if provider == "anthropic":
         return (
@@ -305,7 +306,7 @@ def _prompt_text_for_provider(provider: str, body: Map[str, object]) -> tuple[st
     return ("", "", "")
 
 
-def _anthropic_system_text(system: object) -> str:
+def _anthropic_system_text(system: ProviderPayload) -> str:
     if isinstance(system, str):
         return system
     if isinstance(system, list):
@@ -313,7 +314,7 @@ def _anthropic_system_text(system: object) -> str:
     return ""
 
 
-def _messages_text(messages: object, roles: set[str]) -> str:
+def _messages_text(messages: ProviderPayload, roles: set[str]) -> str:
     if not isinstance(messages, list):
         return ""
     parts = []
@@ -323,7 +324,7 @@ def _messages_text(messages: object, roles: set[str]) -> str:
     return _join_text(parts)
 
 
-def _input_text(input_value: object, roles: set[str]) -> str:
+def _input_text(input_value: ProviderPayload, roles: set[str]) -> str:
     if isinstance(input_value, str):
         return input_value if "user" in roles else ""
     if not isinstance(input_value, list):
@@ -336,7 +337,7 @@ def _input_text(input_value: object, roles: set[str]) -> str:
     return _join_text(parts)
 
 
-def _contents_text(contents: object, roles: set[str]) -> str:
+def _contents_text(contents: ProviderPayload, roles: set[str]) -> str:
     if not isinstance(contents, list):
         return ""
     parts: list[str] = []
@@ -350,7 +351,7 @@ def _contents_text(contents: object, roles: set[str]) -> str:
     return _join_text(parts)
 
 
-def _content_text(content: object) -> str:
+def _content_text(content: ProviderPayload) -> str:
     if isinstance(content, str):
         return content
     if isinstance(content, dict):
@@ -382,7 +383,7 @@ def _content_text(content: object) -> str:
     return _join_text(parts)
 
 
-def _gemini_parts_text(value: object) -> str:
+def _gemini_parts_text(value: ProviderPayload) -> str:
     if not isinstance(value, dict):
         return ""
     parts = value.get("parts")
@@ -393,7 +394,7 @@ def _gemini_parts_text(value: object) -> str:
     )
 
 
-def _anthropic_tools_from_body(body: Map[str, object]) -> list[PromptTool]:
+def _anthropic_tools_from_body(body: ProviderPayload) -> list[PromptTool]:
     tools = _anthropic_tools(body.get("tools"))
     tool_config = body.get("toolConfig")
     if isinstance(tool_config, dict):
@@ -401,7 +402,7 @@ def _anthropic_tools_from_body(body: Map[str, object]) -> list[PromptTool]:
     return tools
 
 
-def _anthropic_tools(tools: object) -> list[PromptTool]:
+def _anthropic_tools(tools: ProviderPayload) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -419,7 +420,7 @@ def _anthropic_tools(tools: object) -> list[PromptTool]:
     return out
 
 
-def _bedrock_tool_config_tools(tools: object) -> list[PromptTool]:
+def _bedrock_tool_config_tools(tools: ProviderPayload) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -442,7 +443,7 @@ def _bedrock_tool_config_tools(tools: object) -> list[PromptTool]:
     return out
 
 
-def _openai_tools(tools: object) -> list[PromptTool]:
+def _openai_tools(tools: ProviderPayload) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -469,7 +470,7 @@ def _openai_tools(tools: object) -> list[PromptTool]:
     return out
 
 
-def _gemini_tools(tools: object) -> list[PromptTool]:
+def _gemini_tools(tools: ProviderPayload) -> list[PromptTool]:
     if not isinstance(tools, list):
         return []
     out: list[PromptTool] = []
@@ -503,7 +504,7 @@ def _gemini_model_from_path(path: str) -> str:
     return tail.split(":", 1)[0]
 
 
-def _join_text(parts: object) -> str:
+def _join_text(parts: list[str]) -> str:
     return "\n\n".join(str(part).strip() for part in parts if isinstance(part, str) and part.strip())
 
 

--- a/claude_tap/proxy.py
+++ b/claude_tap/proxy.py
@@ -19,7 +19,7 @@ from aiohttp import web
 from yarl import URL
 
 from claude_tap.bedrock import attach_bedrock_errors, bedrock_model_from_path, is_bedrock_eventstream_path
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.sse import SSEReassembler
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_encoding import parse_request_body_for_trace as _parse_request_body_for_trace
@@ -69,9 +69,9 @@ SENSITIVE_HEADER_KEYS = frozenset(
 PREFIX_REDACTED_HEADER_KEYS = frozenset({"authorization", "x-api-key"})
 
 
-def filter_headers(headers: Map[str, str], *, redact_keys: bool = False) -> Map[str, str]:
+def filter_headers(headers: dict[str, str], *, redact_keys: bool = False) -> dict[str, str]:
     """Filter hop-by-hop headers and optionally redact sensitive values."""
-    out: Map[str, str] = {}
+    out: dict[str, str] = {}
     for k, v in headers.items():
         key = k.lower()
         if key in HOP_BY_HOP:
@@ -162,7 +162,7 @@ def _is_deepseek_anthropic_target(target: str) -> bool:
     return url.host == "api.deepseek.com" and url.path.rstrip("/") == "/anthropic"
 
 
-def _normalize_request_body_for_upstream(req_body: JsonObject, target: str) -> JsonObject:
+def _normalize_request_body_for_upstream(req_body: ProviderPayload, target: str) -> ProviderPayload:
     """Apply narrow upstream compatibility fixes without changing default Anthropic behavior."""
     normalized_body = _normalize_bedrock_gateway_body(req_body)
     if normalized_body is not req_body:
@@ -187,11 +187,11 @@ def _normalize_request_body_for_upstream(req_body: JsonObject, target: str) -> J
     return normalized_body
 
 
-def _normalize_bedrock_gateway_body(req_body: JsonObject) -> JsonObject:
+def _normalize_bedrock_gateway_body(req_body: ProviderPayload) -> ProviderPayload:
     if not _is_bedrock_gateway_request(req_body):
         return req_body
 
-    normalized_body: JsonObject | None = None
+    normalized_body: ProviderPayload | None = None
     for key in _BEDROCK_GATEWAY_UNSUPPORTED_BODY_FIELDS:
         if key in req_body:
             normalized_body = dict(req_body) if normalized_body is None else normalized_body
@@ -206,7 +206,7 @@ def _normalize_bedrock_gateway_body(req_body: JsonObject) -> JsonObject:
     return normalized_body if normalized_body is not None else req_body
 
 
-def _is_bedrock_gateway_request(req_body: object) -> bool:
+def _is_bedrock_gateway_request(req_body: ProviderPayload) -> bool:
     """Return True when an Anthropic-compatible gateway routes by a Bedrock model prefix."""
     if not isinstance(req_body, dict):
         return False
@@ -214,7 +214,7 @@ def _is_bedrock_gateway_request(req_body: object) -> bool:
     return isinstance(model, str) and model.startswith("bedrock/")
 
 
-def _drop_header(headers: Map[str, str], header_name: str) -> None:
+def _drop_header(headers: dict[str, str], header_name: str) -> None:
     target = header_name.lower()
     for key in list(headers):
         if key.lower() == target:
@@ -231,7 +231,7 @@ def _drop_query_param(raw_path: str, param_name: str) -> str:
     return f"{path}?{'&'.join(kept)}"
 
 
-def is_capture_only_request(path: str, req_body: object) -> bool:
+def is_capture_only_request(path: str, req_body: ProviderPayload) -> bool:
     """Return whether capture-only mode should short-circuit this request.
 
     Forward proxy clients may make unrelated HTTPS calls during startup. Prompt
@@ -271,7 +271,7 @@ def is_capture_only_request(path: str, req_body: object) -> bool:
     )
 
 
-def is_capture_only_streaming_request(path: str, req_body: object) -> bool:
+def is_capture_only_streaming_request(path: str, req_body: ProviderPayload) -> bool:
     """Return whether a captured request expects a streaming response by path or body."""
 
     if is_bedrock_eventstream_path(path):
@@ -291,7 +291,7 @@ def capture_only_content_type(path: str, is_streaming: bool) -> str:
     return "application/json"
 
 
-def capture_only_response(path: str, req_body: object) -> JsonObject:
+def capture_only_response(path: str, req_body: ProviderPayload) -> ProviderPayload:
     """Return a protocol-shaped success response without contacting upstream."""
     model = req_body.get("model", "claude-tap-capture") if isinstance(req_body, dict) else "claude-tap-capture"
     clean_path = path.split("?", 1)[0]
@@ -355,7 +355,7 @@ def capture_only_response(path: str, req_body: object) -> JsonObject:
     }
 
 
-def _capture_only_anthropic_completion_response(model: object) -> JsonObject:
+def _capture_only_anthropic_completion_response(model: ProviderPayload) -> ProviderPayload:
     return {
         "id": "compl_claude_tap_capture",
         "type": "completion",
@@ -365,7 +365,7 @@ def _capture_only_anthropic_completion_response(model: object) -> JsonObject:
     }
 
 
-def _capture_only_gemini_generation_response() -> JsonObject:
+def _capture_only_gemini_generation_response() -> ProviderPayload:
     return {
         "candidates": [
             {
@@ -378,7 +378,7 @@ def _capture_only_gemini_generation_response() -> JsonObject:
     }
 
 
-def _capture_only_gemini_model_response(clean_path: str, model: object) -> JsonObject:
+def _capture_only_gemini_model_response(clean_path: str, model: ProviderPayload) -> ProviderPayload:
     if clean_path in {"/v1beta/models", "/v1alpha/models"}:
         model_name = f"models/{model}"
         return {"models": [_capture_only_gemini_model(model_name)]}
@@ -388,7 +388,7 @@ def _capture_only_gemini_model_response(clean_path: str, model: object) -> JsonO
     return _capture_only_gemini_model(model_name)
 
 
-def _capture_only_gemini_model(model_name: str) -> JsonObject:
+def _capture_only_gemini_model(model_name: str) -> ProviderPayload:
     model_id = model_name.rsplit("/", 1)[-1]
     return {
         "name": model_name,
@@ -398,7 +398,7 @@ def _capture_only_gemini_model(model_name: str) -> JsonObject:
     }
 
 
-def capture_only_stream_bytes(path: str, req_body: object) -> bytes:
+def capture_only_stream_bytes(path: str, req_body: ProviderPayload) -> bytes:
     """Return a small provider-shaped SSE response for streaming capture-only requests."""
 
     resp_body = capture_only_response(path, req_body)
@@ -467,7 +467,7 @@ def capture_only_stream_bytes(path: str, req_body: object) -> bytes:
     ).encode("utf-8")
 
 
-def _capture_only_anthropic_message_stream_bytes(resp_body: JsonObject) -> bytes:
+def _capture_only_anthropic_message_stream_bytes(resp_body: ProviderPayload) -> bytes:
     events = [
         ("message_start", {"type": "message_start", "message": resp_body}),
         (
@@ -517,7 +517,7 @@ def _capture_only_bedrock_eventstream_bytes(path: str) -> bytes:
     return b"".join(_capture_only_bedrock_frame(event) for event in events)
 
 
-def _capture_only_bedrock_frame(payload: JsonObject, event_type: str = "chunk") -> bytes:
+def _capture_only_bedrock_frame(payload: ProviderPayload, event_type: str = "chunk") -> bytes:
     payload_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = b"".join(
         _bedrock_eventstream_header(name, value)
@@ -546,7 +546,7 @@ def _bedrock_eventstream_header(name: str, value: str) -> bytes:
 
 async def proxy_handler(request: web.Request) -> web.StreamResponse:
     # Reject requests to unknown paths (scanner/crawler protection)
-    ctx: JsonObject = request.app["trace_ctx"]
+    ctx: ProviderPayload = request.app["trace_ctx"]
     extra_prefixes: tuple[str, ...] = ctx.get("extra_allowed_path_prefixes", ())
     if not _is_allowed_path(request.path, extra_prefixes):
         log.debug(f"Blocked non-API path: {request.method} {request.path}")
@@ -848,16 +848,16 @@ def _build_record(
     duration_ms: int,
     method: str,
     path_qs: str,
-    req_headers: JsonObject,
-    req_body: JsonObject | None,
+    req_headers: ProviderPayload,
+    req_body: ProviderPayload | None,
     status: int,
-    resp_headers: JsonObject,
-    resp_body: JsonObject | None,
-    sse_events: list[JsonObject] | None = None,
+    resp_headers: ProviderPayload,
+    resp_body: ProviderPayload | None,
+    sse_events: list[ProviderPayload] | None = None,
     upstream_base_url: str | None = None,
-) -> JsonObject:
+) -> ProviderPayload:
     """Build a trace record for a single API call."""
-    record: JsonObject = {
+    record: ProviderPayload = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "request_id": req_id,
         "turn": turn,

--- a/claude_tap/proxy.py
+++ b/claude_tap/proxy.py
@@ -19,6 +19,7 @@ from aiohttp import web
 from yarl import URL
 
 from claude_tap.bedrock import attach_bedrock_errors, bedrock_model_from_path, is_bedrock_eventstream_path
+from claude_tap.models import JsonObject, Map
 from claude_tap.sse import SSEReassembler
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_encoding import parse_request_body_for_trace as _parse_request_body_for_trace
@@ -68,9 +69,9 @@ SENSITIVE_HEADER_KEYS = frozenset(
 PREFIX_REDACTED_HEADER_KEYS = frozenset({"authorization", "x-api-key"})
 
 
-def filter_headers(headers: dict[str, str], *, redact_keys: bool = False) -> dict[str, str]:
+def filter_headers(headers: Map[str, str], *, redact_keys: bool = False) -> Map[str, str]:
     """Filter hop-by-hop headers and optionally redact sensitive values."""
-    out: dict[str, str] = {}
+    out: Map[str, str] = {}
     for k, v in headers.items():
         key = k.lower()
         if key in HOP_BY_HOP:
@@ -161,7 +162,7 @@ def _is_deepseek_anthropic_target(target: str) -> bool:
     return url.host == "api.deepseek.com" and url.path.rstrip("/") == "/anthropic"
 
 
-def _normalize_request_body_for_upstream(req_body: dict, target: str) -> dict:
+def _normalize_request_body_for_upstream(req_body: JsonObject, target: str) -> JsonObject:
     """Apply narrow upstream compatibility fixes without changing default Anthropic behavior."""
     normalized_body = _normalize_bedrock_gateway_body(req_body)
     if normalized_body is not req_body:
@@ -186,11 +187,11 @@ def _normalize_request_body_for_upstream(req_body: dict, target: str) -> dict:
     return normalized_body
 
 
-def _normalize_bedrock_gateway_body(req_body: dict) -> dict:
+def _normalize_bedrock_gateway_body(req_body: JsonObject) -> JsonObject:
     if not _is_bedrock_gateway_request(req_body):
         return req_body
 
-    normalized_body: dict | None = None
+    normalized_body: JsonObject | None = None
     for key in _BEDROCK_GATEWAY_UNSUPPORTED_BODY_FIELDS:
         if key in req_body:
             normalized_body = dict(req_body) if normalized_body is None else normalized_body
@@ -213,7 +214,7 @@ def _is_bedrock_gateway_request(req_body: object) -> bool:
     return isinstance(model, str) and model.startswith("bedrock/")
 
 
-def _drop_header(headers: dict[str, str], header_name: str) -> None:
+def _drop_header(headers: Map[str, str], header_name: str) -> None:
     target = header_name.lower()
     for key in list(headers):
         if key.lower() == target:
@@ -290,7 +291,7 @@ def capture_only_content_type(path: str, is_streaming: bool) -> str:
     return "application/json"
 
 
-def capture_only_response(path: str, req_body: object) -> dict:
+def capture_only_response(path: str, req_body: object) -> JsonObject:
     """Return a protocol-shaped success response without contacting upstream."""
     model = req_body.get("model", "claude-tap-capture") if isinstance(req_body, dict) else "claude-tap-capture"
     clean_path = path.split("?", 1)[0]
@@ -354,7 +355,7 @@ def capture_only_response(path: str, req_body: object) -> dict:
     }
 
 
-def _capture_only_anthropic_completion_response(model: object) -> dict:
+def _capture_only_anthropic_completion_response(model: object) -> JsonObject:
     return {
         "id": "compl_claude_tap_capture",
         "type": "completion",
@@ -364,7 +365,7 @@ def _capture_only_anthropic_completion_response(model: object) -> dict:
     }
 
 
-def _capture_only_gemini_generation_response() -> dict:
+def _capture_only_gemini_generation_response() -> JsonObject:
     return {
         "candidates": [
             {
@@ -377,7 +378,7 @@ def _capture_only_gemini_generation_response() -> dict:
     }
 
 
-def _capture_only_gemini_model_response(clean_path: str, model: object) -> dict:
+def _capture_only_gemini_model_response(clean_path: str, model: object) -> JsonObject:
     if clean_path in {"/v1beta/models", "/v1alpha/models"}:
         model_name = f"models/{model}"
         return {"models": [_capture_only_gemini_model(model_name)]}
@@ -387,7 +388,7 @@ def _capture_only_gemini_model_response(clean_path: str, model: object) -> dict:
     return _capture_only_gemini_model(model_name)
 
 
-def _capture_only_gemini_model(model_name: str) -> dict:
+def _capture_only_gemini_model(model_name: str) -> JsonObject:
     model_id = model_name.rsplit("/", 1)[-1]
     return {
         "name": model_name,
@@ -466,7 +467,7 @@ def capture_only_stream_bytes(path: str, req_body: object) -> bytes:
     ).encode("utf-8")
 
 
-def _capture_only_anthropic_message_stream_bytes(resp_body: dict) -> bytes:
+def _capture_only_anthropic_message_stream_bytes(resp_body: JsonObject) -> bytes:
     events = [
         ("message_start", {"type": "message_start", "message": resp_body}),
         (
@@ -516,7 +517,7 @@ def _capture_only_bedrock_eventstream_bytes(path: str) -> bytes:
     return b"".join(_capture_only_bedrock_frame(event) for event in events)
 
 
-def _capture_only_bedrock_frame(payload: dict, event_type: str = "chunk") -> bytes:
+def _capture_only_bedrock_frame(payload: JsonObject, event_type: str = "chunk") -> bytes:
     payload_bytes = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     headers = b"".join(
         _bedrock_eventstream_header(name, value)
@@ -545,7 +546,7 @@ def _bedrock_eventstream_header(name: str, value: str) -> bytes:
 
 async def proxy_handler(request: web.Request) -> web.StreamResponse:
     # Reject requests to unknown paths (scanner/crawler protection)
-    ctx: dict = request.app["trace_ctx"]
+    ctx: JsonObject = request.app["trace_ctx"]
     extra_prefixes: tuple[str, ...] = ctx.get("extra_allowed_path_prefixes", ())
     if not _is_allowed_path(request.path, extra_prefixes):
         log.debug(f"Blocked non-API path: {request.method} {request.path}")
@@ -847,16 +848,16 @@ def _build_record(
     duration_ms: int,
     method: str,
     path_qs: str,
-    req_headers: dict,
-    req_body: dict | None,
+    req_headers: JsonObject,
+    req_body: JsonObject | None,
     status: int,
-    resp_headers: dict,
-    resp_body: dict | None,
-    sse_events: list[dict] | None = None,
+    resp_headers: JsonObject,
+    resp_body: JsonObject | None,
+    sse_events: list[JsonObject] | None = None,
     upstream_base_url: str | None = None,
-) -> dict:
+) -> JsonObject:
     """Build a trace record for a single API call."""
-    record: dict = {
+    record: JsonObject = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "request_id": req_id,
         "turn": turn,

--- a/claude_tap/shared_dashboard.py
+++ b/claude_tap/shared_dashboard.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import aiohttp
 
+from claude_tap.models import JsonObject
 from claude_tap.process_utils import windows_no_console_subprocess_kwargs
 from claude_tap.trace_store import resolve_db_path
 
@@ -110,7 +111,7 @@ async def _dashboard_get_status_and_payload(
     url: str,
     *,
     timeout_seconds: float,
-) -> tuple[int | None, dict | None]:
+) -> tuple[int | None, JsonObject | None]:
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -128,7 +129,7 @@ async def _dashboard_get_status_and_payload(
         return None, None
 
 
-def _dashboard_health_matches_current_instance(payload: dict | None) -> bool:
+def _dashboard_health_matches_current_instance(payload: JsonObject | None) -> bool:
     return bool(
         payload
         and payload.get("ok") is True
@@ -410,7 +411,7 @@ def _spawn_dashboard_subprocess(host: str, port: int, output_dir: Path) -> subpr
     if host and host != "127.0.0.1":
         cmd.extend(["--tap-host", host])
 
-    kwargs: dict = {
+    kwargs: JsonObject = {
         "stdin": subprocess.DEVNULL,
         "stdout": subprocess.DEVNULL,
         "stderr": subprocess.DEVNULL,

--- a/claude_tap/shared_dashboard.py
+++ b/claude_tap/shared_dashboard.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import aiohttp
 
-from claude_tap.models import JsonObject
+from claude_tap.models import ProviderPayload
 from claude_tap.process_utils import windows_no_console_subprocess_kwargs
 from claude_tap.trace_store import resolve_db_path
 
@@ -111,7 +111,7 @@ async def _dashboard_get_status_and_payload(
     url: str,
     *,
     timeout_seconds: float,
-) -> tuple[int | None, JsonObject | None]:
+) -> tuple[int | None, ProviderPayload | None]:
     timeout = aiohttp.ClientTimeout(total=timeout_seconds)
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
@@ -129,7 +129,7 @@ async def _dashboard_get_status_and_payload(
         return None, None
 
 
-def _dashboard_health_matches_current_instance(payload: JsonObject | None) -> bool:
+def _dashboard_health_matches_current_instance(payload: ProviderPayload | None) -> bool:
     return bool(
         payload
         and payload.get("ok") is True
@@ -411,7 +411,7 @@ def _spawn_dashboard_subprocess(host: str, port: int, output_dir: Path) -> subpr
     if host and host != "127.0.0.1":
         cmd.extend(["--tap-host", host])
 
-    kwargs: JsonObject = {
+    kwargs: ProviderPayload = {
         "stdin": subprocess.DEVNULL,
         "stdout": subprocess.DEVNULL,
         "stderr": subprocess.DEVNULL,

--- a/claude_tap/sse.py
+++ b/claude_tap/sse.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import copy
 import json
 
-from claude_tap.models import JsonObject
+from claude_tap.models import ProviderPayload
 from claude_tap.usage import normalize_usage
 
 
@@ -15,11 +15,11 @@ class SSEReassembler:
 
     def __init__(self, *, store_events: bool = True):
         self._store_events = store_events
-        self.events: list[JsonObject] = []
+        self.events: list[ProviderPayload] = []
         self._buf = b""
         self._current_event: str | None = None
         self._current_data_lines: list[str] = []
-        self._snapshot: JsonObject | None = None
+        self._snapshot: ProviderPayload | None = None
 
     def feed_bytes(self, chunk: bytes):
         self._buf += chunk
@@ -165,7 +165,7 @@ class SSEReassembler:
         except Exception:
             pass
 
-    def _ensure_responses_output(self) -> list:
+    def _ensure_responses_output(self) -> list[ProviderPayload]:
         """Return the snapshot's OpenAI Responses `output` list, creating the
         snapshot and/or the list if a streaming output item arrives before
         response.created."""
@@ -177,7 +177,7 @@ class SSEReassembler:
             self._snapshot["output"] = output
         return output
 
-    def _accumulate_responses_output_item(self, data: JsonObject) -> None:
+    def _accumulate_responses_output_item(self, data: ProviderPayload) -> None:
         """Place an OpenAI Responses output item into the snapshot at its
         output_index. response.output_item.done carries the complete item and
         is authoritative; response.output_item.added seeds a placeholder that
@@ -193,7 +193,7 @@ class SSEReassembler:
             output.append({})
         output[idx] = copy.deepcopy(item)
 
-    def _accumulate_responses_output_text(self, data: JsonObject) -> None:
+    def _accumulate_responses_output_text(self, data: ProviderPayload) -> None:
         """Append a response.output_text.delta to the in-progress message item
         so partial/truncated streams still retain their text even if the
         terminal response.output_item.done never arrives."""
@@ -219,15 +219,15 @@ class SSEReassembler:
             content.append(part)
         part["text"] = (part.get("text") or "") + delta
 
-    def _accumulate_responses_function_arguments(self, data: JsonObject) -> None:
+    def _accumulate_responses_function_arguments(self, data: ProviderPayload) -> None:
         """Append streamed arguments to an in-progress function call item."""
         self._accumulate_responses_tool_delta(data, item_type="function_call", field="arguments")
 
-    def _accumulate_responses_custom_tool_input(self, data: JsonObject) -> None:
+    def _accumulate_responses_custom_tool_input(self, data: ProviderPayload) -> None:
         """Append streamed input to an in-progress custom tool call item."""
         self._accumulate_responses_tool_delta(data, item_type="custom_tool_call", field="input")
 
-    def _accumulate_responses_tool_delta(self, data: JsonObject, *, item_type: str, field: str) -> None:
+    def _accumulate_responses_tool_delta(self, data: ProviderPayload, *, item_type: str, field: str) -> None:
         delta = data.get("delta")
         if not isinstance(delta, str) or not delta:
             return
@@ -242,7 +242,7 @@ class SSEReassembler:
             return
         item[field] = (item.get(field) or "") + delta
 
-    def _merge_responses_terminal(self, data: JsonObject) -> None:
+    def _merge_responses_terminal(self, data: ProviderPayload) -> None:
         """Apply a terminal response.completed / response.done event.
 
         The terminal `response` object carries the final status and usage but
@@ -259,7 +259,7 @@ class SSEReassembler:
             response["output"] = accumulated
         self._snapshot = response
 
-    def _record_responses_error(self, data: JsonObject) -> None:
+    def _record_responses_error(self, data: ProviderPayload) -> None:
         """Capture a stream-level response.error event. It carries no response
         object, so attach the error to the snapshot without discarding output
         already accumulated from response.output_item.* events."""
@@ -272,7 +272,7 @@ class SSEReassembler:
         if self._snapshot.get("status") in (None, "", "queued", "in_progress"):
             self._snapshot["status"] = "failed"
 
-    def _content_block_for_delta(self, idx: int, delta: JsonObject) -> JsonObject | None:
+    def _content_block_for_delta(self, idx: int, delta: ProviderPayload) -> ProviderPayload | None:
         if not isinstance(idx, int) or idx < 0:
             idx = 0
         if "content" not in self._snapshot:
@@ -291,14 +291,14 @@ class SSEReassembler:
             block.update(self._empty_content_block_for_delta(delta))
         return block
 
-    def _empty_content_block_for_delta(self, delta: JsonObject) -> JsonObject:
+    def _empty_content_block_for_delta(self, delta: ProviderPayload) -> ProviderPayload:
         if delta.get("type") == "thinking_delta":
             return {"type": "thinking", "thinking": ""}
         if delta.get("type") == "input_json_delta":
             return {"type": "tool_use", "id": "", "name": "", "input": {}}
         return {"type": "text", "text": ""}
 
-    def _accumulate_chat_completion_chunk(self, data: JsonObject) -> None:
+    def _accumulate_chat_completion_chunk(self, data: ProviderPayload) -> None:
         choices = data.get("choices") or []
         usage = data.get("usage")
 
@@ -387,7 +387,7 @@ class SSEReassembler:
         if isinstance(choice_usage, dict):
             self._merge_chat_completion_usage(choice_usage)
 
-    def _gemini_chunk_payload(self, data: JsonObject) -> JsonObject | None:
+    def _gemini_chunk_payload(self, data: ProviderPayload) -> ProviderPayload | None:
         if self._is_gemini_chunk(data):
             return data
         response = data.get("response")
@@ -395,10 +395,10 @@ class SSEReassembler:
             return response
         return None
 
-    def _is_gemini_chunk(self, data: JsonObject) -> bool:
+    def _is_gemini_chunk(self, data: ProviderPayload) -> bool:
         return "candidates" in data or "usageMetadata" in data
 
-    def _accumulate_gemini_chunk(self, data: JsonObject) -> None:
+    def _accumulate_gemini_chunk(self, data: ProviderPayload) -> None:
         if self._snapshot is None or not isinstance(self._snapshot.get("candidates"), list):
             self._snapshot = {"candidates": []}
 
@@ -420,7 +420,7 @@ class SSEReassembler:
 
         self._snapshot["content"] = self._gemini_content_blocks()
 
-    def _merge_gemini_candidate(self, position: int, candidate: JsonObject) -> None:
+    def _merge_gemini_candidate(self, position: int, candidate: ProviderPayload) -> None:
         idx = candidate.get("index")
         if not isinstance(idx, int) or idx < 0:
             idx = position
@@ -440,7 +440,7 @@ class SSEReassembler:
             else:
                 target[key] = copy.deepcopy(value)
 
-    def _merge_gemini_candidate_content(self, candidate: JsonObject, incoming: JsonObject) -> None:
+    def _merge_gemini_candidate_content(self, candidate: ProviderPayload, incoming: ProviderPayload) -> None:
         content = candidate.get("content")
         if not isinstance(content, dict):
             content = {}
@@ -460,7 +460,7 @@ class SSEReassembler:
             if isinstance(part, dict):
                 self._append_gemini_part(parts, part)
 
-    def _append_gemini_part(self, parts: list, part: JsonObject) -> None:
+    def _append_gemini_part(self, parts: list[ProviderPayload], part: ProviderPayload) -> None:
         if self._is_mergeable_gemini_text_part(part):
             previous = parts[-1] if parts else None
             if (
@@ -473,13 +473,13 @@ class SSEReassembler:
                 return
         parts.append(copy.deepcopy(part))
 
-    def _is_mergeable_gemini_text_part(self, part: JsonObject) -> bool:
+    def _is_mergeable_gemini_text_part(self, part: ProviderPayload) -> bool:
         if not isinstance(part.get("text"), str):
             return False
         return set(part).issubset({"text", "thought"})
 
-    def _gemini_content_blocks(self) -> list[JsonObject]:
-        content: list[JsonObject] = []
+    def _gemini_content_blocks(self) -> list[ProviderPayload]:
+        content: list[ProviderPayload] = []
         for candidate in self._snapshot.get("candidates") or []:
             if not isinstance(candidate, dict):
                 continue
@@ -506,7 +506,7 @@ class SSEReassembler:
                     )
         return content
 
-    def _append_mergeable_content_block(self, content: list[JsonObject], block: JsonObject) -> None:
+    def _append_mergeable_content_block(self, content: list[ProviderPayload], block: ProviderPayload) -> None:
         previous = content[-1] if content else None
         if isinstance(previous, dict) and previous.get("type") == block.get("type"):
             if block.get("type") == "thinking":
@@ -517,7 +517,7 @@ class SSEReassembler:
                 return
         content.append(block)
 
-    def _mirror_tool_call_to_content(self, idx: int, tc: JsonObject) -> None:
+    def _mirror_tool_call_to_content(self, idx: int, tc: ProviderPayload) -> None:
         """Sync one accumulated tool_call into the `content` array as a
         tool_use block. content always has a text block, and may also have a
         leading thinking block, so tool_use blocks live after those mirrors."""
@@ -541,7 +541,7 @@ class SSEReassembler:
                 # input (or {}) until a complete JSON arrives.
                 pass
 
-    def _chat_completion_text_block(self) -> JsonObject:
+    def _chat_completion_text_block(self) -> ProviderPayload:
         content = self._snapshot["content"]
         for block in content:
             if block.get("type") == "text":
@@ -550,7 +550,7 @@ class SSEReassembler:
         content.append(block)
         return block
 
-    def _chat_completion_thinking_block(self, *, create: bool) -> JsonObject | None:
+    def _chat_completion_thinking_block(self, *, create: bool) -> ProviderPayload | None:
         content = self._snapshot["content"]
         for block in content:
             if block.get("type") == "thinking":
@@ -566,7 +566,7 @@ class SSEReassembler:
         if block is not None:
             block["thinking"] = reasoning
 
-    def _merge_chat_completion_reasoning_details(self, msg: JsonObject, details) -> str:
+    def _merge_chat_completion_reasoning_details(self, msg: ProviderPayload, details) -> str:
         """Merge MiniMax reasoning_details buffers and return display text."""
         if not isinstance(details, list):
             return ""
@@ -592,12 +592,12 @@ class SSEReassembler:
         ]
         return "\n\n".join(texts)
 
-    def _merge_chat_completion_usage(self, usage: JsonObject) -> None:
+    def _merge_chat_completion_usage(self, usage: ProviderPayload) -> None:
         """Merge an OpenAI-shape usage dict into the snapshot, exposing both
         prompt/completion and input/output token names for downstream code."""
         self._snapshot["usage"] = normalize_usage(usage)
 
-    def reconstruct(self) -> JsonObject | None:
+    def reconstruct(self) -> ProviderPayload | None:
         if self._snapshot is None:
             return None
         return self._snapshot

--- a/claude_tap/sse.py
+++ b/claude_tap/sse.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import copy
 import json
 
+from claude_tap.models import JsonObject
 from claude_tap.usage import normalize_usage
 
 
@@ -14,11 +15,11 @@ class SSEReassembler:
 
     def __init__(self, *, store_events: bool = True):
         self._store_events = store_events
-        self.events: list[dict] = []
+        self.events: list[JsonObject] = []
         self._buf = b""
         self._current_event: str | None = None
         self._current_data_lines: list[str] = []
-        self._snapshot: dict | None = None
+        self._snapshot: JsonObject | None = None
 
     def feed_bytes(self, chunk: bytes):
         self._buf += chunk
@@ -176,7 +177,7 @@ class SSEReassembler:
             self._snapshot["output"] = output
         return output
 
-    def _accumulate_responses_output_item(self, data: dict) -> None:
+    def _accumulate_responses_output_item(self, data: JsonObject) -> None:
         """Place an OpenAI Responses output item into the snapshot at its
         output_index. response.output_item.done carries the complete item and
         is authoritative; response.output_item.added seeds a placeholder that
@@ -192,7 +193,7 @@ class SSEReassembler:
             output.append({})
         output[idx] = copy.deepcopy(item)
 
-    def _accumulate_responses_output_text(self, data: dict) -> None:
+    def _accumulate_responses_output_text(self, data: JsonObject) -> None:
         """Append a response.output_text.delta to the in-progress message item
         so partial/truncated streams still retain their text even if the
         terminal response.output_item.done never arrives."""
@@ -218,15 +219,15 @@ class SSEReassembler:
             content.append(part)
         part["text"] = (part.get("text") or "") + delta
 
-    def _accumulate_responses_function_arguments(self, data: dict) -> None:
+    def _accumulate_responses_function_arguments(self, data: JsonObject) -> None:
         """Append streamed arguments to an in-progress function call item."""
         self._accumulate_responses_tool_delta(data, item_type="function_call", field="arguments")
 
-    def _accumulate_responses_custom_tool_input(self, data: dict) -> None:
+    def _accumulate_responses_custom_tool_input(self, data: JsonObject) -> None:
         """Append streamed input to an in-progress custom tool call item."""
         self._accumulate_responses_tool_delta(data, item_type="custom_tool_call", field="input")
 
-    def _accumulate_responses_tool_delta(self, data: dict, *, item_type: str, field: str) -> None:
+    def _accumulate_responses_tool_delta(self, data: JsonObject, *, item_type: str, field: str) -> None:
         delta = data.get("delta")
         if not isinstance(delta, str) or not delta:
             return
@@ -241,7 +242,7 @@ class SSEReassembler:
             return
         item[field] = (item.get(field) or "") + delta
 
-    def _merge_responses_terminal(self, data: dict) -> None:
+    def _merge_responses_terminal(self, data: JsonObject) -> None:
         """Apply a terminal response.completed / response.done event.
 
         The terminal `response` object carries the final status and usage but
@@ -258,7 +259,7 @@ class SSEReassembler:
             response["output"] = accumulated
         self._snapshot = response
 
-    def _record_responses_error(self, data: dict) -> None:
+    def _record_responses_error(self, data: JsonObject) -> None:
         """Capture a stream-level response.error event. It carries no response
         object, so attach the error to the snapshot without discarding output
         already accumulated from response.output_item.* events."""
@@ -271,7 +272,7 @@ class SSEReassembler:
         if self._snapshot.get("status") in (None, "", "queued", "in_progress"):
             self._snapshot["status"] = "failed"
 
-    def _content_block_for_delta(self, idx: int, delta: dict) -> dict | None:
+    def _content_block_for_delta(self, idx: int, delta: JsonObject) -> JsonObject | None:
         if not isinstance(idx, int) or idx < 0:
             idx = 0
         if "content" not in self._snapshot:
@@ -290,14 +291,14 @@ class SSEReassembler:
             block.update(self._empty_content_block_for_delta(delta))
         return block
 
-    def _empty_content_block_for_delta(self, delta: dict) -> dict:
+    def _empty_content_block_for_delta(self, delta: JsonObject) -> JsonObject:
         if delta.get("type") == "thinking_delta":
             return {"type": "thinking", "thinking": ""}
         if delta.get("type") == "input_json_delta":
             return {"type": "tool_use", "id": "", "name": "", "input": {}}
         return {"type": "text", "text": ""}
 
-    def _accumulate_chat_completion_chunk(self, data: dict) -> None:
+    def _accumulate_chat_completion_chunk(self, data: JsonObject) -> None:
         choices = data.get("choices") or []
         usage = data.get("usage")
 
@@ -386,7 +387,7 @@ class SSEReassembler:
         if isinstance(choice_usage, dict):
             self._merge_chat_completion_usage(choice_usage)
 
-    def _gemini_chunk_payload(self, data: dict) -> dict | None:
+    def _gemini_chunk_payload(self, data: JsonObject) -> JsonObject | None:
         if self._is_gemini_chunk(data):
             return data
         response = data.get("response")
@@ -394,10 +395,10 @@ class SSEReassembler:
             return response
         return None
 
-    def _is_gemini_chunk(self, data: dict) -> bool:
+    def _is_gemini_chunk(self, data: JsonObject) -> bool:
         return "candidates" in data or "usageMetadata" in data
 
-    def _accumulate_gemini_chunk(self, data: dict) -> None:
+    def _accumulate_gemini_chunk(self, data: JsonObject) -> None:
         if self._snapshot is None or not isinstance(self._snapshot.get("candidates"), list):
             self._snapshot = {"candidates": []}
 
@@ -419,7 +420,7 @@ class SSEReassembler:
 
         self._snapshot["content"] = self._gemini_content_blocks()
 
-    def _merge_gemini_candidate(self, position: int, candidate: dict) -> None:
+    def _merge_gemini_candidate(self, position: int, candidate: JsonObject) -> None:
         idx = candidate.get("index")
         if not isinstance(idx, int) or idx < 0:
             idx = position
@@ -439,7 +440,7 @@ class SSEReassembler:
             else:
                 target[key] = copy.deepcopy(value)
 
-    def _merge_gemini_candidate_content(self, candidate: dict, incoming: dict) -> None:
+    def _merge_gemini_candidate_content(self, candidate: JsonObject, incoming: JsonObject) -> None:
         content = candidate.get("content")
         if not isinstance(content, dict):
             content = {}
@@ -459,7 +460,7 @@ class SSEReassembler:
             if isinstance(part, dict):
                 self._append_gemini_part(parts, part)
 
-    def _append_gemini_part(self, parts: list, part: dict) -> None:
+    def _append_gemini_part(self, parts: list, part: JsonObject) -> None:
         if self._is_mergeable_gemini_text_part(part):
             previous = parts[-1] if parts else None
             if (
@@ -472,13 +473,13 @@ class SSEReassembler:
                 return
         parts.append(copy.deepcopy(part))
 
-    def _is_mergeable_gemini_text_part(self, part: dict) -> bool:
+    def _is_mergeable_gemini_text_part(self, part: JsonObject) -> bool:
         if not isinstance(part.get("text"), str):
             return False
         return set(part).issubset({"text", "thought"})
 
-    def _gemini_content_blocks(self) -> list[dict]:
-        content: list[dict] = []
+    def _gemini_content_blocks(self) -> list[JsonObject]:
+        content: list[JsonObject] = []
         for candidate in self._snapshot.get("candidates") or []:
             if not isinstance(candidate, dict):
                 continue
@@ -505,7 +506,7 @@ class SSEReassembler:
                     )
         return content
 
-    def _append_mergeable_content_block(self, content: list[dict], block: dict) -> None:
+    def _append_mergeable_content_block(self, content: list[JsonObject], block: JsonObject) -> None:
         previous = content[-1] if content else None
         if isinstance(previous, dict) and previous.get("type") == block.get("type"):
             if block.get("type") == "thinking":
@@ -516,7 +517,7 @@ class SSEReassembler:
                 return
         content.append(block)
 
-    def _mirror_tool_call_to_content(self, idx: int, tc: dict) -> None:
+    def _mirror_tool_call_to_content(self, idx: int, tc: JsonObject) -> None:
         """Sync one accumulated tool_call into the `content` array as a
         tool_use block. content always has a text block, and may also have a
         leading thinking block, so tool_use blocks live after those mirrors."""
@@ -540,7 +541,7 @@ class SSEReassembler:
                 # input (or {}) until a complete JSON arrives.
                 pass
 
-    def _chat_completion_text_block(self) -> dict:
+    def _chat_completion_text_block(self) -> JsonObject:
         content = self._snapshot["content"]
         for block in content:
             if block.get("type") == "text":
@@ -549,7 +550,7 @@ class SSEReassembler:
         content.append(block)
         return block
 
-    def _chat_completion_thinking_block(self, *, create: bool) -> dict | None:
+    def _chat_completion_thinking_block(self, *, create: bool) -> JsonObject | None:
         content = self._snapshot["content"]
         for block in content:
             if block.get("type") == "thinking":
@@ -565,7 +566,7 @@ class SSEReassembler:
         if block is not None:
             block["thinking"] = reasoning
 
-    def _merge_chat_completion_reasoning_details(self, msg: dict, details) -> str:
+    def _merge_chat_completion_reasoning_details(self, msg: JsonObject, details) -> str:
         """Merge MiniMax reasoning_details buffers and return display text."""
         if not isinstance(details, list):
             return ""
@@ -591,12 +592,12 @@ class SSEReassembler:
         ]
         return "\n\n".join(texts)
 
-    def _merge_chat_completion_usage(self, usage: dict) -> None:
+    def _merge_chat_completion_usage(self, usage: JsonObject) -> None:
         """Merge an OpenAI-shape usage dict into the snapshot, exposing both
         prompt/completion and input/output token names for downstream code."""
         self._snapshot["usage"] = normalize_usage(usage)
 
-    def reconstruct(self) -> dict | None:
+    def reconstruct(self) -> JsonObject | None:
         if self._snapshot is None:
             return None
         return self._snapshot

--- a/claude_tap/trace.py
+++ b/claude_tap/trace.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.trace_store import TraceStore, get_trace_store
 from claude_tap.usage import normalize_usage
 
@@ -25,7 +25,7 @@ class TraceWriter:
         self,
         session_id: str,
         live_server: "LiveViewerServer | None" = None,
-        metadata: Map[str, str] | None = None,
+        metadata: dict[str, str] | None = None,
         store: TraceStore | None = None,
     ):
         self.session_id = session_id
@@ -35,7 +35,7 @@ class TraceWriter:
         self.total_output_tokens = 0
         self.total_cache_read_tokens = 0
         self.total_cache_create_tokens = 0
-        self.models_used: Map[str, int] = {}
+        self.models_used: dict[str, int] = {}
         self._live_server = live_server
         self._metadata = metadata or {}
         self._store = store or get_trace_store()
@@ -47,7 +47,7 @@ class TraceWriter:
         self._startup_storage_error: sqlite3.Error | None = None
         self._storage_warning_emitted = False
 
-    async def write(self, record: JsonObject) -> None:
+    async def write(self, record: ProviderPayload) -> None:
         """Write a record and update statistics."""
         async with self._lock:
             self._write_locked(record)
@@ -55,7 +55,7 @@ class TraceWriter:
         if self._live_server:
             await self._live_server.broadcast(record)
 
-    async def write_next_turn(self, record: JsonObject) -> None:
+    async def write_next_turn(self, record: ProviderPayload) -> None:
         """Assign the next trace turn under the writer lock, then write the record."""
         async with self._lock:
             record["turn"] = self.count + 1
@@ -64,7 +64,7 @@ class TraceWriter:
         if self._live_server:
             await self._live_server.broadcast(record)
 
-    def _write_locked(self, record: JsonObject) -> None:
+    def _write_locked(self, record: ProviderPayload) -> None:
         if self._metadata:
             capture = record.get("capture") if isinstance(record.get("capture"), dict) else {}
             record["capture"] = {**self._metadata, **capture}
@@ -98,7 +98,7 @@ class TraceWriter:
         self._storage_warning_emitted = True
         sys.stderr.write(f"claude-tap: trace storage failed; continuing without blocking proxy ({exc})\n")
 
-    def _update_stats(self, record: JsonObject) -> None:
+    def _update_stats(self, record: ProviderPayload) -> None:
         req_body = record.get("request", {}).get("body", {})
         model = req_body.get("model", "unknown") if isinstance(req_body, dict) else "unknown"
         self.models_used[model] = self.models_used.get(model, 0) + 1
@@ -129,7 +129,7 @@ class TraceWriter:
             if isinstance(response.get("error"), str) and response["error"]:
                 self._has_error = True
 
-    def get_summary(self) -> JsonObject:
+    def get_summary(self) -> ProviderPayload:
         """Return a summary of the trace statistics."""
         has_error = self._has_error or (self._has_auxiliary_status_probe_error and not self._has_primary_success)
         return {
@@ -150,7 +150,7 @@ def create_trace_writer(
     store: TraceStore,
     client: str,
     proxy_mode: str,
-    metadata: Map[str, str],
+    metadata: dict[str, str],
     started_at: datetime | None = None,
 ) -> TraceWriter:
     """Create a writer without letting unavailable trace storage block the client."""
@@ -163,7 +163,7 @@ def create_trace_writer(
     return TraceWriter(session_id, live_server=None, metadata=metadata, store=store)
 
 
-def _is_auxiliary_status_probe(record: JsonObject) -> bool:
+def _is_auxiliary_status_probe(record: ProviderPayload) -> bool:
     request = record.get("request")
     path = request.get("path") if isinstance(request, dict) else ""
     if not isinstance(path, str):

--- a/claude_tap/trace.py
+++ b/claude_tap/trace.py
@@ -10,6 +10,7 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from claude_tap.models import JsonObject, Map
 from claude_tap.trace_store import TraceStore, get_trace_store
 from claude_tap.usage import normalize_usage
 
@@ -24,7 +25,7 @@ class TraceWriter:
         self,
         session_id: str,
         live_server: "LiveViewerServer | None" = None,
-        metadata: dict[str, str] | None = None,
+        metadata: Map[str, str] | None = None,
         store: TraceStore | None = None,
     ):
         self.session_id = session_id
@@ -34,7 +35,7 @@ class TraceWriter:
         self.total_output_tokens = 0
         self.total_cache_read_tokens = 0
         self.total_cache_create_tokens = 0
-        self.models_used: dict[str, int] = {}
+        self.models_used: Map[str, int] = {}
         self._live_server = live_server
         self._metadata = metadata or {}
         self._store = store or get_trace_store()
@@ -46,7 +47,7 @@ class TraceWriter:
         self._startup_storage_error: sqlite3.Error | None = None
         self._storage_warning_emitted = False
 
-    async def write(self, record: dict) -> None:
+    async def write(self, record: JsonObject) -> None:
         """Write a record and update statistics."""
         async with self._lock:
             self._write_locked(record)
@@ -54,7 +55,7 @@ class TraceWriter:
         if self._live_server:
             await self._live_server.broadcast(record)
 
-    async def write_next_turn(self, record: dict) -> None:
+    async def write_next_turn(self, record: JsonObject) -> None:
         """Assign the next trace turn under the writer lock, then write the record."""
         async with self._lock:
             record["turn"] = self.count + 1
@@ -63,7 +64,7 @@ class TraceWriter:
         if self._live_server:
             await self._live_server.broadcast(record)
 
-    def _write_locked(self, record: dict) -> None:
+    def _write_locked(self, record: JsonObject) -> None:
         if self._metadata:
             capture = record.get("capture") if isinstance(record.get("capture"), dict) else {}
             record["capture"] = {**self._metadata, **capture}
@@ -97,7 +98,7 @@ class TraceWriter:
         self._storage_warning_emitted = True
         sys.stderr.write(f"claude-tap: trace storage failed; continuing without blocking proxy ({exc})\n")
 
-    def _update_stats(self, record: dict) -> None:
+    def _update_stats(self, record: JsonObject) -> None:
         req_body = record.get("request", {}).get("body", {})
         model = req_body.get("model", "unknown") if isinstance(req_body, dict) else "unknown"
         self.models_used[model] = self.models_used.get(model, 0) + 1
@@ -128,7 +129,7 @@ class TraceWriter:
             if isinstance(response.get("error"), str) and response["error"]:
                 self._has_error = True
 
-    def get_summary(self) -> dict:
+    def get_summary(self) -> JsonObject:
         """Return a summary of the trace statistics."""
         has_error = self._has_error or (self._has_auxiliary_status_probe_error and not self._has_primary_success)
         return {
@@ -149,7 +150,7 @@ def create_trace_writer(
     store: TraceStore,
     client: str,
     proxy_mode: str,
-    metadata: dict[str, str],
+    metadata: Map[str, str],
     started_at: datetime | None = None,
 ) -> TraceWriter:
     """Create a writer without letting unavailable trace storage block the client."""
@@ -162,7 +163,7 @@ def create_trace_writer(
     return TraceWriter(session_id, live_server=None, metadata=metadata, store=store)
 
 
-def _is_auxiliary_status_probe(record: dict) -> bool:
+def _is_auxiliary_status_probe(record: JsonObject) -> bool:
     request = record.get("request")
     path = request.get("path") if isinstance(request, dict) else ""
     if not isinstance(path, str):

--- a/claude_tap/trace_encoding.py
+++ b/claude_tap/trace_encoding.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 
 PROTOBUF_CONTENT_TYPE_TOKENS = (
     "application/proto",
@@ -16,7 +16,7 @@ PROTOBUF_CONTENT_TYPE_TOKENS = (
 _ENCODED_BLOB_ENCODINGS = frozenset({"protobuf", "binary"})
 
 
-def content_type_from_headers(headers: Map[str, object] | None) -> str:
+def content_type_from_headers(headers: ProviderPayload | None) -> str:
     if not headers:
         return ""
     return str(headers.get("Content-Type") or headers.get("content-type") or "")
@@ -37,11 +37,11 @@ def looks_like_binary_text(text: str) -> bool:
     return control / max(len(sample), 1) >= 0.1
 
 
-def is_encoded_blob_body(body: object) -> bool:
+def is_encoded_blob_body(body: ProviderPayload) -> bool:
     return isinstance(body, dict) and body.get("_encoding") in _ENCODED_BLOB_ENCODINGS
 
 
-def parse_request_body_for_trace(body: bytes, headers: Map[str, str] | None = None) -> object:
+def parse_request_body_for_trace(body: bytes, headers: dict[str, str] | None = None) -> ProviderPayload:
     """Parse a request body for trace storage without mutating upstream bytes."""
     if not body:
         return None

--- a/claude_tap/trace_encoding.py
+++ b/claude_tap/trace_encoding.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
-from typing import Any
+
+from claude_tap.models import Map
 
 PROTOBUF_CONTENT_TYPE_TOKENS = (
     "application/proto",
@@ -16,7 +16,7 @@ PROTOBUF_CONTENT_TYPE_TOKENS = (
 _ENCODED_BLOB_ENCODINGS = frozenset({"protobuf", "binary"})
 
 
-def content_type_from_headers(headers: Mapping[str, Any] | None) -> str:
+def content_type_from_headers(headers: Map[str, object] | None) -> str:
     if not headers:
         return ""
     return str(headers.get("Content-Type") or headers.get("content-type") or "")
@@ -37,11 +37,11 @@ def looks_like_binary_text(text: str) -> bool:
     return control / max(len(sample), 1) >= 0.1
 
 
-def is_encoded_blob_body(body: Any) -> bool:
+def is_encoded_blob_body(body: object) -> bool:
     return isinstance(body, dict) and body.get("_encoding") in _ENCODED_BLOB_ENCODINGS
 
 
-def parse_request_body_for_trace(body: bytes, headers: Mapping[str, str] | None = None) -> object:
+def parse_request_body_for_trace(body: bytes, headers: Map[str, str] | None = None) -> object:
     """Parse a request body for trace storage without mutating upstream bytes."""
     if not body:
         return None

--- a/claude_tap/trace_store.py
+++ b/claude_tap/trace_store.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Iterator
 
 from claude_tap.compact_trace import (
     BLOB_KIND_JSON,
@@ -27,6 +27,7 @@ from claude_tap.compact_trace import (
     json_blob_payload,
     make_blob_ref,
 )
+from claude_tap.models import Map
 
 DB_FILENAME = "traces.sqlite3"
 SCHEMA_VERSION = 4
@@ -125,7 +126,7 @@ class TraceStore:
             conn.commit()
         return session_id
 
-    def append_record(self, session_id: str, record: dict[str, Any]) -> None:
+    def append_record(self, session_id: str, record: Map[str, object]) -> None:
         """Append one API trace record to a session."""
         with self._write_access() as conn:
             next_index = self._next_record_index(conn, session_id)
@@ -160,7 +161,7 @@ class TraceStore:
             self._refresh_summary_after_append(conn, session_id, record, record_count)
             conn.commit()
 
-    def replace_record_payloads(self, session_id: str, records: list[dict[str, Any]]) -> int:
+    def replace_record_payloads(self, session_id: str, records: list[Map[str, object]]) -> int:
         """Rewrite stored record payloads without changing ``record_count``.
 
         Used to backfill reconstructed fields (for example Cursor request
@@ -224,7 +225,7 @@ class TraceStore:
             )
             conn.commit()
 
-    def finalize_session(self, session_id: str, summary: dict[str, Any] | None = None) -> None:
+    def finalize_session(self, session_id: str, summary: Map[str, object] | None = None) -> None:
         """Mark a session complete and persist its summary."""
         with self._write_access() as conn:
             row = conn.execute(
@@ -367,7 +368,7 @@ class TraceStore:
             ).fetchone()
         return int(row["total"] or 0) if row is not None else 0
 
-    def get_session_aggregates(self, query: SessionQuery | None = None) -> dict[str, Any]:
+    def get_session_aggregates(self, query: SessionQuery | None = None) -> Map[str, object]:
         where_sql, params = self._session_where(query)
         with self._read_connect() as conn:
             row = conn.execute(
@@ -405,7 +406,7 @@ class TraceStore:
                 """
             ).fetchall()
 
-    def delete_sessions(self, session_ids: list[str]) -> dict[str, int | list[str]]:
+    def delete_sessions(self, session_ids: list[str]) -> Map[str, int | list[str]]:
         """Delete multiple trace sessions and their dependent records/logs."""
         unique_ids = list(dict.fromkeys(session_id for session_id in session_ids if session_id))
         if not unique_ids:
@@ -505,7 +506,7 @@ class TraceStore:
         session_id: str,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Map[str, object]]:
         with self._read_connect() as conn:
             return self._load_records_with_connection(
                 conn,
@@ -521,7 +522,7 @@ class TraceStore:
         *,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[dict[str, Any]]:
+    ) -> list[Map[str, object]]:
         offset = max(0, offset)
         params: list[object] = [session_id]
         limit_sql = ""
@@ -543,7 +544,7 @@ class TraceStore:
         ).fetchall()
         return self._rows_to_records(conn, rows)
 
-    def load_boundary_records(self, session_id: str) -> list[dict[str, Any]]:
+    def load_boundary_records(self, session_id: str) -> list[Map[str, object]]:
         """Load the first and last records for a session without reading everything."""
         with self._read_connect() as conn:
             first = conn.execute(
@@ -572,7 +573,7 @@ class TraceStore:
                 return self._rows_to_records(conn, [first])
             return self._rows_to_records(conn, [first, last])
 
-    def load_records_for_date(self, date_key: str) -> list[dict[str, Any]]:
+    def load_records_for_date(self, date_key: str) -> list[Map[str, object]]:
         """Load all records for sessions on a given date in one query."""
         with self._read_connect() as conn:
             if date_key == "legacy":
@@ -600,7 +601,7 @@ class TraceStore:
                 raise ValueError("Invalid date format")
             return self._rows_to_records(conn, rows)
 
-    def load_logs(self, session_id: str) -> list[dict[str, str]]:
+    def load_logs(self, session_id: str) -> list[Map[str, str]]:
         with self._read_connect() as conn:
             rows = conn.execute(
                 """
@@ -641,7 +642,7 @@ class TraceStore:
                 lines.append(message)
         return "\n".join(lines) + ("\n" if lines else "")
 
-    def store_summary(self, session_id: str, summary: dict[str, Any]) -> None:
+    def store_summary(self, session_id: str, summary: Map[str, object]) -> None:
         with self._write_access() as conn:
             conn.execute(
                 """
@@ -658,14 +659,14 @@ class TraceStore:
             )
             conn.commit()
 
-    def dashboard_snapshot(self) -> dict[str, tuple[int, str]]:
+    def dashboard_snapshot(self) -> Map[str, tuple[int, str]]:
         """Return session_id -> (record_count, status) for dashboard refresh detection.
 
         Log heartbeats bump ``updated_at`` without changing the conversation, so
         that timestamp is intentionally excluded. Otherwise a busy logger would
         force the dashboard to refresh every poll.
         """
-        snapshot: dict[str, tuple[int, str]] = {}
+        snapshot: Map[str, tuple[int, str]] = {}
         with self._read_connect() as conn:
             rows = conn.execute(
                 """
@@ -695,7 +696,7 @@ class TraceStore:
 
     def delete_sessions_by_date(
         self, date_key: str, *, protected_session_ids: set[str] | None = None
-    ) -> dict[str, int | str]:
+    ) -> Map[str, int | str]:
         protected = protected_session_ids or set()
         with self._write_access() as conn:
             if date_key == "legacy":
@@ -721,7 +722,7 @@ class TraceStore:
             "skipped_files": len(skipped),
         }
 
-    def delete_session(self, session_id: str) -> dict[str, int | str]:
+    def delete_session(self, session_id: str) -> Map[str, int | str]:
         """Delete one trace session and its dependent records/logs."""
         with self._write_access() as conn:
             row = conn.execute("SELECT id FROM sessions WHERE id = ?", (session_id,)).fetchone()
@@ -829,9 +830,9 @@ class TraceStore:
         legacy_source_key: str,
         rel_path: str,
         trace_path: Path,
-        records: list[dict[str, Any]],
+        records: list[Map[str, object]],
         logs: list[str],
-        manifest_entry: dict[str, Any],
+        manifest_entry: Map[str, object],
     ) -> str | None:
         session_id = str(uuid.uuid4())
         stat = trace_path.stat()
@@ -958,7 +959,7 @@ class TraceStore:
         self,
         conn: sqlite3.Connection,
         session_id: str,
-        record: dict[str, Any],
+        record: Map[str, object],
         record_count: int,
     ) -> None:
         from claude_tap.dashboard import (
@@ -1358,11 +1359,11 @@ class TraceStore:
             return "", []
         return f"WHERE {' AND '.join(clauses)}", params
 
-    def _encode_record(self, conn: sqlite3.Connection, session_id: str, record: dict[str, Any]) -> str:
+    def _encode_record(self, conn: sqlite3.Connection, session_id: str, record: Map[str, object]) -> str:
         compact_record, refs = compact_record_blobs(
             record, lambda value: self._store_json_blob(conn, session_id, value)
         )
-        payload: dict[str, Any] = compact_record
+        payload: Map[str, object] = compact_record
         if refs:
             payload = {
                 COMPACT_RECORD_MARKER: {
@@ -1374,7 +1375,7 @@ class TraceStore:
             }
         return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
-    def _store_json_blob(self, conn: sqlite3.Connection, session_id: str, value: Any) -> dict[str, Any] | None:
+    def _store_json_blob(self, conn: sqlite3.Connection, session_id: str, value: object) -> Map[str, object] | None:
         payload_json, size_bytes, hash_value = json_blob_payload(value)
         if size_bytes < MIN_BLOB_BYTES:
             return None
@@ -1387,9 +1388,9 @@ class TraceStore:
         )
         return make_blob_ref(hash_value, size_bytes)
 
-    def _rows_to_records(self, conn: sqlite3.Connection, rows: list[sqlite3.Row]) -> list[dict[str, Any]]:
-        records: list[dict[str, Any]] = []
-        blob_cache: dict[tuple[str, str], Any] = {}
+    def _rows_to_records(self, conn: sqlite3.Connection, rows: list[sqlite3.Row]) -> list[Map[str, object]]:
+        records: list[Map[str, object]] = []
+        blob_cache: Map[tuple[str, str], object] = {}
         for row in rows:
             try:
                 record = self._decode_record_payload(conn, row["session_id"], row["payload_json"], blob_cache)
@@ -1404,8 +1405,8 @@ class TraceStore:
         conn: sqlite3.Connection,
         session_id: str,
         payload_json: str,
-        blob_cache: dict[tuple[str, str], Any],
-    ) -> dict[str, Any] | None:
+        blob_cache: Map[tuple[str, str], object],
+    ) -> Map[str, object] | None:
         payload = json.loads(payload_json)
         return decode_compact_record_payload(
             payload,
@@ -1416,9 +1417,9 @@ class TraceStore:
         self,
         conn: sqlite3.Connection,
         session_id: str,
-        ref: dict[str, Any],
-        blob_cache: dict[tuple[str, str], Any],
-    ) -> Any:
+        ref: Map[str, object],
+        blob_cache: Map[tuple[str, str], object],
+    ) -> object:
         hash_value = ref["hash"]
         cache_key = (session_id, hash_value)
         if cache_key not in blob_cache:
@@ -1432,7 +1433,7 @@ class TraceStore:
         return blob_cache[cache_key]
 
 
-def _try_lock_file_exclusive(lock_file: Any) -> None:
+def _try_lock_file_exclusive(lock_file: object) -> None:
     lock_file.seek(0)
     if os.name == "nt":
         import msvcrt
@@ -1445,7 +1446,7 @@ def _try_lock_file_exclusive(lock_file: Any) -> None:
     fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
 
 
-def _unlock_file(lock_file: Any) -> None:
+def _unlock_file(lock_file: object) -> None:
     lock_file.seek(0)
     if os.name == "nt":
         import msvcrt
@@ -1470,8 +1471,8 @@ def _legacy_source_key(output_dir: Path) -> str:
     return sha256(str(output_dir.resolve()).encode("utf-8")).hexdigest()[:16]
 
 
-def _read_jsonl_file(path: Path) -> list[dict[str, Any]]:
-    records: list[dict[str, Any]] = []
+def _read_jsonl_file(path: Path) -> list[Map[str, object]]:
+    records: list[Map[str, object]] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
@@ -1496,7 +1497,7 @@ def _read_log_file(path: Path) -> list[str]:
         return []
 
 
-def _manifest_entries_by_rel_path(output_dir: Path) -> dict[str, dict[str, Any]]:
+def _manifest_entries_by_rel_path(output_dir: Path) -> Map[str, Map[str, object]]:
     manifest_path = output_dir / ".cloudtap-manifest.json"
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -1504,7 +1505,7 @@ def _manifest_entries_by_rel_path(output_dir: Path) -> dict[str, dict[str, Any]]
         return {}
     if not isinstance(manifest, dict):
         return {}
-    entries: dict[str, dict[str, Any]] = {}
+    entries: Map[str, Map[str, object]] = {}
     for entry in manifest.get("traces", []):
         if not isinstance(entry, dict):
             continue
@@ -1514,14 +1515,14 @@ def _manifest_entries_by_rel_path(output_dir: Path) -> dict[str, dict[str, Any]]
     return entries
 
 
-def _manifest_entry_for_rel_path(output_dir: Path, rel_path: str) -> dict[str, Any]:
+def _manifest_entry_for_rel_path(output_dir: Path, rel_path: str) -> Map[str, object]:
     return _manifest_entries_by_rel_path(output_dir).get(rel_path, {})
 
 
 def _legacy_started_at(
     trace_path: Path,
-    records: list[dict[str, Any]],
-    manifest_entry: dict[str, Any],
+    records: list[Map[str, object]],
+    manifest_entry: Map[str, object],
     mtime: float,
 ) -> str:
     if records:

--- a/claude_tap/trace_store.py
+++ b/claude_tap/trace_store.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from hashlib import sha256
 from pathlib import Path
-from typing import Iterator
+from typing import IO, Iterator
 
 from claude_tap.compact_trace import (
     BLOB_KIND_JSON,
@@ -27,7 +27,7 @@ from claude_tap.compact_trace import (
     json_blob_payload,
     make_blob_ref,
 )
-from claude_tap.models import Map
+from claude_tap.models import ProviderPayload
 
 DB_FILENAME = "traces.sqlite3"
 SCHEMA_VERSION = 4
@@ -126,7 +126,7 @@ class TraceStore:
             conn.commit()
         return session_id
 
-    def append_record(self, session_id: str, record: Map[str, object]) -> None:
+    def append_record(self, session_id: str, record: ProviderPayload) -> None:
         """Append one API trace record to a session."""
         with self._write_access() as conn:
             next_index = self._next_record_index(conn, session_id)
@@ -161,7 +161,7 @@ class TraceStore:
             self._refresh_summary_after_append(conn, session_id, record, record_count)
             conn.commit()
 
-    def replace_record_payloads(self, session_id: str, records: list[Map[str, object]]) -> int:
+    def replace_record_payloads(self, session_id: str, records: list[ProviderPayload]) -> int:
         """Rewrite stored record payloads without changing ``record_count``.
 
         Used to backfill reconstructed fields (for example Cursor request
@@ -225,7 +225,7 @@ class TraceStore:
             )
             conn.commit()
 
-    def finalize_session(self, session_id: str, summary: Map[str, object] | None = None) -> None:
+    def finalize_session(self, session_id: str, summary: ProviderPayload | None = None) -> None:
         """Mark a session complete and persist its summary."""
         with self._write_access() as conn:
             row = conn.execute(
@@ -368,7 +368,7 @@ class TraceStore:
             ).fetchone()
         return int(row["total"] or 0) if row is not None else 0
 
-    def get_session_aggregates(self, query: SessionQuery | None = None) -> Map[str, object]:
+    def get_session_aggregates(self, query: SessionQuery | None = None) -> ProviderPayload:
         where_sql, params = self._session_where(query)
         with self._read_connect() as conn:
             row = conn.execute(
@@ -406,7 +406,7 @@ class TraceStore:
                 """
             ).fetchall()
 
-    def delete_sessions(self, session_ids: list[str]) -> Map[str, int | list[str]]:
+    def delete_sessions(self, session_ids: list[str]) -> dict[str, int | list[str]]:
         """Delete multiple trace sessions and their dependent records/logs."""
         unique_ids = list(dict.fromkeys(session_id for session_id in session_ids if session_id))
         if not unique_ids:
@@ -506,7 +506,7 @@ class TraceStore:
         session_id: str,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[Map[str, object]]:
+    ) -> list[ProviderPayload]:
         with self._read_connect() as conn:
             return self._load_records_with_connection(
                 conn,
@@ -522,9 +522,9 @@ class TraceStore:
         *,
         limit: int | None = None,
         offset: int = 0,
-    ) -> list[Map[str, object]]:
+    ) -> list[ProviderPayload]:
         offset = max(0, offset)
-        params: list[object] = [session_id]
+        params: list[str | int] = [session_id]
         limit_sql = ""
         if limit is not None:
             limit_sql = " LIMIT ? OFFSET ?"
@@ -544,7 +544,7 @@ class TraceStore:
         ).fetchall()
         return self._rows_to_records(conn, rows)
 
-    def load_boundary_records(self, session_id: str) -> list[Map[str, object]]:
+    def load_boundary_records(self, session_id: str) -> list[ProviderPayload]:
         """Load the first and last records for a session without reading everything."""
         with self._read_connect() as conn:
             first = conn.execute(
@@ -573,7 +573,7 @@ class TraceStore:
                 return self._rows_to_records(conn, [first])
             return self._rows_to_records(conn, [first, last])
 
-    def load_records_for_date(self, date_key: str) -> list[Map[str, object]]:
+    def load_records_for_date(self, date_key: str) -> list[ProviderPayload]:
         """Load all records for sessions on a given date in one query."""
         with self._read_connect() as conn:
             if date_key == "legacy":
@@ -601,7 +601,7 @@ class TraceStore:
                 raise ValueError("Invalid date format")
             return self._rows_to_records(conn, rows)
 
-    def load_logs(self, session_id: str) -> list[Map[str, str]]:
+    def load_logs(self, session_id: str) -> list[dict[str, str]]:
         with self._read_connect() as conn:
             rows = conn.execute(
                 """
@@ -642,7 +642,7 @@ class TraceStore:
                 lines.append(message)
         return "\n".join(lines) + ("\n" if lines else "")
 
-    def store_summary(self, session_id: str, summary: Map[str, object]) -> None:
+    def store_summary(self, session_id: str, summary: ProviderPayload) -> None:
         with self._write_access() as conn:
             conn.execute(
                 """
@@ -659,14 +659,14 @@ class TraceStore:
             )
             conn.commit()
 
-    def dashboard_snapshot(self) -> Map[str, tuple[int, str]]:
+    def dashboard_snapshot(self) -> dict[str, tuple[int, str]]:
         """Return session_id -> (record_count, status) for dashboard refresh detection.
 
         Log heartbeats bump ``updated_at`` without changing the conversation, so
         that timestamp is intentionally excluded. Otherwise a busy logger would
         force the dashboard to refresh every poll.
         """
-        snapshot: Map[str, tuple[int, str]] = {}
+        snapshot: dict[str, tuple[int, str]] = {}
         with self._read_connect() as conn:
             rows = conn.execute(
                 """
@@ -696,7 +696,7 @@ class TraceStore:
 
     def delete_sessions_by_date(
         self, date_key: str, *, protected_session_ids: set[str] | None = None
-    ) -> Map[str, int | str]:
+    ) -> dict[str, int | str]:
         protected = protected_session_ids or set()
         with self._write_access() as conn:
             if date_key == "legacy":
@@ -722,7 +722,7 @@ class TraceStore:
             "skipped_files": len(skipped),
         }
 
-    def delete_session(self, session_id: str) -> Map[str, int | str]:
+    def delete_session(self, session_id: str) -> dict[str, int | str]:
         """Delete one trace session and its dependent records/logs."""
         with self._write_access() as conn:
             row = conn.execute("SELECT id FROM sessions WHERE id = ?", (session_id,)).fetchone()
@@ -830,9 +830,9 @@ class TraceStore:
         legacy_source_key: str,
         rel_path: str,
         trace_path: Path,
-        records: list[Map[str, object]],
+        records: list[ProviderPayload],
         logs: list[str],
-        manifest_entry: Map[str, object],
+        manifest_entry: ProviderPayload,
     ) -> str | None:
         session_id = str(uuid.uuid4())
         stat = trace_path.stat()
@@ -959,7 +959,7 @@ class TraceStore:
         self,
         conn: sqlite3.Connection,
         session_id: str,
-        record: Map[str, object],
+        record: ProviderPayload,
         record_count: int,
     ) -> None:
         from claude_tap.dashboard import (
@@ -1299,12 +1299,12 @@ class TraceStore:
     def _escape_like(value: str) -> str:
         return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
-    def _session_where(self, query: SessionQuery | None) -> tuple[str, list[object]]:
+    def _session_where(self, query: SessionQuery | None) -> tuple[str, list[str | int]]:
         if query is None:
             return "", []
 
         clauses: list[str] = []
-        params: list[object] = []
+        params: list[str | int] = []
         if query.date:
             if query.date == "legacy":
                 clauses.append("(date_key = 'legacy' OR legacy_rel_path NOT LIKE '%/%')")
@@ -1359,11 +1359,11 @@ class TraceStore:
             return "", []
         return f"WHERE {' AND '.join(clauses)}", params
 
-    def _encode_record(self, conn: sqlite3.Connection, session_id: str, record: Map[str, object]) -> str:
+    def _encode_record(self, conn: sqlite3.Connection, session_id: str, record: ProviderPayload) -> str:
         compact_record, refs = compact_record_blobs(
             record, lambda value: self._store_json_blob(conn, session_id, value)
         )
-        payload: Map[str, object] = compact_record
+        payload: ProviderPayload = compact_record
         if refs:
             payload = {
                 COMPACT_RECORD_MARKER: {
@@ -1375,7 +1375,9 @@ class TraceStore:
             }
         return json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
 
-    def _store_json_blob(self, conn: sqlite3.Connection, session_id: str, value: object) -> Map[str, object] | None:
+    def _store_json_blob(
+        self, conn: sqlite3.Connection, session_id: str, value: ProviderPayload
+    ) -> ProviderPayload | None:
         payload_json, size_bytes, hash_value = json_blob_payload(value)
         if size_bytes < MIN_BLOB_BYTES:
             return None
@@ -1388,9 +1390,9 @@ class TraceStore:
         )
         return make_blob_ref(hash_value, size_bytes)
 
-    def _rows_to_records(self, conn: sqlite3.Connection, rows: list[sqlite3.Row]) -> list[Map[str, object]]:
-        records: list[Map[str, object]] = []
-        blob_cache: Map[tuple[str, str], object] = {}
+    def _rows_to_records(self, conn: sqlite3.Connection, rows: list[sqlite3.Row]) -> list[ProviderPayload]:
+        records: list[ProviderPayload] = []
+        blob_cache: dict[tuple[str, str], ProviderPayload] = {}
         for row in rows:
             try:
                 record = self._decode_record_payload(conn, row["session_id"], row["payload_json"], blob_cache)
@@ -1405,8 +1407,8 @@ class TraceStore:
         conn: sqlite3.Connection,
         session_id: str,
         payload_json: str,
-        blob_cache: Map[tuple[str, str], object],
-    ) -> Map[str, object] | None:
+        blob_cache: dict[tuple[str, str], ProviderPayload],
+    ) -> ProviderPayload | None:
         payload = json.loads(payload_json)
         return decode_compact_record_payload(
             payload,
@@ -1417,9 +1419,9 @@ class TraceStore:
         self,
         conn: sqlite3.Connection,
         session_id: str,
-        ref: Map[str, object],
-        blob_cache: Map[tuple[str, str], object],
-    ) -> object:
+        ref: ProviderPayload,
+        blob_cache: dict[tuple[str, str], ProviderPayload],
+    ) -> ProviderPayload:
         hash_value = ref["hash"]
         cache_key = (session_id, hash_value)
         if cache_key not in blob_cache:
@@ -1433,7 +1435,7 @@ class TraceStore:
         return blob_cache[cache_key]
 
 
-def _try_lock_file_exclusive(lock_file: object) -> None:
+def _try_lock_file_exclusive(lock_file: IO[str]) -> None:
     lock_file.seek(0)
     if os.name == "nt":
         import msvcrt
@@ -1446,7 +1448,7 @@ def _try_lock_file_exclusive(lock_file: object) -> None:
     fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
 
 
-def _unlock_file(lock_file: object) -> None:
+def _unlock_file(lock_file: IO[str]) -> None:
     lock_file.seek(0)
     if os.name == "nt":
         import msvcrt
@@ -1471,8 +1473,8 @@ def _legacy_source_key(output_dir: Path) -> str:
     return sha256(str(output_dir.resolve()).encode("utf-8")).hexdigest()[:16]
 
 
-def _read_jsonl_file(path: Path) -> list[Map[str, object]]:
-    records: list[Map[str, object]] = []
+def _read_jsonl_file(path: Path) -> list[ProviderPayload]:
+    records: list[ProviderPayload] = []
     try:
         lines = path.read_text(encoding="utf-8").splitlines()
     except OSError:
@@ -1497,7 +1499,7 @@ def _read_log_file(path: Path) -> list[str]:
         return []
 
 
-def _manifest_entries_by_rel_path(output_dir: Path) -> Map[str, Map[str, object]]:
+def _manifest_entries_by_rel_path(output_dir: Path) -> dict[str, ProviderPayload]:
     manifest_path = output_dir / ".cloudtap-manifest.json"
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -1505,7 +1507,7 @@ def _manifest_entries_by_rel_path(output_dir: Path) -> Map[str, Map[str, object]
         return {}
     if not isinstance(manifest, dict):
         return {}
-    entries: Map[str, Map[str, object]] = {}
+    entries: dict[str, ProviderPayload] = {}
     for entry in manifest.get("traces", []):
         if not isinstance(entry, dict):
             continue
@@ -1515,14 +1517,14 @@ def _manifest_entries_by_rel_path(output_dir: Path) -> Map[str, Map[str, object]
     return entries
 
 
-def _manifest_entry_for_rel_path(output_dir: Path, rel_path: str) -> Map[str, object]:
+def _manifest_entry_for_rel_path(output_dir: Path, rel_path: str) -> ProviderPayload:
     return _manifest_entries_by_rel_path(output_dir).get(rel_path, {})
 
 
 def _legacy_started_at(
     trace_path: Path,
-    records: list[Map[str, object]],
-    manifest_entry: Map[str, object],
+    records: list[ProviderPayload],
+    manifest_entry: ProviderPayload,
     mtime: float,
 ) -> str:
     if records:
@@ -1545,7 +1547,7 @@ def _parse_log_message(line: str) -> str:
     return match.group(1) if match else line
 
 
-def _parse_iso_datetime(value: object) -> datetime | None:
+def _parse_iso_datetime(value: str | None) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
     try:
@@ -1557,7 +1559,7 @@ def _parse_iso_datetime(value: object) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
-def _is_stale_active_session(updated_at: object, now: datetime) -> bool:
+def _is_stale_active_session(updated_at: str | None, now: datetime) -> bool:
     updated = _parse_iso_datetime(updated_at)
     return updated is not None and updated <= now - STALE_ACTIVE_SESSION_AFTER
 
@@ -1572,7 +1574,7 @@ def _stale_active_final_status(row: sqlite3.Row) -> str:
     return "empty" if int(row["record_count"] or 0) == 0 else "complete"
 
 
-def _stale_active_summary_json(summary_json: object, session_id: str, status: str) -> str | None:
+def _stale_active_summary_json(summary_json: str | None, session_id: str, status: str) -> str | None:
     if not summary_json:
         return None
     try:
@@ -1587,9 +1589,9 @@ def _stale_active_summary_json(summary_json: object, session_id: str, status: st
     return json.dumps(summary, ensure_ascii=False, separators=(",", ":"))
 
 
-def _int_or_none(value: object) -> int | None:
+def _int_or_none(value: int | None) -> int | None:
     return value if isinstance(value, int) else None
 
 
-def _str_or_none(value: object) -> str | None:
+def _str_or_none(value: str | None) -> str | None:
     return value if isinstance(value, str) else None

--- a/claude_tap/usage.py
+++ b/claude_tap/usage.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from claude_tap.models import JsonObject
+
 
 def _missing_or_zero(value: object) -> bool:
     return value is None or value == 0
 
 
-def normalize_usage(usage: object) -> dict:
+def normalize_usage(usage: object) -> JsonObject:
     """Return usage with provider-specific token fields mapped to shared names."""
     if not isinstance(usage, dict):
         return {}

--- a/claude_tap/usage.py
+++ b/claude_tap/usage.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from claude_tap.models import JsonObject
+from claude_tap.models import ProviderPayload
 
 
-def _missing_or_zero(value: object) -> bool:
+def _missing_or_zero(value: int | float | str | bool | None) -> bool:
     return value is None or value == 0
 
 
-def normalize_usage(usage: object) -> JsonObject:
+def normalize_usage(usage: ProviderPayload) -> ProviderPayload:
     """Return usage with provider-specific token fields mapped to shared names."""
     if not isinstance(usage, dict):
         return {}

--- a/claude_tap/viewer.py
+++ b/claude_tap/viewer.py
@@ -9,7 +9,7 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from claude_tap.compact_trace import COMPACT_TRACE_MARKER, build_compact_trace_bundle, is_compact_trace_bundle
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.sse import SSEReassembler
 from claude_tap.usage import normalize_usage
 
@@ -43,7 +43,7 @@ VIEWER_SCRIPT_TEMPLATE_ANCHOR = "<!-- CLAUDE_TAP_VIEWER_SCRIPT -->"
 VIEWER_SCRIPT_ANCHOR = "<script>\nconst $ = s =>"
 
 
-def _load_viewer_i18n() -> Map[str, Map[str, str]]:
+def _load_viewer_i18n() -> dict[str, dict[str, str]]:
     data = json.loads(VIEWER_I18N_PATH.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("viewer_i18n.json must contain a JSON object.")
@@ -79,7 +79,7 @@ def _read_viewer_template() -> str:
     return html
 
 
-def _iter_response_events(resp: JsonObject) -> list[JsonObject]:
+def _iter_response_events(resp: ProviderPayload) -> list[ProviderPayload]:
     """Return stream events from SSE or WebSocket traces."""
     if not isinstance(resp, dict):
         return []
@@ -92,7 +92,7 @@ def _iter_response_events(resp: JsonObject) -> list[JsonObject]:
     return []
 
 
-def _iter_request_events(req: JsonObject) -> list[JsonObject]:
+def _iter_request_events(req: ProviderPayload) -> list[ProviderPayload]:
     """Return request-side WebSocket events when a raw trace stores them."""
     if not isinstance(req, dict):
         return []
@@ -102,14 +102,14 @@ def _iter_request_events(req: JsonObject) -> list[JsonObject]:
     return []
 
 
-def _event_type(event: JsonObject) -> str:
+def _event_type(event: ProviderPayload) -> str:
     if not isinstance(event, dict):
         return ""
     value = event.get("event") or event.get("type")
     return value if isinstance(value, str) else ""
 
 
-def _event_payload(event: JsonObject) -> JsonObject | None:
+def _event_payload(event: ProviderPayload) -> ProviderPayload | None:
     if not isinstance(event, dict):
         return None
     payload = event.get("data", event)
@@ -121,14 +121,14 @@ def _event_payload(event: JsonObject) -> JsonObject | None:
     return payload if isinstance(payload, dict) else None
 
 
-def _first_bool(*values: object) -> bool | None:
+def _first_bool(*values: ProviderPayload) -> bool | None:
     for value in values:
         if isinstance(value, bool):
             return value
     return None
 
 
-def _response_payload_from_event(event: JsonObject) -> JsonObject:
+def _response_payload_from_event(event: ProviderPayload) -> ProviderPayload:
     data = _event_payload(event)
     if not isinstance(data, dict):
         return {}
@@ -138,14 +138,14 @@ def _response_payload_from_event(event: JsonObject) -> JsonObject:
     return data
 
 
-def _last_response_payload_for_event(events: list[JsonObject], event_type: str) -> JsonObject:
+def _last_response_payload_for_event(events: list[ProviderPayload], event_type: str) -> ProviderPayload:
     for event in reversed(events):
         if _event_type(event) == event_type:
             return _response_payload_from_event(event)
     return {}
 
 
-def _response_output_count_from_events(events: list[JsonObject]) -> int:
+def _response_output_count_from_events(events: list[ProviderPayload]) -> int:
     completed = _last_response_payload_for_event(events, "response.completed")
     output = completed.get("output")
     if isinstance(output, list):
@@ -153,7 +153,7 @@ def _response_output_count_from_events(events: list[JsonObject]) -> int:
     return sum(1 for event in events if _event_type(event) == "response.output_item.done")
 
 
-def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
+def _decode_bedrock_eventstream_events(body: ProviderPayload) -> list[ProviderPayload]:
     """Extract normalized stream events from a decoded AWS EventStream body.
 
     Bedrock streaming responses are binary AWS EventStream frames. Legacy
@@ -185,7 +185,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
     if not any(f'"{key}"' in body for key in stream_event_keys):
         return []
 
-    def _converse_event_payload(payload: JsonObject) -> tuple[str | None, JsonObject | None]:
+    def _converse_event_payload(payload: ProviderPayload) -> tuple[str | None, ProviderPayload | None]:
         message_start = payload.get("messageStart")
         if isinstance(message_start, dict):
             return "message_start", {
@@ -200,7 +200,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
         if isinstance(block_start, dict):
             start = block_start.get("start") if isinstance(block_start.get("start"), dict) else {}
             tool_use = start.get("toolUse") if isinstance(start, dict) else None
-            block: JsonObject = {}
+            block: ProviderPayload = {}
             if isinstance(tool_use, dict):
                 block = {
                     "type": "tool_use",
@@ -216,7 +216,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
         block_delta = payload.get("contentBlockDelta")
         if isinstance(block_delta, dict):
             delta = block_delta.get("delta") if isinstance(block_delta.get("delta"), dict) else {}
-            normalized_delta: JsonObject = {}
+            normalized_delta: ProviderPayload = {}
             if isinstance(delta.get("text"), str):
                 normalized_delta = {"type": "text_delta", "text": delta["text"]}
             elif isinstance(delta.get("reasoningContent"), dict):
@@ -254,7 +254,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
 
         return None, None
 
-    def _event_payload_from_frame(frame: JsonObject) -> tuple[str | None, JsonObject | None]:
+    def _event_payload_from_frame(frame: ProviderPayload) -> tuple[str | None, ProviderPayload | None]:
         encoded = frame.get("bytes")
         if not isinstance(encoded, str):
             chunk = frame.get("chunk")
@@ -294,7 +294,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
                 return event_type, payload
         return None, None
 
-    events: list[JsonObject] = []
+    events: list[ProviderPayload] = []
     decoder = json.JSONDecoder()
     pos = 0
     while True:
@@ -346,7 +346,7 @@ def _normalize_record_for_viewer(record_json: str) -> str:
     return json.dumps(record, ensure_ascii=False, separators=(",", ":"))
 
 
-def _parse_function_call_arguments(arguments: object) -> object:
+def _parse_function_call_arguments(arguments: ProviderPayload) -> ProviderPayload:
     if isinstance(arguments, str):
         try:
             return json.loads(arguments)
@@ -357,11 +357,11 @@ def _parse_function_call_arguments(arguments: object) -> object:
     return arguments
 
 
-def _parse_sse_data_frames(body: object) -> list[JsonObject]:
+def _parse_sse_data_frames(body: ProviderPayload) -> list[ProviderPayload]:
     if not isinstance(body, str) or "data:" not in body:
         return []
 
-    events: list[JsonObject] = []
+    events: list[ProviderPayload] = []
     data_lines: list[str] = []
     for line in body.splitlines():
         if line.startswith("data:"):
@@ -393,32 +393,32 @@ def _parse_sse_data_frames(body: object) -> list[JsonObject]:
     return events
 
 
-def _looks_like_gemini_request(value: object) -> bool:
+def _looks_like_gemini_request(value: ProviderPayload) -> bool:
     return isinstance(value, dict) and (
         isinstance(value.get("contents"), list) or isinstance(value.get("systemInstruction"), dict)
     )
 
 
-def _gemini_request(body: JsonObject) -> JsonObject:
+def _gemini_request(body: ProviderPayload) -> ProviderPayload:
     req = body.get("request")
     if _looks_like_gemini_request(req):
         return req
     return body if _looks_like_gemini_request(body) else {}
 
 
-def _is_gemini_request_body(body: JsonObject) -> bool:
+def _is_gemini_request_body(body: ProviderPayload) -> bool:
     req = _gemini_request(body)
     return _looks_like_gemini_request(req)
 
 
-def _model_from_path(path: object) -> str:
+def _model_from_path(path: str | None) -> str:
     if not isinstance(path, str):
         return ""
     match = re.search(r"/models?/([^:?/]+)", path)
     return match.group(1) if match else ""
 
 
-def _gemini_text_from_parts(parts: object) -> str:
+def _gemini_text_from_parts(parts: ProviderPayload) -> str:
     if not isinstance(parts, list):
         return ""
     return "\n".join(
@@ -426,14 +426,14 @@ def _gemini_text_from_parts(parts: object) -> str:
     )
 
 
-def _extract_gemini_system(body: JsonObject) -> str:
+def _extract_gemini_system(body: ProviderPayload) -> str:
     instr = _gemini_request(body).get("systemInstruction")
     if not isinstance(instr, dict):
         return ""
     return _gemini_text_from_parts(instr.get("parts")).strip()
 
 
-def _gemini_function_response_content(resp: JsonObject) -> str:
+def _gemini_function_response_content(resp: ProviderPayload) -> str:
     payload = resp.get("response")
     if isinstance(payload, dict) and "output" in payload:
         output = payload["output"]
@@ -444,8 +444,8 @@ def _gemini_function_response_content(resp: JsonObject) -> str:
     return json.dumps(output, ensure_ascii=False)
 
 
-def _gemini_part_blocks(part: JsonObject) -> list[JsonObject]:
-    blocks: list[JsonObject] = []
+def _gemini_part_blocks(part: ProviderPayload) -> list[ProviderPayload]:
+    blocks: list[ProviderPayload] = []
     text = part.get("text")
     if isinstance(text, str) and text.strip():
         if part.get("thought") is True:
@@ -476,22 +476,22 @@ def _gemini_part_blocks(part: JsonObject) -> list[JsonObject]:
     return blocks
 
 
-def _gemini_role(role: object) -> str:
+def _gemini_role(role: str | None) -> str:
     if role == "model":
         return "assistant"
     return role if isinstance(role, str) and role else "user"
 
 
-def _extract_gemini_request_messages(body: JsonObject) -> list[JsonObject]:
+def _extract_gemini_request_messages(body: ProviderPayload) -> list[ProviderPayload]:
     contents = _gemini_request(body).get("contents")
     if not isinstance(contents, list):
         return []
 
-    messages: list[JsonObject] = []
+    messages: list[ProviderPayload] = []
     for content in contents:
         if not isinstance(content, dict):
             continue
-        blocks: list[JsonObject] = []
+        blocks: list[ProviderPayload] = []
         for part in content.get("parts") or []:
             if isinstance(part, dict):
                 blocks.extend(_gemini_part_blocks(part))
@@ -504,12 +504,12 @@ def _extract_gemini_request_messages(body: JsonObject) -> list[JsonObject]:
     return messages
 
 
-def _extract_gemini_tools(body: JsonObject) -> list[JsonObject]:
+def _extract_gemini_tools(body: ProviderPayload) -> list[ProviderPayload]:
     tools = _gemini_request(body).get("tools")
     if not isinstance(tools, list):
         return []
 
-    normalized: list[JsonObject] = []
+    normalized: list[ProviderPayload] = []
     for tool_group in tools:
         if not isinstance(tool_group, dict):
             continue
@@ -529,7 +529,7 @@ def _extract_gemini_tools(body: JsonObject) -> list[JsonObject]:
     return normalized
 
 
-def _gemini_payloads_from_response_body(body: object) -> list[JsonObject]:
+def _gemini_payloads_from_response_body(body: ProviderPayload) -> list[ProviderPayload]:
     if isinstance(body, str):
         return [event["data"] for event in _parse_sse_data_frames(body) if isinstance(event.get("data"), dict)]
     if isinstance(body, dict):
@@ -537,11 +537,11 @@ def _gemini_payloads_from_response_body(body: object) -> list[JsonObject]:
     return []
 
 
-def _extract_gemini_response_output(body: object) -> JsonObject | None:
+def _extract_gemini_response_output(body: ProviderPayload) -> ProviderPayload | None:
     payloads = _gemini_payloads_from_response_body(body)
-    content: list[JsonObject] = []
+    content: list[ProviderPayload] = []
 
-    def append_mergeable_block(block: Map[str, str]) -> None:
+    def append_mergeable_block(block: dict[str, str]) -> None:
         previous = content[-1] if content else None
         if previous and previous.get("type") == block.get("type"):
             if block.get("type") == "thinking":
@@ -592,8 +592,8 @@ def _extract_gemini_response_output(body: object) -> JsonObject | None:
     return {"content": content} if content else None
 
 
-def _extract_gemini_response_usage(body: object) -> JsonObject:
-    usage: JsonObject = {}
+def _extract_gemini_response_usage(body: ProviderPayload) -> ProviderPayload:
+    usage: ProviderPayload = {}
     for payload in _gemini_payloads_from_response_body(body):
         response = payload.get("response") if isinstance(payload.get("response"), dict) else payload
         if not isinstance(response, dict):
@@ -604,14 +604,14 @@ def _extract_gemini_response_usage(body: object) -> JsonObject:
     return normalize_usage(usage)
 
 
-def _extract_gemini_response_tool_names(body: object) -> list[str]:
+def _extract_gemini_response_tool_names(body: ProviderPayload) -> list[str]:
     output = _extract_gemini_response_output(body)
     if not output:
         return []
     return [block.get("name", "") for block in output["content"] if block.get("type") == "tool_use"]
 
 
-def _tool_search_output_content(item: JsonObject) -> str:
+def _tool_search_output_content(item: ProviderPayload) -> str:
     names: list[str] = []
     tools = item.get("tools")
     if isinstance(tools, list):
@@ -639,7 +639,7 @@ def _tool_search_output_content(item: JsonObject) -> str:
     return json.dumps(item, ensure_ascii=False)
 
 
-def _response_call_tool_name(item: JsonObject) -> str:
+def _response_call_tool_name(item: ProviderPayload) -> str:
     item_type = item.get("type")
     if item_type == "tool_search_call":
         return "tool_search"
@@ -651,12 +651,12 @@ def _response_call_tool_name(item: JsonObject) -> str:
     return ""
 
 
-def _is_response_call_item(item: JsonObject) -> bool:
+def _is_response_call_item(item: ProviderPayload) -> bool:
     item_type = item.get("type")
     return isinstance(item_type, str) and item_type.endswith("_call")
 
 
-def _response_call_input(item: JsonObject) -> object:
+def _response_call_input(item: ProviderPayload) -> ProviderPayload:
     if "arguments" in item:
         return _parse_function_call_arguments(item.get("arguments"))
     return {
@@ -664,12 +664,12 @@ def _response_call_input(item: JsonObject) -> object:
     }
 
 
-def _is_response_tool_result_item(item: JsonObject) -> bool:
+def _is_response_tool_result_item(item: ProviderPayload) -> bool:
     item_type = item.get("type")
     return item_type == "tool_search_output" or (isinstance(item_type, str) and item_type.endswith("_call_output"))
 
 
-def _response_tool_result_content(item: JsonObject) -> str:
+def _response_tool_result_content(item: ProviderPayload) -> str:
     if item.get("type") == "tool_search_output":
         return _tool_search_output_content(item)
     if "output" in item:
@@ -683,7 +683,7 @@ def _response_tool_result_content(item: JsonObject) -> str:
     )
 
 
-def _extract_request_messages(body: JsonObject) -> list[JsonObject]:
+def _extract_request_messages(body: ProviderPayload) -> list[ProviderPayload]:
     if not isinstance(body, dict):
         return []
     msgs = body.get("messages")
@@ -728,7 +728,7 @@ def _extract_request_messages(body: JsonObject) -> list[JsonObject]:
     return normalized
 
 
-def _extract_response_tool_names(output: list) -> list[str]:
+def _extract_response_tool_names(output: list[ProviderPayload]) -> list[str]:
     names: list[str] = []
     if not isinstance(output, list):
         return names
@@ -744,7 +744,7 @@ def _extract_response_tool_names(output: list) -> list[str]:
     return names
 
 
-def _extract_response_tool_names_from_output_item_events(events: list[JsonObject]) -> list[str]:
+def _extract_response_tool_names_from_output_item_events(events: list[ProviderPayload]) -> list[str]:
     names: list[str] = []
     for ev in events:
         if _event_type(ev) != "response.output_item.done":
@@ -758,11 +758,11 @@ def _extract_response_tool_names_from_output_item_events(events: list[JsonObject
     return names
 
 
-def _dict_or_empty(value: object) -> JsonObject:
+def _dict_or_empty(value: ProviderPayload) -> ProviderPayload:
     return value if isinstance(value, dict) else {}
 
 
-def _tool_display_name(tool: JsonObject) -> str:
+def _tool_display_name(tool: ProviderPayload) -> str:
     for value in (
         tool.get("name"),
         (tool.get("function") or {}).get("name") if isinstance(tool.get("function"), dict) else None,
@@ -832,7 +832,7 @@ def _clean_session_user_text(text: str) -> str:
     return re.sub(r"^\[Image #\d+\]\s*", "", value, flags=re.IGNORECASE).strip()
 
 
-def _session_text_from_content(content: object) -> str:
+def _session_text_from_content(content: ProviderPayload) -> str:
     if content is None:
         return ""
     if isinstance(content, str):
@@ -858,7 +858,7 @@ def _session_text_from_content(content: object) -> str:
     return ""
 
 
-def _is_tool_result_only_message(message: JsonObject) -> bool:
+def _is_tool_result_only_message(message: ProviderPayload) -> bool:
     content = message.get("content")
     if not isinstance(content, list) or not content:
         return False
@@ -867,7 +867,7 @@ def _is_tool_result_only_message(message: JsonObject) -> bool:
     )
 
 
-def _first_user_text(messages: list[JsonObject]) -> str:
+def _first_user_text(messages: list[ProviderPayload]) -> str:
     for message in messages:
         if message.get("role") != "user" or _is_tool_result_only_message(message):
             continue
@@ -877,7 +877,7 @@ def _first_user_text(messages: list[JsonObject]) -> str:
     return ""
 
 
-def _latest_user_text(messages: list[JsonObject]) -> str:
+def _latest_user_text(messages: list[ProviderPayload]) -> str:
     for message in reversed(messages):
         if message.get("role") != "user" or _is_tool_result_only_message(message):
             continue
@@ -887,7 +887,7 @@ def _latest_user_text(messages: list[JsonObject]) -> str:
     return ""
 
 
-def _extract_metadata(record_json: str) -> JsonObject | None:
+def _extract_metadata(record_json: str) -> ProviderPayload | None:
     """Extract sidebar-relevant metadata from a raw JSON record string."""
     try:
         r = json.loads(record_json)
@@ -896,7 +896,7 @@ def _extract_metadata(record_json: str) -> JsonObject | None:
     return _extract_metadata_from_record(r)
 
 
-def _extract_metadata_from_record(r: JsonObject) -> JsonObject | None:
+def _extract_metadata_from_record(r: ProviderPayload) -> ProviderPayload | None:
     """Extract sidebar metadata from a raw record without embedding full payloads.
 
     The returned dict contains only fields needed for sidebar rendering,
@@ -1057,7 +1057,7 @@ def _generate_html_viewer(
             )
             return
 
-    records: list[JsonObject] = []
+    records: list[ProviderPayload] = []
     if trace_path.exists():
         with open(trace_path, "r", encoding="utf-8") as f:
             for line in f:
@@ -1078,7 +1078,7 @@ def _generate_html_viewer(
 
 
 def _generate_html_viewer_from_compact_bundle(
-    compact_bundle: JsonObject,
+    compact_bundle: ProviderPayload,
     html_path: Path,
     *,
     display_trace_path: str | Path,
@@ -1113,7 +1113,7 @@ def _generate_html_viewer_from_compact_bundle(
 
 
 def _generate_html_viewer_from_metadata(
-    metadata: list[JsonObject],
+    metadata: list[ProviderPayload],
     html_path: Path,
     *,
     display_trace_path: str | Path,

--- a/claude_tap/viewer.py
+++ b/claude_tap/viewer.py
@@ -9,6 +9,7 @@ from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 from claude_tap.compact_trace import COMPACT_TRACE_MARKER, build_compact_trace_bundle, is_compact_trace_bundle
+from claude_tap.models import JsonObject, Map
 from claude_tap.sse import SSEReassembler
 from claude_tap.usage import normalize_usage
 
@@ -42,7 +43,7 @@ VIEWER_SCRIPT_TEMPLATE_ANCHOR = "<!-- CLAUDE_TAP_VIEWER_SCRIPT -->"
 VIEWER_SCRIPT_ANCHOR = "<script>\nconst $ = s =>"
 
 
-def _load_viewer_i18n() -> dict[str, dict[str, str]]:
+def _load_viewer_i18n() -> Map[str, Map[str, str]]:
     data = json.loads(VIEWER_I18N_PATH.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("viewer_i18n.json must contain a JSON object.")
@@ -78,7 +79,7 @@ def _read_viewer_template() -> str:
     return html
 
 
-def _iter_response_events(resp: dict) -> list[dict]:
+def _iter_response_events(resp: JsonObject) -> list[JsonObject]:
     """Return stream events from SSE or WebSocket traces."""
     if not isinstance(resp, dict):
         return []
@@ -91,7 +92,7 @@ def _iter_response_events(resp: dict) -> list[dict]:
     return []
 
 
-def _iter_request_events(req: dict) -> list[dict]:
+def _iter_request_events(req: JsonObject) -> list[JsonObject]:
     """Return request-side WebSocket events when a raw trace stores them."""
     if not isinstance(req, dict):
         return []
@@ -101,14 +102,14 @@ def _iter_request_events(req: dict) -> list[dict]:
     return []
 
 
-def _event_type(event: dict) -> str:
+def _event_type(event: JsonObject) -> str:
     if not isinstance(event, dict):
         return ""
     value = event.get("event") or event.get("type")
     return value if isinstance(value, str) else ""
 
 
-def _event_payload(event: dict) -> dict | None:
+def _event_payload(event: JsonObject) -> JsonObject | None:
     if not isinstance(event, dict):
         return None
     payload = event.get("data", event)
@@ -127,7 +128,7 @@ def _first_bool(*values: object) -> bool | None:
     return None
 
 
-def _response_payload_from_event(event: dict) -> dict:
+def _response_payload_from_event(event: JsonObject) -> JsonObject:
     data = _event_payload(event)
     if not isinstance(data, dict):
         return {}
@@ -137,14 +138,14 @@ def _response_payload_from_event(event: dict) -> dict:
     return data
 
 
-def _last_response_payload_for_event(events: list[dict], event_type: str) -> dict:
+def _last_response_payload_for_event(events: list[JsonObject], event_type: str) -> JsonObject:
     for event in reversed(events):
         if _event_type(event) == event_type:
             return _response_payload_from_event(event)
     return {}
 
 
-def _response_output_count_from_events(events: list[dict]) -> int:
+def _response_output_count_from_events(events: list[JsonObject]) -> int:
     completed = _last_response_payload_for_event(events, "response.completed")
     output = completed.get("output")
     if isinstance(output, list):
@@ -152,7 +153,7 @@ def _response_output_count_from_events(events: list[dict]) -> int:
     return sum(1 for event in events if _event_type(event) == "response.output_item.done")
 
 
-def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
+def _decode_bedrock_eventstream_events(body: object) -> list[JsonObject]:
     """Extract normalized stream events from a decoded AWS EventStream body.
 
     Bedrock streaming responses are binary AWS EventStream frames. Legacy
@@ -184,7 +185,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
     if not any(f'"{key}"' in body for key in stream_event_keys):
         return []
 
-    def _converse_event_payload(payload: dict) -> tuple[str | None, dict | None]:
+    def _converse_event_payload(payload: JsonObject) -> tuple[str | None, JsonObject | None]:
         message_start = payload.get("messageStart")
         if isinstance(message_start, dict):
             return "message_start", {
@@ -199,7 +200,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
         if isinstance(block_start, dict):
             start = block_start.get("start") if isinstance(block_start.get("start"), dict) else {}
             tool_use = start.get("toolUse") if isinstance(start, dict) else None
-            block: dict = {}
+            block: JsonObject = {}
             if isinstance(tool_use, dict):
                 block = {
                     "type": "tool_use",
@@ -215,7 +216,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
         block_delta = payload.get("contentBlockDelta")
         if isinstance(block_delta, dict):
             delta = block_delta.get("delta") if isinstance(block_delta.get("delta"), dict) else {}
-            normalized_delta: dict = {}
+            normalized_delta: JsonObject = {}
             if isinstance(delta.get("text"), str):
                 normalized_delta = {"type": "text_delta", "text": delta["text"]}
             elif isinstance(delta.get("reasoningContent"), dict):
@@ -253,7 +254,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
 
         return None, None
 
-    def _event_payload_from_frame(frame: dict) -> tuple[str | None, dict | None]:
+    def _event_payload_from_frame(frame: JsonObject) -> tuple[str | None, JsonObject | None]:
         encoded = frame.get("bytes")
         if not isinstance(encoded, str):
             chunk = frame.get("chunk")
@@ -293,7 +294,7 @@ def _decode_bedrock_eventstream_events(body: object) -> list[dict]:
                 return event_type, payload
         return None, None
 
-    events: list[dict] = []
+    events: list[JsonObject] = []
     decoder = json.JSONDecoder()
     pos = 0
     while True:
@@ -356,11 +357,11 @@ def _parse_function_call_arguments(arguments: object) -> object:
     return arguments
 
 
-def _parse_sse_data_frames(body: object) -> list[dict]:
+def _parse_sse_data_frames(body: object) -> list[JsonObject]:
     if not isinstance(body, str) or "data:" not in body:
         return []
 
-    events: list[dict] = []
+    events: list[JsonObject] = []
     data_lines: list[str] = []
     for line in body.splitlines():
         if line.startswith("data:"):
@@ -398,14 +399,14 @@ def _looks_like_gemini_request(value: object) -> bool:
     )
 
 
-def _gemini_request(body: dict) -> dict:
+def _gemini_request(body: JsonObject) -> JsonObject:
     req = body.get("request")
     if _looks_like_gemini_request(req):
         return req
     return body if _looks_like_gemini_request(body) else {}
 
 
-def _is_gemini_request_body(body: dict) -> bool:
+def _is_gemini_request_body(body: JsonObject) -> bool:
     req = _gemini_request(body)
     return _looks_like_gemini_request(req)
 
@@ -425,14 +426,14 @@ def _gemini_text_from_parts(parts: object) -> str:
     )
 
 
-def _extract_gemini_system(body: dict) -> str:
+def _extract_gemini_system(body: JsonObject) -> str:
     instr = _gemini_request(body).get("systemInstruction")
     if not isinstance(instr, dict):
         return ""
     return _gemini_text_from_parts(instr.get("parts")).strip()
 
 
-def _gemini_function_response_content(resp: dict) -> str:
+def _gemini_function_response_content(resp: JsonObject) -> str:
     payload = resp.get("response")
     if isinstance(payload, dict) and "output" in payload:
         output = payload["output"]
@@ -443,8 +444,8 @@ def _gemini_function_response_content(resp: dict) -> str:
     return json.dumps(output, ensure_ascii=False)
 
 
-def _gemini_part_blocks(part: dict) -> list[dict]:
-    blocks: list[dict] = []
+def _gemini_part_blocks(part: JsonObject) -> list[JsonObject]:
+    blocks: list[JsonObject] = []
     text = part.get("text")
     if isinstance(text, str) and text.strip():
         if part.get("thought") is True:
@@ -481,16 +482,16 @@ def _gemini_role(role: object) -> str:
     return role if isinstance(role, str) and role else "user"
 
 
-def _extract_gemini_request_messages(body: dict) -> list[dict]:
+def _extract_gemini_request_messages(body: JsonObject) -> list[JsonObject]:
     contents = _gemini_request(body).get("contents")
     if not isinstance(contents, list):
         return []
 
-    messages: list[dict] = []
+    messages: list[JsonObject] = []
     for content in contents:
         if not isinstance(content, dict):
             continue
-        blocks: list[dict] = []
+        blocks: list[JsonObject] = []
         for part in content.get("parts") or []:
             if isinstance(part, dict):
                 blocks.extend(_gemini_part_blocks(part))
@@ -503,12 +504,12 @@ def _extract_gemini_request_messages(body: dict) -> list[dict]:
     return messages
 
 
-def _extract_gemini_tools(body: dict) -> list[dict]:
+def _extract_gemini_tools(body: JsonObject) -> list[JsonObject]:
     tools = _gemini_request(body).get("tools")
     if not isinstance(tools, list):
         return []
 
-    normalized: list[dict] = []
+    normalized: list[JsonObject] = []
     for tool_group in tools:
         if not isinstance(tool_group, dict):
             continue
@@ -528,7 +529,7 @@ def _extract_gemini_tools(body: dict) -> list[dict]:
     return normalized
 
 
-def _gemini_payloads_from_response_body(body: object) -> list[dict]:
+def _gemini_payloads_from_response_body(body: object) -> list[JsonObject]:
     if isinstance(body, str):
         return [event["data"] for event in _parse_sse_data_frames(body) if isinstance(event.get("data"), dict)]
     if isinstance(body, dict):
@@ -536,11 +537,11 @@ def _gemini_payloads_from_response_body(body: object) -> list[dict]:
     return []
 
 
-def _extract_gemini_response_output(body: object) -> dict | None:
+def _extract_gemini_response_output(body: object) -> JsonObject | None:
     payloads = _gemini_payloads_from_response_body(body)
-    content: list[dict] = []
+    content: list[JsonObject] = []
 
-    def append_mergeable_block(block: dict[str, str]) -> None:
+    def append_mergeable_block(block: Map[str, str]) -> None:
         previous = content[-1] if content else None
         if previous and previous.get("type") == block.get("type"):
             if block.get("type") == "thinking":
@@ -591,8 +592,8 @@ def _extract_gemini_response_output(body: object) -> dict | None:
     return {"content": content} if content else None
 
 
-def _extract_gemini_response_usage(body: object) -> dict:
-    usage: dict = {}
+def _extract_gemini_response_usage(body: object) -> JsonObject:
+    usage: JsonObject = {}
     for payload in _gemini_payloads_from_response_body(body):
         response = payload.get("response") if isinstance(payload.get("response"), dict) else payload
         if not isinstance(response, dict):
@@ -610,7 +611,7 @@ def _extract_gemini_response_tool_names(body: object) -> list[str]:
     return [block.get("name", "") for block in output["content"] if block.get("type") == "tool_use"]
 
 
-def _tool_search_output_content(item: dict) -> str:
+def _tool_search_output_content(item: JsonObject) -> str:
     names: list[str] = []
     tools = item.get("tools")
     if isinstance(tools, list):
@@ -638,7 +639,7 @@ def _tool_search_output_content(item: dict) -> str:
     return json.dumps(item, ensure_ascii=False)
 
 
-def _response_call_tool_name(item: dict) -> str:
+def _response_call_tool_name(item: JsonObject) -> str:
     item_type = item.get("type")
     if item_type == "tool_search_call":
         return "tool_search"
@@ -650,12 +651,12 @@ def _response_call_tool_name(item: dict) -> str:
     return ""
 
 
-def _is_response_call_item(item: dict) -> bool:
+def _is_response_call_item(item: JsonObject) -> bool:
     item_type = item.get("type")
     return isinstance(item_type, str) and item_type.endswith("_call")
 
 
-def _response_call_input(item: dict) -> object:
+def _response_call_input(item: JsonObject) -> object:
     if "arguments" in item:
         return _parse_function_call_arguments(item.get("arguments"))
     return {
@@ -663,12 +664,12 @@ def _response_call_input(item: dict) -> object:
     }
 
 
-def _is_response_tool_result_item(item: dict) -> bool:
+def _is_response_tool_result_item(item: JsonObject) -> bool:
     item_type = item.get("type")
     return item_type == "tool_search_output" or (isinstance(item_type, str) and item_type.endswith("_call_output"))
 
 
-def _response_tool_result_content(item: dict) -> str:
+def _response_tool_result_content(item: JsonObject) -> str:
     if item.get("type") == "tool_search_output":
         return _tool_search_output_content(item)
     if "output" in item:
@@ -682,7 +683,7 @@ def _response_tool_result_content(item: dict) -> str:
     )
 
 
-def _extract_request_messages(body: dict) -> list[dict]:
+def _extract_request_messages(body: JsonObject) -> list[JsonObject]:
     if not isinstance(body, dict):
         return []
     msgs = body.get("messages")
@@ -743,7 +744,7 @@ def _extract_response_tool_names(output: list) -> list[str]:
     return names
 
 
-def _extract_response_tool_names_from_output_item_events(events: list[dict]) -> list[str]:
+def _extract_response_tool_names_from_output_item_events(events: list[JsonObject]) -> list[str]:
     names: list[str] = []
     for ev in events:
         if _event_type(ev) != "response.output_item.done":
@@ -757,11 +758,11 @@ def _extract_response_tool_names_from_output_item_events(events: list[dict]) -> 
     return names
 
 
-def _dict_or_empty(value: object) -> dict:
+def _dict_or_empty(value: object) -> JsonObject:
     return value if isinstance(value, dict) else {}
 
 
-def _tool_display_name(tool: dict) -> str:
+def _tool_display_name(tool: JsonObject) -> str:
     for value in (
         tool.get("name"),
         (tool.get("function") or {}).get("name") if isinstance(tool.get("function"), dict) else None,
@@ -857,7 +858,7 @@ def _session_text_from_content(content: object) -> str:
     return ""
 
 
-def _is_tool_result_only_message(message: dict) -> bool:
+def _is_tool_result_only_message(message: JsonObject) -> bool:
     content = message.get("content")
     if not isinstance(content, list) or not content:
         return False
@@ -866,7 +867,7 @@ def _is_tool_result_only_message(message: dict) -> bool:
     )
 
 
-def _first_user_text(messages: list[dict]) -> str:
+def _first_user_text(messages: list[JsonObject]) -> str:
     for message in messages:
         if message.get("role") != "user" or _is_tool_result_only_message(message):
             continue
@@ -876,7 +877,7 @@ def _first_user_text(messages: list[dict]) -> str:
     return ""
 
 
-def _latest_user_text(messages: list[dict]) -> str:
+def _latest_user_text(messages: list[JsonObject]) -> str:
     for message in reversed(messages):
         if message.get("role") != "user" or _is_tool_result_only_message(message):
             continue
@@ -886,7 +887,7 @@ def _latest_user_text(messages: list[dict]) -> str:
     return ""
 
 
-def _extract_metadata(record_json: str) -> dict | None:
+def _extract_metadata(record_json: str) -> JsonObject | None:
     """Extract sidebar-relevant metadata from a raw JSON record string."""
     try:
         r = json.loads(record_json)
@@ -895,7 +896,7 @@ def _extract_metadata(record_json: str) -> dict | None:
     return _extract_metadata_from_record(r)
 
 
-def _extract_metadata_from_record(r: dict) -> dict | None:
+def _extract_metadata_from_record(r: JsonObject) -> JsonObject | None:
     """Extract sidebar metadata from a raw record without embedding full payloads.
 
     The returned dict contains only fields needed for sidebar rendering,
@@ -1056,7 +1057,7 @@ def _generate_html_viewer(
             )
             return
 
-    records: list[dict] = []
+    records: list[JsonObject] = []
     if trace_path.exists():
         with open(trace_path, "r", encoding="utf-8") as f:
             for line in f:
@@ -1077,7 +1078,7 @@ def _generate_html_viewer(
 
 
 def _generate_html_viewer_from_compact_bundle(
-    compact_bundle: dict,
+    compact_bundle: JsonObject,
     html_path: Path,
     *,
     display_trace_path: str | Path,
@@ -1112,7 +1113,7 @@ def _generate_html_viewer_from_compact_bundle(
 
 
 def _generate_html_viewer_from_metadata(
-    metadata: list[dict],
+    metadata: list[JsonObject],
     html_path: Path,
     *,
     display_trace_path: str | Path,

--- a/claude_tap/ws_proxy.py
+++ b/claude_tap/ws_proxy.py
@@ -15,6 +15,7 @@ from aiohttp import web
 from aiohttp.helpers import get_env_proxy_for_url
 from yarl import URL
 
+from claude_tap.models import JsonObject, Map
 from claude_tap.proxy import capture_only_response, filter_headers, is_capture_only_request
 from claude_tap.trace import TraceWriter
 from claude_tap.upstream import build_upstream_url, format_upstream_error
@@ -62,7 +63,7 @@ def _get_ws_proxy_settings(ws_url: str) -> tuple[URL, aiohttp.BasicAuth | None] 
 
 async def _handle_websocket(request: web.Request) -> web.StreamResponse:
     """Proxy a WebSocket connection to the upstream, recording all messages."""
-    ctx: dict = request.app["trace_ctx"]
+    ctx: JsonObject = request.app["trace_ctx"]
     target: str = ctx["target_url"]
     writer: TraceWriter = ctx["writer"]
     session: aiohttp.ClientSession = ctx["session"]
@@ -116,7 +117,7 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
 
     # Resolve proxy from env — aiohttp ws_connect ignores trust_env
     proxy_settings = _get_ws_proxy_settings(upstream_ws_url) if session.trust_env else None
-    ws_connect_kwargs: dict[str, object] = {}
+    ws_connect_kwargs: Map[str, object] = {}
     if proxy_settings:
         proxy_url, proxy_auth = proxy_settings
         ws_connect_kwargs["proxy"] = proxy_url
@@ -382,18 +383,18 @@ def _build_ws_record(
     turn: int | str,
     duration_ms: int,
     path_qs: str,
-    req_headers: dict,
+    req_headers: JsonObject,
     client_messages: list[str],
     server_messages: list[str],
     upstream_base_url: str,
     error: str | None = None,
     store_stream_events: bool = True,
-) -> dict:
+) -> JsonObject:
     """Build a trace record for a WebSocket session."""
     req_body = _reconstruct_ws_request_body(client_messages)
 
     # Parse server messages into structured events
-    ws_events: list[dict] = []
+    ws_events: list[JsonObject] = []
     for msg in server_messages:
         try:
             parsed = json.loads(msg)
@@ -404,7 +405,7 @@ def _build_ws_record(
     resp_body = _reconstruct_ws_response_body(ws_events)
     req_events = _parse_ws_messages(client_messages)
 
-    record: dict = {
+    record: JsonObject = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "request_id": req_id,
         "turn": turn,
@@ -433,8 +434,8 @@ def _build_ws_record(
     return record
 
 
-def _parse_ws_messages(messages: list[str]) -> list[dict]:
-    parsed_messages: list[dict] = []
+def _parse_ws_messages(messages: list[str]) -> list[JsonObject]:
+    parsed_messages: list[JsonObject] = []
     for msg in messages:
         try:
             parsed = json.loads(msg)
@@ -457,9 +458,9 @@ def _response_completed_message_key(message: str) -> str | None:
     return json.dumps(parsed, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
 
-def _reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
+def _reconstruct_ws_request_body(client_messages: list[str]) -> JsonObject | None:
     """Merge client WebSocket messages into the most complete request body."""
-    merged: dict | None = None
+    merged: JsonObject | None = None
     for msg in client_messages:
         try:
             parsed = json.loads(msg)
@@ -506,15 +507,15 @@ def _json_list_item_key(item: object) -> str:
         return repr(item)
 
 
-def _reconstruct_ws_response_body(ws_events: list[dict]) -> dict | None:
+def _reconstruct_ws_response_body(ws_events: list[JsonObject]) -> JsonObject | None:
     """Build a best-effort response body from WS events.
 
     Recent Codex versions may emit multiple response.completed events and keep
     the actual assistant text inside response.output_item.done rather than the
     terminal response payload. Reconstruct a richer body for traces/viewer use.
     """
-    merged: dict | None = None
-    output_items: dict[int, dict] = {}
+    merged: JsonObject | None = None
+    output_items: Map[int, JsonObject] = {}
 
     for event in ws_events:
         if not isinstance(event, dict):
@@ -565,7 +566,7 @@ def _reconstruct_ws_response_body(ws_events: list[dict]) -> dict | None:
     return merged
 
 
-def reconstruct_ws_response_body(ws_events: list[dict]) -> dict | None:
+def reconstruct_ws_response_body(ws_events: list[JsonObject]) -> JsonObject | None:
     """Public wrapper for websocket response-body reconstruction.
 
     Forward and reverse proxy code paths both need identical reconstruction
@@ -574,12 +575,12 @@ def reconstruct_ws_response_body(ws_events: list[dict]) -> dict | None:
     return _reconstruct_ws_response_body(ws_events)
 
 
-def reconstruct_ws_request_body(client_messages: list[str]) -> dict | None:
+def reconstruct_ws_request_body(client_messages: list[str]) -> JsonObject | None:
     """Public wrapper for websocket request-body reconstruction."""
     return _reconstruct_ws_request_body(client_messages)
 
 
-def is_prompt_bearing_ws_request_body(body: dict | None) -> bool:
+def is_prompt_bearing_ws_request_body(body: JsonObject | None) -> bool:
     """Return whether a reconstructed WebSocket request contains an actual prompt."""
     if not isinstance(body, dict):
         return False

--- a/claude_tap/ws_proxy.py
+++ b/claude_tap/ws_proxy.py
@@ -15,7 +15,7 @@ from aiohttp import web
 from aiohttp.helpers import get_env_proxy_for_url
 from yarl import URL
 
-from claude_tap.models import JsonObject, Map
+from claude_tap.models import ProviderPayload
 from claude_tap.proxy import capture_only_response, filter_headers, is_capture_only_request
 from claude_tap.trace import TraceWriter
 from claude_tap.upstream import build_upstream_url, format_upstream_error
@@ -63,7 +63,7 @@ def _get_ws_proxy_settings(ws_url: str) -> tuple[URL, aiohttp.BasicAuth | None] 
 
 async def _handle_websocket(request: web.Request) -> web.StreamResponse:
     """Proxy a WebSocket connection to the upstream, recording all messages."""
-    ctx: JsonObject = request.app["trace_ctx"]
+    ctx: ProviderPayload = request.app["trace_ctx"]
     target: str = ctx["target_url"]
     writer: TraceWriter = ctx["writer"]
     session: aiohttp.ClientSession = ctx["session"]
@@ -117,7 +117,7 @@ async def _handle_websocket(request: web.Request) -> web.StreamResponse:
 
     # Resolve proxy from env — aiohttp ws_connect ignores trust_env
     proxy_settings = _get_ws_proxy_settings(upstream_ws_url) if session.trust_env else None
-    ws_connect_kwargs: Map[str, object] = {}
+    ws_connect_kwargs: ProviderPayload = {}
     if proxy_settings:
         proxy_url, proxy_auth = proxy_settings
         ws_connect_kwargs["proxy"] = proxy_url
@@ -383,18 +383,18 @@ def _build_ws_record(
     turn: int | str,
     duration_ms: int,
     path_qs: str,
-    req_headers: JsonObject,
+    req_headers: ProviderPayload,
     client_messages: list[str],
     server_messages: list[str],
     upstream_base_url: str,
     error: str | None = None,
     store_stream_events: bool = True,
-) -> JsonObject:
+) -> ProviderPayload:
     """Build a trace record for a WebSocket session."""
     req_body = _reconstruct_ws_request_body(client_messages)
 
     # Parse server messages into structured events
-    ws_events: list[JsonObject] = []
+    ws_events: list[ProviderPayload] = []
     for msg in server_messages:
         try:
             parsed = json.loads(msg)
@@ -405,7 +405,7 @@ def _build_ws_record(
     resp_body = _reconstruct_ws_response_body(ws_events)
     req_events = _parse_ws_messages(client_messages)
 
-    record: JsonObject = {
+    record: ProviderPayload = {
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "request_id": req_id,
         "turn": turn,
@@ -434,8 +434,8 @@ def _build_ws_record(
     return record
 
 
-def _parse_ws_messages(messages: list[str]) -> list[JsonObject]:
-    parsed_messages: list[JsonObject] = []
+def _parse_ws_messages(messages: list[str]) -> list[ProviderPayload]:
+    parsed_messages: list[ProviderPayload] = []
     for msg in messages:
         try:
             parsed = json.loads(msg)
@@ -458,9 +458,9 @@ def _response_completed_message_key(message: str) -> str | None:
     return json.dumps(parsed, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
 
 
-def _reconstruct_ws_request_body(client_messages: list[str]) -> JsonObject | None:
+def _reconstruct_ws_request_body(client_messages: list[str]) -> ProviderPayload | None:
     """Merge client WebSocket messages into the most complete request body."""
-    merged: JsonObject | None = None
+    merged: ProviderPayload | None = None
     for msg in client_messages:
         try:
             parsed = json.loads(msg)
@@ -487,7 +487,7 @@ def _reconstruct_ws_request_body(client_messages: list[str]) -> JsonObject | Non
     return merged
 
 
-def _merge_json_lists(existing: list, incoming: list) -> list:
+def _merge_json_lists(existing: list[ProviderPayload], incoming: list[ProviderPayload]) -> list[ProviderPayload]:
     """Append JSON-like list items while preserving order and removing exact duplicates."""
     merged = list(existing)
     seen = {_json_list_item_key(item) for item in merged}
@@ -500,22 +500,22 @@ def _merge_json_lists(existing: list, incoming: list) -> list:
     return merged
 
 
-def _json_list_item_key(item: object) -> str:
+def _json_list_item_key(item: ProviderPayload) -> str:
     try:
         return json.dumps(item, sort_keys=True, ensure_ascii=False, separators=(",", ":"))
     except (TypeError, ValueError):
         return repr(item)
 
 
-def _reconstruct_ws_response_body(ws_events: list[JsonObject]) -> JsonObject | None:
+def _reconstruct_ws_response_body(ws_events: list[ProviderPayload]) -> ProviderPayload | None:
     """Build a best-effort response body from WS events.
 
     Recent Codex versions may emit multiple response.completed events and keep
     the actual assistant text inside response.output_item.done rather than the
     terminal response payload. Reconstruct a richer body for traces/viewer use.
     """
-    merged: JsonObject | None = None
-    output_items: Map[int, JsonObject] = {}
+    merged: ProviderPayload | None = None
+    output_items: dict[int, ProviderPayload] = {}
 
     for event in ws_events:
         if not isinstance(event, dict):
@@ -566,7 +566,7 @@ def _reconstruct_ws_response_body(ws_events: list[JsonObject]) -> JsonObject | N
     return merged
 
 
-def reconstruct_ws_response_body(ws_events: list[JsonObject]) -> JsonObject | None:
+def reconstruct_ws_response_body(ws_events: list[ProviderPayload]) -> ProviderPayload | None:
     """Public wrapper for websocket response-body reconstruction.
 
     Forward and reverse proxy code paths both need identical reconstruction
@@ -575,12 +575,12 @@ def reconstruct_ws_response_body(ws_events: list[JsonObject]) -> JsonObject | No
     return _reconstruct_ws_response_body(ws_events)
 
 
-def reconstruct_ws_request_body(client_messages: list[str]) -> JsonObject | None:
+def reconstruct_ws_request_body(client_messages: list[str]) -> ProviderPayload | None:
     """Public wrapper for websocket request-body reconstruction."""
     return _reconstruct_ws_request_body(client_messages)
 
 
-def is_prompt_bearing_ws_request_body(body: JsonObject | None) -> bool:
+def is_prompt_bearing_ws_request_body(body: ProviderPayload | None) -> bool:
     """Return whether a reconstructed WebSocket request contains an actual prompt."""
     if not isinstance(body, dict):
         return False
@@ -598,7 +598,7 @@ def is_prompt_bearing_ws_request_body(body: JsonObject | None) -> bool:
     return isinstance(nested, dict) and is_prompt_bearing_ws_request_body(nested)
 
 
-def _ws_input_item_is_prompt(item: object) -> bool:
+def _ws_input_item_is_prompt(item: ProviderPayload) -> bool:
     if isinstance(item, str):
         return bool(item.strip())
     if not isinstance(item, dict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "aiohttp==3.14.1",
     "backports-zstd>=1.0; python_version < '3.14'",
     "cryptography>=42.0",
+    "pydantic>=2.7",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,11 @@ target-version = "py311"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "ANN401"]
 ignore = ["E501"]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["ANN401"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -55,6 +55,17 @@ python scripts/check_pr_policy.py \
 The CI workflow runs this check both as a standalone `pr-policy` job and inside
 the existing required `lint` job.
 
+## `check_schema.py`
+
+Check only changed Python lines for new bare `dict`, `Any`, or `TypedDict`
+annotations. Existing dynamic provider payload code remains valid, while new
+application-owned structures must use Pydantic models. Use `JsonObject` from
+`claude_tap.models` when an external provider payload is intentionally open-ended.
+
+```bash
+python scripts/check_schema.py --base origin/main
+```
+
 ## `translate_i18n.py`
 
 Translate missing i18n strings in `claude_tap/viewer_i18n.json` using OpenRouter.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -57,10 +57,11 @@ the existing required `lint` job.
 
 ## `check_schema.py`
 
-Check only changed Python lines for new bare `dict`, `Any`, or `TypedDict`
-annotations. Existing dynamic provider payload code remains valid, while new
-application-owned structures must use Pydantic models. Use `JsonObject` from
-`claude_tap.models` when an external provider payload is intentionally open-ended.
+Scan the repository for bare `dict`, `Any`, `Mapping`, or `TypedDict`
+annotations, then check changed Python lines for regressions. Existing dynamic
+provider payload code remains valid only when it uses the explicit
+`JsonObject`/`JsonValue` boundaries; application-owned structures must use
+Pydantic models.
 
 ```bash
 python scripts/check_schema.py --base origin/main

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -17,12 +17,13 @@ import subprocess
 import sys
 import tempfile
 import tomllib
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from claude_tap.models import Map
+    from claude_tap.models import ProviderPayload
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CONFIG = REPO_ROOT / "pyproject.toml"
@@ -70,8 +71,8 @@ def _run_git_diff(base: str, paths: list[str]) -> str:
     return subprocess.check_output(cmd, cwd=REPO_ROOT, text=True)
 
 
-def changed_lines_from_diff(diff_text: str) -> Map[str, set[int]]:
-    changed: Map[str, set[int]] = {}
+def changed_lines_from_diff(diff_text: str) -> dict[str, set[int]]:
+    changed: dict[str, set[int]] = {}
     current_file: str | None = None
     new_line: int | None = None
     hunk_re = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
@@ -137,7 +138,7 @@ def _base_file_text(base: str, path: str) -> str | None:
         return None
 
 
-def _filter_pure_viewer_asset_split(changed_lines: Map[str, set[int]], base: str) -> Map[str, set[int]]:
+def _filter_pure_viewer_asset_split(changed_lines: dict[str, set[int]], base: str) -> dict[str, set[int]]:
     """Ignore asset files that are exact extractions from the base monolithic viewer."""
     js_changed = [source for source in (VIEWER_LEGACY_JS_SOURCE, *VIEWER_JS_SOURCES) if source in changed_lines]
     if not js_changed and VIEWER_CSS_SOURCE not in changed_lines and VIEWER_HTML_SOURCE not in changed_lines:
@@ -197,7 +198,7 @@ def _filter_pure_viewer_asset_split(changed_lines: Map[str, set[int]], base: str
     return filtered
 
 
-def load_thresholds(config_path: Path = DEFAULT_CONFIG) -> Map[str, float]:
+def load_thresholds(config_path: Path = DEFAULT_CONFIG) -> dict[str, float]:
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     configured = data.get("tool", {}).get("claude_tap", {}).get("coverage", {})
     thresholds = dict(DEFAULT_THRESHOLDS)
@@ -209,7 +210,7 @@ def load_thresholds(config_path: Path = DEFAULT_CONFIG) -> Map[str, float]:
 
 def check_python_coverage(
     coverage_json_path: Path,
-    changed_lines: Map[str, set[int]],
+    changed_lines: dict[str, set[int]],
     total_min: float,
     diff_min: float,
 ) -> list[CheckResult]:
@@ -267,9 +268,9 @@ def check_python_coverage(
     return results
 
 
-def js_function_ranges(source: str) -> Map[str, tuple[int, int]]:
+def js_function_ranges(source: str) -> dict[str, tuple[int, int]]:
     lines = source.splitlines()
-    ranges: Map[str, tuple[int, int]] = {}
+    ranges: dict[str, tuple[int, int]] = {}
     fn_re = re.compile(r"\bfunction\s+([A-Za-z_$][\w$]*)\s*\(")
 
     line_no = 1
@@ -305,7 +306,7 @@ def js_function_ranges(source: str) -> Map[str, tuple[int, int]]:
     return ranges
 
 
-def _changed_lines_for_source(source_path: Path, changed_lines: Map[str, set[int]], fallback_key: str) -> set[int]:
+def _changed_lines_for_source(source_path: Path, changed_lines: dict[str, set[int]], fallback_key: str) -> set[int]:
     keys = []
     if source_path.name == "viewer.js":
         keys.append(VIEWER_LEGACY_JS_SOURCE)
@@ -326,7 +327,7 @@ def _changed_lines_for_source(source_path: Path, changed_lines: Map[str, set[int
     return set()
 
 
-def changed_viewer_functions(viewer_js: Path | tuple[Path, ...], changed_lines: Map[str, set[int]]) -> set[str]:
+def changed_viewer_functions(viewer_js: Path | tuple[Path, ...], changed_lines: dict[str, set[int]]) -> set[str]:
     functions: set[str] = set()
     for source_path in viewer_js if isinstance(viewer_js, tuple) else (viewer_js,):
         changed = _changed_lines_for_source(source_path, changed_lines, VIEWER_HTML_SOURCE)
@@ -365,9 +366,9 @@ def _style_block_ranges(source: str) -> list[tuple[int, int]]:
     return ranges
 
 
-def css_selector_ranges(source: str) -> Map[str, list[tuple[int, int]]]:
+def css_selector_ranges(source: str) -> dict[str, list[tuple[int, int]]]:
     lines = source.splitlines()
-    ranges: Map[str, list[tuple[int, int]]] = {}
+    ranges: dict[str, list[tuple[int, int]]] = {}
 
     for style_start, style_end in _style_block_ranges(source):
         line_no = style_start
@@ -401,7 +402,7 @@ def css_selector_ranges(source: str) -> Map[str, list[tuple[int, int]]]:
     return ranges
 
 
-def changed_viewer_css_selectors(viewer_css: Path, changed_lines: Map[str, set[int]]) -> set[str]:
+def changed_viewer_css_selectors(viewer_css: Path, changed_lines: dict[str, set[int]]) -> set[str]:
     changed = _changed_lines_for_source(viewer_css, changed_lines, VIEWER_HTML_SOURCE)
     if not changed:
         return set()
@@ -413,7 +414,7 @@ def changed_viewer_css_selectors(viewer_css: Path, changed_lines: Map[str, set[i
     return selectors
 
 
-def _main_viewer_script(coverage: Map[str, object], suffix: str) -> Map[str, object]:
+def _main_viewer_script(coverage: ProviderPayload, suffix: str) -> ProviderPayload:
     scripts = coverage.get("result") or []
     candidates = [
         script for script in scripts if script.get("url", "").endswith(suffix) and len(script.get("functions", [])) > 50
@@ -433,12 +434,12 @@ def _main_viewer_script(coverage: Map[str, object], suffix: str) -> Map[str, obj
     return max(candidates, key=lambda script: len(script.get("functions", [])))
 
 
-def _restart_precise_coverage(session: object) -> None:
+def _restart_precise_coverage(session: ProviderPayload) -> None:
     session.send("Profiler.stopPreciseCoverage")
     session.send("Profiler.startPreciseCoverage", {"callCount": True, "detailed": True})
 
 
-def _is_top_level_wrapper(function: Map[str, object], script_end: int) -> bool:
+def _is_top_level_wrapper(function: ProviderPayload, script_end: int) -> bool:
     if function.get("functionName"):
         return False
     ranges = function.get("ranges", [])
@@ -448,17 +449,19 @@ def _is_top_level_wrapper(function: Map[str, object], script_end: int) -> bool:
     return script_end > 0 and widest >= script_end * 0.8
 
 
-def _viewer_script_functions(script: Map[str, object]) -> list[Map[str, object]]:
+def _viewer_script_functions(script: ProviderPayload) -> list[ProviderPayload]:
     all_ranges = [item for function in script["functions"] for item in function.get("ranges", [])]
     script_end = max((item.get("endOffset", 0) for item in all_ranges), default=0)
     return [function for function in script["functions"] if not _is_top_level_wrapper(function, script_end)]
 
 
-def _is_function_covered(function: Map[str, object]) -> bool:
+def _is_function_covered(function: ProviderPayload) -> bool:
     return any(item.get("count", 0) > 0 for item in function.get("ranges", []))
 
 
-def _load_viewer_contract_helpers() -> tuple[object, object, object]:
+def _load_viewer_contract_helpers() -> tuple[
+    Callable[..., ProviderPayload], Callable[..., str], Callable[..., ProviderPayload]
+]:
     contracts_path = REPO_ROOT / "tests" / "test_viewer_contracts.py"
     spec = importlib.util.spec_from_file_location("viewer_contracts_for_coverage", contracts_path)
     if spec is None or spec.loader is None:
@@ -913,7 +916,7 @@ def collect_viewer_css_coverage() -> tuple[float, set[str], int, int, int]:
     all_selectors: set[str] = set()
     skipped_selectors: set[str] = set()
 
-    def merge(snapshot: Map[str, list[str]]) -> None:
+    def merge(snapshot: dict[str, list[str]]) -> None:
         used_selectors.update(snapshot["used"])
         all_selectors.update(snapshot["all"])
         skipped_selectors.update(snapshot["skipped"])

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -463,6 +463,8 @@ def _load_viewer_contract_helpers() -> tuple[
     Callable[..., ProviderPayload], Callable[..., str], Callable[..., ProviderPayload]
 ]:
     contracts_path = REPO_ROOT / "tests" / "test_viewer_contracts.py"
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
     spec = importlib.util.spec_from_file_location("viewer_contracts_for_coverage", contracts_path)
     if spec is None or spec.loader is None:
         raise RuntimeError(f"Could not load viewer contract helpers from {contracts_path}")

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -19,8 +19,10 @@ import tempfile
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from claude_tap.models import Map
+if TYPE_CHECKING:
+    from claude_tap.models import Map
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CONFIG = REPO_ROOT / "pyproject.toml"

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -19,7 +19,8 @@ import tempfile
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+
+from claude_tap.models import Map
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DEFAULT_CONFIG = REPO_ROOT / "pyproject.toml"
@@ -67,8 +68,8 @@ def _run_git_diff(base: str, paths: list[str]) -> str:
     return subprocess.check_output(cmd, cwd=REPO_ROOT, text=True)
 
 
-def changed_lines_from_diff(diff_text: str) -> dict[str, set[int]]:
-    changed: dict[str, set[int]] = {}
+def changed_lines_from_diff(diff_text: str) -> Map[str, set[int]]:
+    changed: Map[str, set[int]] = {}
     current_file: str | None = None
     new_line: int | None = None
     hunk_re = re.compile(r"@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
@@ -134,7 +135,7 @@ def _base_file_text(base: str, path: str) -> str | None:
         return None
 
 
-def _filter_pure_viewer_asset_split(changed_lines: dict[str, set[int]], base: str) -> dict[str, set[int]]:
+def _filter_pure_viewer_asset_split(changed_lines: Map[str, set[int]], base: str) -> Map[str, set[int]]:
     """Ignore asset files that are exact extractions from the base monolithic viewer."""
     js_changed = [source for source in (VIEWER_LEGACY_JS_SOURCE, *VIEWER_JS_SOURCES) if source in changed_lines]
     if not js_changed and VIEWER_CSS_SOURCE not in changed_lines and VIEWER_HTML_SOURCE not in changed_lines:
@@ -194,7 +195,7 @@ def _filter_pure_viewer_asset_split(changed_lines: dict[str, set[int]], base: st
     return filtered
 
 
-def load_thresholds(config_path: Path = DEFAULT_CONFIG) -> dict[str, float]:
+def load_thresholds(config_path: Path = DEFAULT_CONFIG) -> Map[str, float]:
     data = tomllib.loads(config_path.read_text(encoding="utf-8"))
     configured = data.get("tool", {}).get("claude_tap", {}).get("coverage", {})
     thresholds = dict(DEFAULT_THRESHOLDS)
@@ -206,7 +207,7 @@ def load_thresholds(config_path: Path = DEFAULT_CONFIG) -> dict[str, float]:
 
 def check_python_coverage(
     coverage_json_path: Path,
-    changed_lines: dict[str, set[int]],
+    changed_lines: Map[str, set[int]],
     total_min: float,
     diff_min: float,
 ) -> list[CheckResult]:
@@ -264,9 +265,9 @@ def check_python_coverage(
     return results
 
 
-def js_function_ranges(source: str) -> dict[str, tuple[int, int]]:
+def js_function_ranges(source: str) -> Map[str, tuple[int, int]]:
     lines = source.splitlines()
-    ranges: dict[str, tuple[int, int]] = {}
+    ranges: Map[str, tuple[int, int]] = {}
     fn_re = re.compile(r"\bfunction\s+([A-Za-z_$][\w$]*)\s*\(")
 
     line_no = 1
@@ -302,7 +303,7 @@ def js_function_ranges(source: str) -> dict[str, tuple[int, int]]:
     return ranges
 
 
-def _changed_lines_for_source(source_path: Path, changed_lines: dict[str, set[int]], fallback_key: str) -> set[int]:
+def _changed_lines_for_source(source_path: Path, changed_lines: Map[str, set[int]], fallback_key: str) -> set[int]:
     keys = []
     if source_path.name == "viewer.js":
         keys.append(VIEWER_LEGACY_JS_SOURCE)
@@ -323,7 +324,7 @@ def _changed_lines_for_source(source_path: Path, changed_lines: dict[str, set[in
     return set()
 
 
-def changed_viewer_functions(viewer_js: Path | tuple[Path, ...], changed_lines: dict[str, set[int]]) -> set[str]:
+def changed_viewer_functions(viewer_js: Path | tuple[Path, ...], changed_lines: Map[str, set[int]]) -> set[str]:
     functions: set[str] = set()
     for source_path in viewer_js if isinstance(viewer_js, tuple) else (viewer_js,):
         changed = _changed_lines_for_source(source_path, changed_lines, VIEWER_HTML_SOURCE)
@@ -362,9 +363,9 @@ def _style_block_ranges(source: str) -> list[tuple[int, int]]:
     return ranges
 
 
-def css_selector_ranges(source: str) -> dict[str, list[tuple[int, int]]]:
+def css_selector_ranges(source: str) -> Map[str, list[tuple[int, int]]]:
     lines = source.splitlines()
-    ranges: dict[str, list[tuple[int, int]]] = {}
+    ranges: Map[str, list[tuple[int, int]]] = {}
 
     for style_start, style_end in _style_block_ranges(source):
         line_no = style_start
@@ -398,7 +399,7 @@ def css_selector_ranges(source: str) -> dict[str, list[tuple[int, int]]]:
     return ranges
 
 
-def changed_viewer_css_selectors(viewer_css: Path, changed_lines: dict[str, set[int]]) -> set[str]:
+def changed_viewer_css_selectors(viewer_css: Path, changed_lines: Map[str, set[int]]) -> set[str]:
     changed = _changed_lines_for_source(viewer_css, changed_lines, VIEWER_HTML_SOURCE)
     if not changed:
         return set()
@@ -410,7 +411,7 @@ def changed_viewer_css_selectors(viewer_css: Path, changed_lines: dict[str, set[
     return selectors
 
 
-def _main_viewer_script(coverage: dict[str, Any], suffix: str) -> dict[str, Any]:
+def _main_viewer_script(coverage: Map[str, object], suffix: str) -> Map[str, object]:
     scripts = coverage.get("result") or []
     candidates = [
         script for script in scripts if script.get("url", "").endswith(suffix) and len(script.get("functions", [])) > 50
@@ -430,12 +431,12 @@ def _main_viewer_script(coverage: dict[str, Any], suffix: str) -> dict[str, Any]
     return max(candidates, key=lambda script: len(script.get("functions", [])))
 
 
-def _restart_precise_coverage(session: Any) -> None:
+def _restart_precise_coverage(session: object) -> None:
     session.send("Profiler.stopPreciseCoverage")
     session.send("Profiler.startPreciseCoverage", {"callCount": True, "detailed": True})
 
 
-def _is_top_level_wrapper(function: dict[str, Any], script_end: int) -> bool:
+def _is_top_level_wrapper(function: Map[str, object], script_end: int) -> bool:
     if function.get("functionName"):
         return False
     ranges = function.get("ranges", [])
@@ -445,17 +446,17 @@ def _is_top_level_wrapper(function: dict[str, Any], script_end: int) -> bool:
     return script_end > 0 and widest >= script_end * 0.8
 
 
-def _viewer_script_functions(script: dict[str, Any]) -> list[dict[str, Any]]:
+def _viewer_script_functions(script: Map[str, object]) -> list[Map[str, object]]:
     all_ranges = [item for function in script["functions"] for item in function.get("ranges", [])]
     script_end = max((item.get("endOffset", 0) for item in all_ranges), default=0)
     return [function for function in script["functions"] if not _is_top_level_wrapper(function, script_end)]
 
 
-def _is_function_covered(function: dict[str, Any]) -> bool:
+def _is_function_covered(function: Map[str, object]) -> bool:
     return any(item.get("count", 0) > 0 for item in function.get("ranges", []))
 
 
-def _load_viewer_contract_helpers() -> tuple[Any, Any, Any]:
+def _load_viewer_contract_helpers() -> tuple[object, object, object]:
     contracts_path = REPO_ROOT / "tests" / "test_viewer_contracts.py"
     spec = importlib.util.spec_from_file_location("viewer_contracts_for_coverage", contracts_path)
     if spec is None or spec.loader is None:
@@ -910,7 +911,7 @@ def collect_viewer_css_coverage() -> tuple[float, set[str], int, int, int]:
     all_selectors: set[str] = set()
     skipped_selectors: set[str] = set()
 
-    def merge(snapshot: dict[str, list[str]]) -> None:
+    def merge(snapshot: Map[str, list[str]]) -> None:
         used_selectors.update(snapshot["used"])
         all_selectors.update(snapshot["all"])
         skipped_selectors.update(snapshot["skipped"])

--- a/scripts/check_legibility.py
+++ b/scripts/check_legibility.py
@@ -9,8 +9,10 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from claude_tap.models import Map
+if TYPE_CHECKING:
+    from claude_tap.models import Map
 
 ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 REQUIRED_STANDARDS_KEYS = ("owner", "last_reviewed", "source_of_truth")

--- a/scripts/check_legibility.py
+++ b/scripts/check_legibility.py
@@ -10,6 +10,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from claude_tap.models import Map
+
 ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 REQUIRED_STANDARDS_KEYS = ("owner", "last_reviewed", "source_of_truth")
 ALLOWED_PLAN_STATUS = {"active", "completed", "cancelled"}
@@ -27,7 +29,7 @@ class CheckResult:
     warnings: list[str]
 
 
-def parse_frontmatter(markdown_text: str) -> dict[str, str]:
+def parse_frontmatter(markdown_text: str) -> Map[str, str]:
     lines = markdown_text.splitlines()
     if len(lines) < 3 or lines[0].strip() != "---":
         return {}
@@ -39,7 +41,7 @@ def parse_frontmatter(markdown_text: str) -> dict[str, str]:
     else:
         return {}
 
-    fields: dict[str, str] = {}
+    fields: Map[str, str] = {}
     for line in frontmatter_lines:
         if ":" not in line:
             continue

--- a/scripts/check_legibility.py
+++ b/scripts/check_legibility.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from claude_tap.models import Map
+    pass
 
 ISO_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 REQUIRED_STANDARDS_KEYS = ("owner", "last_reviewed", "source_of_truth")
@@ -31,7 +31,7 @@ class CheckResult:
     warnings: list[str]
 
 
-def parse_frontmatter(markdown_text: str) -> Map[str, str]:
+def parse_frontmatter(markdown_text: str) -> dict[str, str]:
     lines = markdown_text.splitlines()
     if len(lines) < 3 or lines[0].strip() != "---":
         return {}
@@ -43,7 +43,7 @@ def parse_frontmatter(markdown_text: str) -> Map[str, str]:
     else:
         return {}
 
-    fields: Map[str, str] = {}
+    fields: dict[str, str] = {}
     for line in frontmatter_lines:
         if ":" not in line:
             continue

--- a/scripts/check_pr.sh
+++ b/scripts/check_pr.sh
@@ -165,6 +165,13 @@ if [ "$run_tests" -eq 1 ]; then
     echo '  FAIL uv run ruff format --check .'
   fi
 
+  if python3 scripts/check_schema.py --base origin/main; then
+    echo '  PASS incremental schema check'
+  else
+    gate_failed=1
+    echo '  FAIL incremental schema check'
+  fi
+
   if uv run pytest tests/ -x --timeout=60; then
     echo '  PASS uv run pytest tests/ -x --timeout=60'
   else

--- a/scripts/check_schema.py
+++ b/scripts/check_schema.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Reject new schema-less Python annotations while preserving dynamic JSON edges.
+
+This is intentionally incremental: the repository contains existing provider
+protocol code whose payloads are open-ended. New code must use a Pydantic
+model, a concrete collection type, or the explicit JsonObject boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+_SCHEMALESS_NAMES = {"Any", "Dict", "TypedDict"}
+_BARE_NAMES = {"dict", "Dict", "Any"}
+_ALLOWED_FILES = {Path("claude_tap/models.py"), Path("scripts/check_schema.py")}
+
+
+def _changed_lines(base: str) -> dict[Path, set[int]]:
+    result = subprocess.run(
+        ["git", "diff", "--unified=0", base, "--", "*.py"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    changed: dict[Path, set[int]] = {}
+    current: Path | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("+++ b/"):
+            current = Path(line[6:])
+            changed.setdefault(current, set())
+            continue
+        if not line.startswith("@@") or current is None:
+            continue
+        hunk = line.split("+")[1].split(" ", 1)[0]
+        start, _, count = hunk.partition(",")
+        first = int(start)
+        length = int(count or "1")
+        changed[current].update(range(first, first + length))
+    return changed
+
+
+def _annotation_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Name):
+            names.add(child.id)
+    return names
+
+
+def _find_violations(path: Path, lines: set[int]) -> list[str]:
+    if path in _ALLOWED_FILES or not path.exists():
+        return []
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        return [f"{path}:{exc.lineno}: unable to parse Python source: {exc.msg}"]
+
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and any(
+            isinstance(base, ast.Name) and base.id == "TypedDict" for base in node.bases
+        ):
+            if node.lineno in lines:
+                violations.append(f"{path}:{node.lineno}: use a Pydantic BaseModel instead of TypedDict")
+        annotation = None
+        if isinstance(node, (ast.AnnAssign, ast.arg)):
+            annotation = node.annotation
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            annotation = node.returns
+        if annotation is None or annotation.lineno not in lines:
+            continue
+        names = _annotation_names(annotation)
+        if "Any" in names:
+            violations.append(f"{path}:{annotation.lineno}: new Any annotation; use a Pydantic model or JsonValue")
+            continue
+        if isinstance(annotation, ast.Name) and annotation.id in _BARE_NAMES:
+            violations.append(f"{path}:{annotation.lineno}: bare {annotation.id} annotation; use a Pydantic model")
+        elif (
+            isinstance(annotation, ast.Subscript)
+            and isinstance(annotation.value, ast.Name)
+            and annotation.value.id
+            in {
+                "dict",
+                "Dict",
+            }
+        ):
+            violations.append(f"{path}:{annotation.lineno}: dict annotation; use a Pydantic model or JsonObject")
+    return violations
+
+
+def check_paths(paths: dict[Path, set[int]]) -> list[str]:
+    """Return violations for an already computed changed-line map."""
+    return [violation for path, lines in paths.items() for violation in _find_violations(path, lines)]
+
+
+def _ruff_any_violations(paths: dict[Path, set[int]]) -> list[str]:
+    files = [str(path) for path in paths if path.exists() and path.suffix == ".py"]
+    if not files:
+        return []
+    ruff = shutil.which("ruff")
+    command = [ruff] if ruff else ["uv", "run", "ruff"]
+    result = subprocess.run(
+        [*command, "check", "--select", "ANN401", "--output-format", "json", *files],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if not result.stdout.strip():
+        return []
+    findings = json.loads(result.stdout)
+    violations: list[str] = []
+    for finding in findings:
+        path = Path(finding["filename"])
+        line = finding["location"]["row"]
+        if line in paths.get(path, set()):
+            violations.append(f"{path}:{line}: {finding['message']} (Ruff ANN401)")
+    return violations
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", default="origin/main", help="Git base used to identify changed lines")
+    args = parser.parse_args()
+    changed = _changed_lines(args.base)
+    violations = check_paths(changed) + _ruff_any_violations(changed)
+    if violations:
+        print("Incremental schema check failed:")
+        print("\n".join(violations))
+        return 1
+    print("Incremental schema check passed (new annotations are schema-defined or explicit JSON boundaries).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_schema.py
+++ b/scripts/check_schema.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""Reject new schema-less Python annotations while preserving dynamic JSON edges.
+"""Reject schema-less Python annotations while preserving dynamic JSON edges.
 
-This is intentionally incremental: the repository contains existing provider
-protocol code whose payloads are open-ended. New code must use a Pydantic
-model, a concrete collection type, or the explicit JsonObject boundary.
+The checker has two complementary modes: a full repository scan keeps the
+existing tree clean, while the diff scan gives contributors a focused error
+when a forbidden annotation is added. Open-ended provider payloads must use
+the explicit ``JsonObject``/``JsonValue`` boundaries instead.
 """
 
 from __future__ import annotations
@@ -16,9 +17,9 @@ import subprocess
 import sys
 from pathlib import Path
 
-_SCHEMALESS_NAMES = {"Any", "Dict", "TypedDict"}
-_BARE_NAMES = {"dict", "Dict", "Any"}
+_SCHEMALESS_NAMES = {"Any", "Dict", "TypedDict", "Mapping", "MutableMapping", "dict"}
 _ALLOWED_FILES = {Path("claude_tap/models.py"), Path("scripts/check_schema.py")}
+_SOURCE_ROOTS = (Path("claude_tap"), Path("scripts"), Path("tests"))
 
 
 def _changed_lines(base: str) -> dict[Path, set[int]]:
@@ -50,11 +51,13 @@ def _annotation_names(node: ast.AST) -> set[str]:
     for child in ast.walk(node):
         if isinstance(child, ast.Name):
             names.add(child.id)
+        elif isinstance(child, ast.Attribute):
+            names.add(child.attr)
     return names
 
 
-def _find_violations(path: Path, lines: set[int]) -> list[str]:
-    if path in _ALLOWED_FILES or not path.exists():
+def _find_violations(path: Path, lines: set[int] | None = None) -> list[str]:
+    if any(path == allowed or path.resolve() == allowed.resolve() for allowed in _ALLOWED_FILES) or not path.exists():
         return []
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
@@ -66,37 +69,46 @@ def _find_violations(path: Path, lines: set[int]) -> list[str]:
         if isinstance(node, ast.ClassDef) and any(
             isinstance(base, ast.Name) and base.id == "TypedDict" for base in node.bases
         ):
-            if node.lineno in lines:
+            if lines is None or node.lineno in lines:
                 violations.append(f"{path}:{node.lineno}: use a Pydantic BaseModel instead of TypedDict")
         annotation = None
         if isinstance(node, (ast.AnnAssign, ast.arg)):
             annotation = node.annotation
         elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             annotation = node.returns
-        if annotation is None or annotation.lineno not in lines:
+        if annotation is None or (lines is not None and annotation.lineno not in lines):
             continue
         names = _annotation_names(annotation)
-        if "Any" in names:
-            violations.append(f"{path}:{annotation.lineno}: new Any annotation; use a Pydantic model or JsonValue")
-            continue
-        if isinstance(annotation, ast.Name) and annotation.id in _BARE_NAMES:
-            violations.append(f"{path}:{annotation.lineno}: bare {annotation.id} annotation; use a Pydantic model")
-        elif (
-            isinstance(annotation, ast.Subscript)
-            and isinstance(annotation.value, ast.Name)
-            and annotation.value.id
-            in {
-                "dict",
-                "Dict",
-            }
-        ):
-            violations.append(f"{path}:{annotation.lineno}: dict annotation; use a Pydantic model or JsonObject")
+        forbidden = names & _SCHEMALESS_NAMES
+        if forbidden:
+            name = sorted(forbidden)[0]
+            if name == "Any":
+                prefix = "new " if lines is not None else ""
+                message = f"{prefix}Any annotation; use a Pydantic model or JsonValue"
+            elif name in {"Mapping", "MutableMapping"}:
+                message = f"{name} annotation; use a Pydantic model or explicit JSON boundary"
+            elif name == "TypedDict":
+                message = "TypedDict annotation; use a Pydantic BaseModel"
+            else:
+                message = "dict annotation; use a Pydantic model or JsonObject"
+            violations.append(f"{path}:{annotation.lineno}: {message}")
     return violations
 
 
 def check_paths(paths: dict[Path, set[int]]) -> list[str]:
     """Return violations for an already computed changed-line map."""
     return [violation for path, lines in paths.items() for violation in _find_violations(path, lines)]
+
+
+def repository_paths(root: Path | None = None) -> list[Path]:
+    """Return Python source files covered by the repository schema policy."""
+    base = root or Path(__file__).resolve().parents[1]
+    return [path for source_root in _SOURCE_ROOTS for path in (base / source_root).rglob("*.py")]
+
+
+def check_repository(paths: list[Path]) -> list[str]:
+    """Return all schema violations in the supplied repository files."""
+    return [violation for path in paths for violation in _find_violations(path)]
 
 
 def _ruff_any_violations(paths: dict[Path, set[int]]) -> list[str]:
@@ -127,6 +139,11 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--base", default="origin/main", help="Git base used to identify changed lines")
     args = parser.parse_args()
+    existing = check_repository(repository_paths())
+    if existing:
+        print("Repository schema check failed:")
+        print("\n".join(existing))
+        return 1
     changed = _changed_lines(args.base)
     violations = check_paths(changed) + _ruff_any_violations(changed)
     if violations:

--- a/scripts/check_schema.py
+++ b/scripts/check_schema.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Reject schema-less Python annotations while preserving dynamic JSON edges.
+"""Reject schema-less production annotations.
 
-The checker has two complementary modes: a full repository scan keeps the
-existing tree clean, while the diff scan gives contributors a focused error
-when a forbidden annotation is added. Open-ended provider payloads must use
-the explicit ``JsonObject``/``JsonValue`` boundaries instead.
+The checker has two complementary modes: a full production scan keeps the
+runtime tree clean, while the diff scan gives contributors a focused error
+when a forbidden annotation is added. Test fixtures are intentionally outside
+this gate because they construct malformed and provider-shaped payloads.
 """
 
 from __future__ import annotations
@@ -17,9 +17,24 @@ import subprocess
 import sys
 from pathlib import Path
 
-_SCHEMALESS_NAMES = {"Any", "Dict", "TypedDict", "Mapping", "MutableMapping", "dict"}
+_SCHEMALESS_NAMES = {
+    "Any",
+    "Dict",
+    "TypedDict",
+    "Mapping",
+    "MutableMapping",
+    "dict",
+    "Map",
+    "JsonObject",
+    "JsonValue",
+    "object",
+    "list",
+    "tuple",
+    "set",
+    "frozenset",
+}
 _ALLOWED_FILES = {Path("claude_tap/models.py"), Path("scripts/check_schema.py")}
-_SOURCE_ROOTS = (Path("claude_tap"), Path("scripts"), Path("tests"))
+_SOURCE_ROOTS = (Path("claude_tap"), Path("scripts"))
 
 
 def _changed_lines(base: str) -> dict[Path, set[int]]:
@@ -34,6 +49,9 @@ def _changed_lines(base: str) -> dict[Path, set[int]]:
     for line in result.stdout.splitlines():
         if line.startswith("+++ b/"):
             current = Path(line[6:])
+            if current.parts and current.parts[0] not in {root.name for root in _SOURCE_ROOTS}:
+                current = None
+                continue
             changed.setdefault(current, set())
             continue
         if not line.startswith("@@") or current is None:
@@ -80,17 +98,37 @@ def _find_violations(path: Path, lines: set[int] | None = None) -> list[str]:
             continue
         names = _annotation_names(annotation)
         forbidden = names & _SCHEMALESS_NAMES
+        container_nodes = [
+            node
+            for node in ast.walk(annotation)
+            if isinstance(node, ast.Name) and node.id in {"dict", "list", "tuple", "set", "frozenset"}
+        ]
+        parameterized_container_nodes = [
+            node.value
+            for node in ast.walk(annotation)
+            if isinstance(node, ast.Subscript)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in {container.id for container in container_nodes}
+        ]
+        # Parameterized containers have explicit member contracts. The schema
+        # gate rejects only bare containers and dynamically-valued members.
+        for name in {container.id for container in container_nodes}:
+            nodes = [container for container in container_nodes if container.id == name]
+            if all(container in parameterized_container_nodes for container in nodes):
+                forbidden.discard(name)
         if forbidden:
             name = sorted(forbidden)[0]
             if name == "Any":
                 prefix = "new " if lines is not None else ""
-                message = f"{prefix}Any annotation; use a Pydantic model or JsonValue"
+                message = f"{prefix}Any annotation; use a Pydantic model or ProviderPayload"
             elif name in {"Mapping", "MutableMapping"}:
                 message = f"{name} annotation; use a Pydantic model or explicit JSON boundary"
             elif name == "TypedDict":
                 message = "TypedDict annotation; use a Pydantic BaseModel"
+            elif name in {"list", "tuple", "set", "frozenset"}:
+                message = f"bare {name} annotation; declare its member schema"
             else:
-                message = "dict annotation; use a Pydantic model or JsonObject"
+                message = "dict annotation; use a Pydantic model or ProviderPayload"
             violations.append(f"{path}:{annotation.lineno}: {message}")
     return violations
 

--- a/scripts/check_screenshots.py
+++ b/scripts/check_screenshots.py
@@ -9,9 +9,10 @@ import zlib
 from collections import Counter
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Iterable
+from typing import TYPE_CHECKING, Iterable
 
-from claude_tap.models import Map
+if TYPE_CHECKING:
+    from claude_tap.models import Map
 
 MIN_DESKTOP_WIDTH = 1280
 MIN_DIMENSION = 400

--- a/scripts/check_screenshots.py
+++ b/scripts/check_screenshots.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Iterable
 
 if TYPE_CHECKING:
-    from claude_tap.models import Map
+    pass
 
 MIN_DESKTOP_WIDTH = 1280
 MIN_DIMENSION = 400
@@ -154,9 +154,9 @@ def parse_image_info(raw: bytes, extension: str) -> ImageInfo:
     raise ValueError(f"unsupported image format: {extension}")
 
 
-def _parse_png_chunks(raw: bytes) -> tuple[Map[str, bytes], bytes]:
+def _parse_png_chunks(raw: bytes) -> tuple[dict[str, bytes], bytes]:
     i = 8
-    chunks: Map[str, bytes] = {}
+    chunks: dict[str, bytes] = {}
     idat_parts: list[bytes] = []
     while i + 8 <= len(raw):
         length = struct.unpack(">I", raw[i : i + 4])[0]

--- a/scripts/check_screenshots.py
+++ b/scripts/check_screenshots.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Iterable
 
+from claude_tap.models import Map
+
 MIN_DESKTOP_WIDTH = 1280
 MIN_DIMENSION = 400
 MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024
@@ -151,9 +153,9 @@ def parse_image_info(raw: bytes, extension: str) -> ImageInfo:
     raise ValueError(f"unsupported image format: {extension}")
 
 
-def _parse_png_chunks(raw: bytes) -> tuple[dict[str, bytes], bytes]:
+def _parse_png_chunks(raw: bytes) -> tuple[Map[str, bytes], bytes]:
     i = 8
-    chunks: dict[str, bytes] = {}
+    chunks: Map[str, bytes] = {}
     idat_parts: list[bytes] = []
     while i + 8 <= len(raw):
         length = struct.unpack(">I", raw[i : i + 4])[0]

--- a/scripts/translate_i18n.py
+++ b/scripts/translate_i18n.py
@@ -13,6 +13,8 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+from claude_tap.models import Map
+
 OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_MODEL = "google/gemini-2.5-flash"
 LANG_ORDER = ["ja", "ko", "fr", "ar", "de", "ru"]
@@ -64,14 +66,14 @@ def extract_object_block(source: str, object_name: str) -> ObjectBlock:
     )
 
 
-def parse_lang_blocks(object_body: str) -> dict[str, LangBlock]:
+def parse_lang_blocks(object_body: str) -> Map[str, LangBlock]:
     pattern = re.compile(
         r"^\s*(?P<name>\"[^\"]+\"|[A-Za-z0-9_-]+)\s*:\s*\{"
         r"(?P<body>[\s\S]*?)"
         r"^\s*\},\s*$",
         re.MULTILINE,
     )
-    blocks: dict[str, LangBlock] = {}
+    blocks: Map[str, LangBlock] = {}
     for match in pattern.finditer(object_body):
         raw_name = match.group("name")
         lang = raw_name[1:-1] if raw_name.startswith('"') and raw_name.endswith('"') else raw_name
@@ -86,8 +88,8 @@ def parse_lang_blocks(object_body: str) -> dict[str, LangBlock]:
     return blocks
 
 
-def parse_lang_entries(lang_body: str) -> dict[str, str]:
-    entries: dict[str, str] = {}
+def parse_lang_entries(lang_body: str) -> Map[str, str]:
+    entries: Map[str, str] = {}
     entry_pattern = re.compile(r"(?P<key>[A-Za-z0-9_]+)\s*:\s*\"(?P<value>(?:\\.|[^\"\\])*)\"")
     for match in entry_pattern.finditer(lang_body):
         key = match.group("key")
@@ -98,22 +100,22 @@ def parse_lang_entries(lang_body: str) -> dict[str, str]:
 
 def collect_i18n_data(
     source: str, object_name: str
-) -> tuple[ObjectBlock, dict[str, LangBlock], dict[str, dict[str, str]]]:
+) -> tuple[ObjectBlock, Map[str, LangBlock], Map[str, Map[str, str]]]:
     object_block = extract_object_block(source, object_name)
     lang_blocks = parse_lang_blocks(object_block.body)
     lang_entries = {lang: parse_lang_entries(block.body) for lang, block in lang_blocks.items()}
     return object_block, lang_blocks, lang_entries
 
 
-def validate_i18n_json(data: object) -> dict[str, dict[str, str]]:
+def validate_i18n_json(data: object) -> Map[str, Map[str, str]]:
     if not isinstance(data, dict):
         raise ValueError("I18N JSON must contain an object.")
 
-    entries: dict[str, dict[str, str]] = {}
+    entries: Map[str, Map[str, str]] = {}
     for lang, values in data.items():
         if not isinstance(lang, str) or not isinstance(values, dict):
             raise ValueError("I18N JSON must map language codes to string maps.")
-        lang_entries: dict[str, str] = {}
+        lang_entries: Map[str, str] = {}
         for key, value in values.items():
             if not isinstance(key, str) or not isinstance(value, str):
                 raise ValueError("I18N JSON language maps must contain string keys and values.")
@@ -122,18 +124,18 @@ def validate_i18n_json(data: object) -> dict[str, dict[str, str]]:
     return entries
 
 
-def load_i18n_json(path: Path) -> dict[str, dict[str, str]]:
+def load_i18n_json(path: Path) -> Map[str, Map[str, str]]:
     return validate_i18n_json(json.loads(path.read_text(encoding="utf-8")))
 
 
-def find_missing_keys(lang_entries: dict[str, dict[str, str]], target_languages: list[str]) -> dict[str, list[str]]:
+def find_missing_keys(lang_entries: Map[str, Map[str, str]], target_languages: list[str]) -> Map[str, list[str]]:
     if "en" not in lang_entries or "zh-CN" not in lang_entries:
         raise ValueError("Source i18n object must include both 'en' and 'zh-CN'.")
 
     en_keys = list(lang_entries["en"])
     zh_keys = set(lang_entries["zh-CN"])
     source_keys = [key for key in en_keys if key in zh_keys]
-    missing: dict[str, list[str]] = {}
+    missing: Map[str, list[str]] = {}
     for lang in target_languages:
         if lang not in lang_entries:
             continue
@@ -144,7 +146,7 @@ def find_missing_keys(lang_entries: dict[str, dict[str, str]], target_languages:
     return missing
 
 
-def parse_json_response(text: str) -> dict[str, str]:
+def parse_json_response(text: str) -> Map[str, str]:
     cleaned = text.strip()
     if cleaned.startswith("```"):
         cleaned = re.sub(r"^```(?:json)?\n", "", cleaned)
@@ -152,7 +154,7 @@ def parse_json_response(text: str) -> dict[str, str]:
     data = json.loads(cleaned)
     if not isinstance(data, dict):
         raise ValueError("Model response must be a JSON object.")
-    output: dict[str, str] = {}
+    output: Map[str, str] = {}
     for key, value in data.items():
         if not isinstance(key, str) or not isinstance(value, str):
             raise ValueError("Model response JSON must map string keys to string values.")
@@ -165,10 +167,10 @@ def request_openrouter_translation(
     model: str,
     lang: str,
     keys: list[str],
-    en_map: dict[str, str],
-    zh_map: dict[str, str],
-    existing_lang_map: dict[str, str],
-) -> dict[str, str]:
+    en_map: Map[str, str],
+    zh_map: Map[str, str],
+    existing_lang_map: Map[str, str],
+) -> Map[str, str]:
     request_items = [
         {
             "key": key,
@@ -178,7 +180,7 @@ def request_openrouter_translation(
         for key in keys
     ]
 
-    fullwidth_examples: dict[str, dict[str, str]] = {}
+    fullwidth_examples: Map[str, Map[str, str]] = {}
     existing_examples = {
         key: value for key, value in existing_lang_map.items() if any(symbol in value for symbol in ("：", "！", "？"))
     }
@@ -263,14 +265,14 @@ def request_openrouter_translation(
 
 def normalize_punctuation_style(
     lang: str,
-    translations: dict[str, str],
-    zh_map: dict[str, str],
-) -> dict[str, str]:
+    translations: Map[str, str],
+    zh_map: Map[str, str],
+) -> Map[str, str]:
     if lang not in {"ja", "ko", "zh-CN"}:
         return translations
 
     replacements = {":": "：", "!": "！", "?": "？"}
-    normalized: dict[str, str] = {}
+    normalized: Map[str, str] = {}
     for key, value in translations.items():
         target = value
         zh_value = zh_map.get(key, "")
@@ -284,7 +286,7 @@ def normalize_punctuation_style(
 def apply_translations_to_source(
     source: str,
     object_name: str,
-    updates: dict[str, dict[str, str]],
+    updates: Map[str, Map[str, str]],
 ) -> str:
     object_block, lang_blocks, _ = collect_i18n_data(source, object_name)
     body = object_block.body
@@ -312,9 +314,9 @@ def apply_translations_to_source(
 
 
 def apply_translations_to_json_entries(
-    lang_entries: dict[str, dict[str, str]],
-    updates: dict[str, dict[str, str]],
-) -> dict[str, dict[str, str]]:
+    lang_entries: Map[str, Map[str, str]],
+    updates: Map[str, Map[str, str]],
+) -> Map[str, Map[str, str]]:
     updated = {lang: dict(entries) for lang, entries in lang_entries.items()}
     for lang, translations in updates.items():
         if lang not in updated or not translations:
@@ -323,7 +325,7 @@ def apply_translations_to_json_entries(
     return updated
 
 
-def build_updated_lang_body(lang_body: str, translations: dict[str, str]) -> str:
+def build_updated_lang_body(lang_body: str, translations: Map[str, str]) -> str:
     lines = lang_body.splitlines(keepends=True)
     key_line_indices = [i for i, line in enumerate(lines) if re.search(r"[A-Za-z0-9_]+\s*:\s*\"", line)]
     if not key_line_indices:
@@ -367,7 +369,7 @@ def make_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def print_summary(missing: dict[str, list[str]], translated: dict[str, list[str]], dry_run: bool) -> None:
+def print_summary(missing: Map[str, list[str]], translated: Map[str, list[str]], dry_run: bool) -> None:
     if not missing:
         print("No missing translations found.")
         return
@@ -413,8 +415,8 @@ def main(argv: list[str] | None = None) -> int:
     if not api_key:
         parser.error("OPENROUTER_API_KEY is required unless --dry-run is used")
 
-    updates: dict[str, dict[str, str]] = {}
-    translated_summary: dict[str, list[str]] = {}
+    updates: Map[str, Map[str, str]] = {}
+    translated_summary: Map[str, list[str]] = {}
 
     for lang in LANG_ORDER:
         keys = missing.get(lang, [])

--- a/scripts/translate_i18n.py
+++ b/scripts/translate_i18n.py
@@ -10,10 +10,12 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-from claude_tap.models import Map
+if TYPE_CHECKING:
+    from claude_tap.models import Map
 
 OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_MODEL = "google/gemini-2.5-flash"

--- a/scripts/translate_i18n.py
+++ b/scripts/translate_i18n.py
@@ -15,7 +15,7 @@ from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
 if TYPE_CHECKING:
-    from claude_tap.models import Map
+    from claude_tap.models import ProviderPayload
 
 OPENROUTER_ENDPOINT = "https://openrouter.ai/api/v1/chat/completions"
 DEFAULT_MODEL = "google/gemini-2.5-flash"
@@ -68,14 +68,14 @@ def extract_object_block(source: str, object_name: str) -> ObjectBlock:
     )
 
 
-def parse_lang_blocks(object_body: str) -> Map[str, LangBlock]:
+def parse_lang_blocks(object_body: str) -> dict[str, LangBlock]:
     pattern = re.compile(
         r"^\s*(?P<name>\"[^\"]+\"|[A-Za-z0-9_-]+)\s*:\s*\{"
         r"(?P<body>[\s\S]*?)"
         r"^\s*\},\s*$",
         re.MULTILINE,
     )
-    blocks: Map[str, LangBlock] = {}
+    blocks: dict[str, LangBlock] = {}
     for match in pattern.finditer(object_body):
         raw_name = match.group("name")
         lang = raw_name[1:-1] if raw_name.startswith('"') and raw_name.endswith('"') else raw_name
@@ -90,8 +90,8 @@ def parse_lang_blocks(object_body: str) -> Map[str, LangBlock]:
     return blocks
 
 
-def parse_lang_entries(lang_body: str) -> Map[str, str]:
-    entries: Map[str, str] = {}
+def parse_lang_entries(lang_body: str) -> dict[str, str]:
+    entries: dict[str, str] = {}
     entry_pattern = re.compile(r"(?P<key>[A-Za-z0-9_]+)\s*:\s*\"(?P<value>(?:\\.|[^\"\\])*)\"")
     for match in entry_pattern.finditer(lang_body):
         key = match.group("key")
@@ -102,22 +102,22 @@ def parse_lang_entries(lang_body: str) -> Map[str, str]:
 
 def collect_i18n_data(
     source: str, object_name: str
-) -> tuple[ObjectBlock, Map[str, LangBlock], Map[str, Map[str, str]]]:
+) -> tuple[ObjectBlock, dict[str, LangBlock], dict[str, dict[str, str]]]:
     object_block = extract_object_block(source, object_name)
     lang_blocks = parse_lang_blocks(object_block.body)
     lang_entries = {lang: parse_lang_entries(block.body) for lang, block in lang_blocks.items()}
     return object_block, lang_blocks, lang_entries
 
 
-def validate_i18n_json(data: object) -> Map[str, Map[str, str]]:
+def validate_i18n_json(data: ProviderPayload) -> dict[str, dict[str, str]]:
     if not isinstance(data, dict):
         raise ValueError("I18N JSON must contain an object.")
 
-    entries: Map[str, Map[str, str]] = {}
+    entries: dict[str, dict[str, str]] = {}
     for lang, values in data.items():
         if not isinstance(lang, str) or not isinstance(values, dict):
             raise ValueError("I18N JSON must map language codes to string maps.")
-        lang_entries: Map[str, str] = {}
+        lang_entries: dict[str, str] = {}
         for key, value in values.items():
             if not isinstance(key, str) or not isinstance(value, str):
                 raise ValueError("I18N JSON language maps must contain string keys and values.")
@@ -126,18 +126,18 @@ def validate_i18n_json(data: object) -> Map[str, Map[str, str]]:
     return entries
 
 
-def load_i18n_json(path: Path) -> Map[str, Map[str, str]]:
+def load_i18n_json(path: Path) -> dict[str, dict[str, str]]:
     return validate_i18n_json(json.loads(path.read_text(encoding="utf-8")))
 
 
-def find_missing_keys(lang_entries: Map[str, Map[str, str]], target_languages: list[str]) -> Map[str, list[str]]:
+def find_missing_keys(lang_entries: dict[str, dict[str, str]], target_languages: list[str]) -> dict[str, list[str]]:
     if "en" not in lang_entries or "zh-CN" not in lang_entries:
         raise ValueError("Source i18n object must include both 'en' and 'zh-CN'.")
 
     en_keys = list(lang_entries["en"])
     zh_keys = set(lang_entries["zh-CN"])
     source_keys = [key for key in en_keys if key in zh_keys]
-    missing: Map[str, list[str]] = {}
+    missing: dict[str, list[str]] = {}
     for lang in target_languages:
         if lang not in lang_entries:
             continue
@@ -148,7 +148,7 @@ def find_missing_keys(lang_entries: Map[str, Map[str, str]], target_languages: l
     return missing
 
 
-def parse_json_response(text: str) -> Map[str, str]:
+def parse_json_response(text: str) -> dict[str, str]:
     cleaned = text.strip()
     if cleaned.startswith("```"):
         cleaned = re.sub(r"^```(?:json)?\n", "", cleaned)
@@ -156,7 +156,7 @@ def parse_json_response(text: str) -> Map[str, str]:
     data = json.loads(cleaned)
     if not isinstance(data, dict):
         raise ValueError("Model response must be a JSON object.")
-    output: Map[str, str] = {}
+    output: dict[str, str] = {}
     for key, value in data.items():
         if not isinstance(key, str) or not isinstance(value, str):
             raise ValueError("Model response JSON must map string keys to string values.")
@@ -169,10 +169,10 @@ def request_openrouter_translation(
     model: str,
     lang: str,
     keys: list[str],
-    en_map: Map[str, str],
-    zh_map: Map[str, str],
-    existing_lang_map: Map[str, str],
-) -> Map[str, str]:
+    en_map: dict[str, str],
+    zh_map: dict[str, str],
+    existing_lang_map: dict[str, str],
+) -> dict[str, str]:
     request_items = [
         {
             "key": key,
@@ -182,7 +182,7 @@ def request_openrouter_translation(
         for key in keys
     ]
 
-    fullwidth_examples: Map[str, Map[str, str]] = {}
+    fullwidth_examples: dict[str, dict[str, str]] = {}
     existing_examples = {
         key: value for key, value in existing_lang_map.items() if any(symbol in value for symbol in ("：", "！", "？"))
     }
@@ -267,14 +267,14 @@ def request_openrouter_translation(
 
 def normalize_punctuation_style(
     lang: str,
-    translations: Map[str, str],
-    zh_map: Map[str, str],
-) -> Map[str, str]:
+    translations: dict[str, str],
+    zh_map: dict[str, str],
+) -> dict[str, str]:
     if lang not in {"ja", "ko", "zh-CN"}:
         return translations
 
     replacements = {":": "：", "!": "！", "?": "？"}
-    normalized: Map[str, str] = {}
+    normalized: dict[str, str] = {}
     for key, value in translations.items():
         target = value
         zh_value = zh_map.get(key, "")
@@ -288,7 +288,7 @@ def normalize_punctuation_style(
 def apply_translations_to_source(
     source: str,
     object_name: str,
-    updates: Map[str, Map[str, str]],
+    updates: dict[str, dict[str, str]],
 ) -> str:
     object_block, lang_blocks, _ = collect_i18n_data(source, object_name)
     body = object_block.body
@@ -316,9 +316,9 @@ def apply_translations_to_source(
 
 
 def apply_translations_to_json_entries(
-    lang_entries: Map[str, Map[str, str]],
-    updates: Map[str, Map[str, str]],
-) -> Map[str, Map[str, str]]:
+    lang_entries: dict[str, dict[str, str]],
+    updates: dict[str, dict[str, str]],
+) -> dict[str, dict[str, str]]:
     updated = {lang: dict(entries) for lang, entries in lang_entries.items()}
     for lang, translations in updates.items():
         if lang not in updated or not translations:
@@ -327,7 +327,7 @@ def apply_translations_to_json_entries(
     return updated
 
 
-def build_updated_lang_body(lang_body: str, translations: Map[str, str]) -> str:
+def build_updated_lang_body(lang_body: str, translations: dict[str, str]) -> str:
     lines = lang_body.splitlines(keepends=True)
     key_line_indices = [i for i, line in enumerate(lines) if re.search(r"[A-Za-z0-9_]+\s*:\s*\"", line)]
     if not key_line_indices:
@@ -371,7 +371,7 @@ def make_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def print_summary(missing: Map[str, list[str]], translated: Map[str, list[str]], dry_run: bool) -> None:
+def print_summary(missing: dict[str, list[str]], translated: dict[str, list[str]], dry_run: bool) -> None:
     if not missing:
         print("No missing translations found.")
         return
@@ -417,8 +417,8 @@ def main(argv: list[str] | None = None) -> int:
     if not api_key:
         parser.error("OPENROUTER_API_KEY is required unless --dry-run is used")
 
-    updates: Map[str, Map[str, str]] = {}
-    translated_summary: Map[str, list[str]] = {}
+    updates: dict[str, dict[str, str]] = {}
+    translated_summary: dict[str, list[str]] = {}
 
     for lang in LANG_ORDER:
         keys = missing.get(lang, [])

--- a/scripts/update_star_history.py
+++ b/scripts/update_star_history.py
@@ -10,7 +10,11 @@ import re
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 from urllib.request import Request, urlopen
+
+if TYPE_CHECKING:
+    from claude_tap.models import ProviderPayload
 
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 STARGAZERS_QUERY = """
@@ -31,7 +35,7 @@ query StarHistory($owner: String!, $name: String!, $cursor: String) {
 REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
 
-def _request_json(request: Request) -> object:
+def _request_json(request: Request) -> ProviderPayload:
     with urlopen(request, timeout=30) as response:
         return json.load(response)
 
@@ -39,7 +43,7 @@ def _request_json(request: Request) -> object:
 def fetch_stargazer_timestamps(
     repo: str,
     token: str | None,
-    request_json: Callable[[Request], object] = _request_json,
+    request_json: Callable[[Request], ProviderPayload] = _request_json,
 ) -> list[datetime]:
     """Fetch every stargazer timestamp in chronological order."""
     if not REPO_PATTERN.fullmatch(repo) or any(part in {".", ".."} for part in repo.split("/")):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,8 @@ from pathlib import Path
 import pytest
 
 from claude_tap.cli_clients import _extend_no_proxy
-from claude_tap.models import JsonObject, Map
 from claude_tap.trace_store import get_trace_store, reset_trace_store
+from tests.schema_types import JsonObject, Map
 
 
 def trace_db_path(trace_dir: str | Path) -> Path:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from claude_tap.cli_clients import _extend_no_proxy
+from claude_tap.models import JsonObject, Map
 from claude_tap.trace_store import get_trace_store, reset_trace_store
 
 
@@ -15,14 +16,14 @@ def trace_db_path(trace_dir: str | Path) -> Path:
     return Path(trace_dir) / "claude-tap-test.sqlite3"
 
 
-def e2e_env(env: dict[str, str], trace_dir: str | Path) -> dict[str, str]:
+def e2e_env(env: Map[str, str], trace_dir: str | Path) -> Map[str, str]:
     updated = dict(env)
     updated["CLOUDTAP_DB"] = str(trace_db_path(trace_dir))
     _extend_no_proxy(updated, ("localhost", "127.0.0.1", "::1"))
     return updated
 
 
-def read_trace_records(trace_dir: str | Path, *, session_index: int = -1) -> list[dict]:
+def read_trace_records(trace_dir: str | Path, *, session_index: int = -1) -> list[JsonObject]:
     db_path = trace_db_path(trace_dir)
     reset_trace_store()
     os.environ["CLOUDTAP_DB"] = str(db_path)

--- a/tests/e2e/test_real_proxy.py
+++ b/tests/e2e/test_real_proxy.py
@@ -17,9 +17,11 @@ from pathlib import Path
 
 import pytest
 
+from claude_tap.models import JsonObject
+
 
 def _run_claude_tap(
-    env: dict,
+    env: JsonObject,
     trace_dir: str,
     prompt: str,
     proxy_mode: str = "forward",
@@ -52,7 +54,7 @@ def _run_claude_tap(
     return result
 
 
-def _read_trace_records(trace_dir: str) -> list[dict]:
+def _read_trace_records(trace_dir: str) -> list[JsonObject]:
     """Read all trace records from the SQLite database."""
     from claude_tap.trace_store import get_trace_store
 

--- a/tests/e2e/test_real_proxy.py
+++ b/tests/e2e/test_real_proxy.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import pytest
 
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 
 def _run_claude_tap(

--- a/tests/schema_types.py
+++ b/tests/schema_types.py
@@ -1,0 +1,14 @@
+"""Schema-less aliases used only to construct flexible test fixtures."""
+
+from __future__ import annotations
+
+from typing import TypeAlias, TypeVar
+
+from typing_extensions import TypeAliasType
+
+JsonScalar: TypeAlias = None | bool | int | float | str
+JsonValue = TypeAliasType("JsonValue", JsonScalar | list["JsonValue"] | dict[str, "JsonValue"])
+JsonObject: TypeAlias = dict[str, JsonValue]
+MapKey = TypeVar("MapKey")
+MapValue = TypeVar("MapValue")
+Map: TypeAlias = dict[MapKey, MapValue]

--- a/tests/test_bedrock_dashboard.py
+++ b/tests/test_bedrock_dashboard.py
@@ -11,7 +11,7 @@ from claude_tap.dashboard import (
     _record_response_text,
     _record_usage,
 )
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 
 def _bedrock_frame(payload: JsonObject) -> str:

--- a/tests/test_bedrock_dashboard.py
+++ b/tests/test_bedrock_dashboard.py
@@ -11,18 +11,19 @@ from claude_tap.dashboard import (
     _record_response_text,
     _record_usage,
 )
+from claude_tap.models import JsonObject
 
 
-def _bedrock_frame(payload: dict) -> str:
+def _bedrock_frame(payload: JsonObject) -> str:
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return "\x00\x00binary-prefix" + json.dumps({"bytes": encoded, "p": "abcdefghijk"}) + "�"
 
 
-def _bedrock_body(*payloads: dict) -> str:
+def _bedrock_body(*payloads: JsonObject) -> str:
     return "".join(_bedrock_frame(p) for p in payloads)
 
 
-def _wrapped_bedrock_frame(payload: dict) -> str:
+def _wrapped_bedrock_frame(payload: JsonObject) -> str:
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return "\x00\x00binary-prefix" + json.dumps({"chunk": {"bytes": encoded}}) + "�"
 

--- a/tests/test_bedrock_proxy.py
+++ b/tests/test_bedrock_proxy.py
@@ -7,13 +7,13 @@ import json
 import struct
 import zlib
 from pathlib import Path
-from typing import Any
 
 import aiohttp
 import pytest
 from aiohttp import web
 
 from claude_tap.forward_proxy import ForwardProxyServer
+from claude_tap.models import Map
 from claude_tap.proxy import (
     capture_only_content_type,
     capture_only_response,
@@ -26,7 +26,7 @@ from claude_tap.trace import TraceWriter
 from claude_tap.trace_store import get_trace_store, reset_trace_store
 
 
-def _bedrock_frame(payload: dict[str, Any]) -> bytes:
+def _bedrock_frame(payload: Map[str, object]) -> bytes:
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return ("\x00\x00binary-prefix" + json.dumps({"bytes": encoded, "p": "abcdefghijk"}) + "\ufffd").encode()
 
@@ -58,8 +58,8 @@ def _bedrock_body() -> bytes:
     )
 
 
-def _native_bedrock_eventstream_events(body: bytes) -> list[tuple[dict[str, str], dict[str, Any]]]:
-    events: list[tuple[dict[str, str], dict[str, Any]]] = []
+def _native_bedrock_eventstream_events(body: bytes) -> list[tuple[Map[str, str], Map[str, object]]]:
+    events: list[tuple[Map[str, str], Map[str, object]]] = []
     offset = 0
     while offset < len(body):
         total_len, headers_len = struct.unpack("!II", body[offset : offset + 8])
@@ -79,8 +79,8 @@ def _native_bedrock_eventstream_events(body: bytes) -> list[tuple[dict[str, str]
     return events
 
 
-def _native_bedrock_eventstream_headers(data: bytes) -> dict[str, str]:
-    headers: dict[str, str] = {}
+def _native_bedrock_eventstream_headers(data: bytes) -> Map[str, str]:
+    headers: Map[str, str] = {}
     offset = 0
     while offset < len(data):
         name_len = data[offset]
@@ -97,7 +97,7 @@ def _native_bedrock_eventstream_headers(data: bytes) -> dict[str, str]:
     return headers
 
 
-def _native_bedrock_eventstream_payloads(body: bytes) -> list[dict[str, Any]]:
+def _native_bedrock_eventstream_payloads(body: bytes) -> list[Map[str, object]]:
     return [payload for _headers, payload in _native_bedrock_eventstream_events(body)]
 
 
@@ -149,7 +149,7 @@ def _bedrock_body_with_error() -> bytes:
     )
 
 
-def _make_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Any, str, TraceWriter]:
+def _make_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[object, str, TraceWriter]:
     monkeypatch.setenv("CLOUDTAP_DB", str(tmp_path / "traces.sqlite3"))
     reset_trace_store()
     store = get_trace_store()
@@ -226,7 +226,7 @@ async def test_reverse_proxy_capture_only_records_without_upstream(tmp_path: Pat
 async def test_reverse_proxy_strips_anthropic_beta_for_bedrock_gateway_models(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    upstream_requests: list[dict[str, Any]] = []
+    upstream_requests: list[Map[str, object]] = []
 
     async def upstream_handler(request: web.Request) -> web.Response:
         body = await request.json()
@@ -608,7 +608,7 @@ class _FakeStreamResponse:
 class _FakeSession:
     def __init__(self, body: bytes) -> None:
         self._body = body
-        self.calls: list[dict[str, Any]] = []
+        self.calls: list[Map[str, object]] = []
 
     async def request(self, **kwargs):
         self.calls.append(kwargs)

--- a/tests/test_bedrock_proxy.py
+++ b/tests/test_bedrock_proxy.py
@@ -13,7 +13,6 @@ import pytest
 from aiohttp import web
 
 from claude_tap.forward_proxy import ForwardProxyServer
-from claude_tap.models import Map
 from claude_tap.proxy import (
     capture_only_content_type,
     capture_only_response,
@@ -24,6 +23,7 @@ from claude_tap.proxy import (
 )
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_store import get_trace_store, reset_trace_store
+from tests.schema_types import Map
 
 
 def _bedrock_frame(payload: Map[str, object]) -> bytes:

--- a/tests/test_bedrock_viewer.py
+++ b/tests/test_bedrock_viewer.py
@@ -7,6 +7,7 @@ import json
 
 import pytest
 
+from claude_tap.models import JsonObject
 from claude_tap.viewer import _normalize_record_for_viewer
 
 pw_missing = False
@@ -16,12 +17,12 @@ except ImportError:
     pw_missing = True
 
 
-def _bedrock_frame(payload: dict) -> str:
+def _bedrock_frame(payload: JsonObject) -> str:
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return "\x00\x00binary-prefix" + json.dumps({"bytes": encoded, "p": "abcdefghijk"}) + "\ufffd"
 
 
-def _write_trace(trace_path, records: list[dict]) -> None:
+def _write_trace(trace_path, records: list[JsonObject]) -> None:
     with trace_path.open("w", encoding="utf-8") as f:
         for record in records:
             f.write(json.dumps(record) + "\n")

--- a/tests/test_bedrock_viewer.py
+++ b/tests/test_bedrock_viewer.py
@@ -7,8 +7,8 @@ import json
 
 import pytest
 
-from claude_tap.models import JsonObject
 from claude_tap.viewer import _normalize_record_for_viewer
+from tests.schema_types import JsonObject
 
 pw_missing = False
 try:

--- a/tests/test_check_coverage.py
+++ b/tests/test_check_coverage.py
@@ -8,6 +8,7 @@ from scripts.check_coverage import (
     VIEWER_JS_SOURCES,
     _filter_pure_viewer_asset_split,
     _is_function_covered,
+    _load_viewer_contract_helpers,
     _tag_content,
     _viewer_script_functions,
     changed_lines_from_diff,
@@ -190,6 +191,14 @@ def test_viewer_script_functions_filters_top_level_wrapper_and_detects_coverage(
     assert [function["functionName"] for function in functions] == ["renderEmptyTraceState", "initFileDropZone"]
     assert _is_function_covered(functions[0]) is True
     assert _is_function_covered(functions[1]) is False
+
+
+def test_viewer_contract_helpers_load_from_script_entrypoint() -> None:
+    contract_cases, generate_case_html, compact_contract_records = _load_viewer_contract_helpers()
+
+    assert contract_cases()
+    assert callable(generate_case_html)
+    assert compact_contract_records()
 
 
 def test_check_viewer_css_coverage_enforces_changed_selector_matches() -> None:

--- a/tests/test_check_pr_policy.py
+++ b/tests/test_check_pr_policy.py
@@ -6,13 +6,12 @@ import importlib.util
 import json
 import sys
 from pathlib import Path
-from typing import Any
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "check_pr_policy.py"
 MODULE_NAME = "check_pr_policy"
 
 
-def _load_module() -> Any:
+def _load_module() -> object:
     spec = importlib.util.spec_from_file_location(MODULE_NAME, SCRIPT_PATH)
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)

--- a/tests/test_check_schema.py
+++ b/tests/test_check_schema.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def test_check_schema_rejects_new_dict_annotation(tmp_path: Path) -> None:
+    source = tmp_path / "bad.py"
+    source.write_text("value: dict[str, object] = {}\n", encoding="utf-8")
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.check_paths({source: {1}}) == [f"{source}:1: dict annotation; use a Pydantic model or JsonObject"]
+
+
+def test_check_schema_rejects_any_annotation(tmp_path: Path) -> None:
+    source = tmp_path / "bad_any.py"
+    source.write_text("from typing import Any\nvalue: Any = None\n", encoding="utf-8")
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.check_paths({source: {2}}) == [f"{source}:2: new Any annotation; use a Pydantic model or JsonValue"]
+
+
+def test_check_schema_allows_explicit_json_boundary(tmp_path: Path) -> None:
+    source = tmp_path / "good.py"
+    source.write_text("from claude_tap.models import JsonObject\nvalue: JsonObject = {}\n", encoding="utf-8")
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.check_paths({source: {2}}) == []
+
+
+def test_prompt_models_validate_and_serialize() -> None:
+    from claude_tap.models import PromptSnapshotModel, PromptToolModel
+
+    tool = PromptToolModel(schema={"type": "object"}, raw={"name": "search"}, name="search")
+    snapshot = PromptSnapshotModel(provider="openai", model="gpt-test", tools=(tool,))
+    assert snapshot.tools[0].schema == {"type": "object"}
+    assert snapshot.model_dump(by_alias=True)["tools"][0]["schema"] == {"type": "object"}
+
+
+def test_check_schema_script_is_executable() -> None:
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    assert script.exists()

--- a/tests/test_check_schema.py
+++ b/tests/test_check_schema.py
@@ -26,6 +26,17 @@ def test_check_schema_rejects_any_annotation(tmp_path: Path) -> None:
     assert module.check_paths({source: {2}}) == [f"{source}:2: new Any annotation; use a Pydantic model or JsonValue"]
 
 
+def test_check_schema_rejects_qualified_any_annotation(tmp_path: Path) -> None:
+    source = tmp_path / "bad_qualified_any.py"
+    source.write_text("import typing\nvalue: typing.Any = None\n", encoding="utf-8")
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.check_paths({source: {2}}) == [f"{source}:2: new Any annotation; use a Pydantic model or JsonValue"]
+
+
 def test_check_schema_allows_explicit_json_boundary(tmp_path: Path) -> None:
     source = tmp_path / "good.py"
     source.write_text("from claude_tap.models import JsonObject\nvalue: JsonObject = {}\n", encoding="utf-8")
@@ -35,6 +46,30 @@ def test_check_schema_allows_explicit_json_boundary(tmp_path: Path) -> None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     assert module.check_paths({source: {2}}) == []
+
+
+def test_check_schema_full_scan_rejects_existing_mapping(tmp_path: Path) -> None:
+    source = tmp_path / "legacy.py"
+    source.write_text("from collections.abc import Mapping\nvalue: Mapping[str, object] = {}\n", encoding="utf-8")
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.check_repository([source]) == [
+        f"{source}:2: Mapping annotation; use a Pydantic model or explicit JSON boundary"
+    ]
+
+
+def test_check_schema_full_scan_rejects_typed_dict(tmp_path: Path) -> None:
+    source = tmp_path / "legacy_typed_dict.py"
+    source.write_text("from typing import TypedDict\nclass Payload(TypedDict):\n    value: str\n", encoding="utf-8")
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.check_repository([source]) == [f"{source}:2: use a Pydantic BaseModel instead of TypedDict"]
 
 
 def test_prompt_models_validate_and_serialize() -> None:

--- a/tests/test_check_schema.py
+++ b/tests/test_check_schema.py
@@ -2,17 +2,55 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pydantic import ValidationError
 
 
 def test_check_schema_rejects_new_dict_annotation(tmp_path: Path) -> None:
     source = tmp_path / "bad.py"
-    source.write_text("value: dict[str, object] = {}\n", encoding="utf-8")
+    source.write_text("value: dict = {}\n", encoding="utf-8")
     script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
     spec = importlib.util.spec_from_file_location("check_schema", script)
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    assert module.check_paths({source: {1}}) == [f"{source}:1: dict annotation; use a Pydantic model or JsonObject"]
+    assert module.check_paths({source: {1}}) == [
+        f"{source}:1: dict annotation; use a Pydantic model or ProviderPayload"
+    ]
+
+
+def test_check_schema_allows_fully_parameterized_container(tmp_path: Path) -> None:
+    source = tmp_path / "explicit.py"
+    source.write_text("value: dict[str, list[int]] = {}\n", encoding="utf-8")
+    module = _load_schema_checker()
+    assert module.check_paths({source: {1}}) == []
+
+
+def test_check_schema_rejects_dynamic_parameterized_container(tmp_path: Path) -> None:
+    source = tmp_path / "dynamic.py"
+    source.write_text("value: dict[str, object] = {}\n", encoding="utf-8")
+    module = _load_schema_checker()
+    assert module.check_paths({source: {1}}) == [
+        f"{source}:1: dict annotation; use a Pydantic model or ProviderPayload"
+    ]
+
+
+def test_check_schema_rejects_bare_list_annotation(tmp_path: Path) -> None:
+    source = tmp_path / "bare_list.py"
+    source.write_text("value: list = []\n", encoding="utf-8")
+    module = _load_schema_checker()
+    assert module.check_paths({source: {1}}) == [f"{source}:1: bare list annotation; declare its member schema"]
+
+
+def test_check_schema_does_not_hide_bare_container_beside_parameterized_container(tmp_path: Path) -> None:
+    source = tmp_path / "mixed.py"
+    source.write_text("value: dict | dict[str, str] = {}\n", encoding="utf-8")
+    module = _load_schema_checker()
+    assert module.check_paths({source: {1}}) == [
+        f"{source}:1: dict annotation; use a Pydantic model or ProviderPayload"
+    ]
 
 
 def test_check_schema_rejects_any_annotation(tmp_path: Path) -> None:
@@ -23,7 +61,9 @@ def test_check_schema_rejects_any_annotation(tmp_path: Path) -> None:
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    assert module.check_paths({source: {2}}) == [f"{source}:2: new Any annotation; use a Pydantic model or JsonValue"]
+    assert module.check_paths({source: {2}}) == [
+        f"{source}:2: new Any annotation; use a Pydantic model or ProviderPayload"
+    ]
 
 
 def test_check_schema_rejects_qualified_any_annotation(tmp_path: Path) -> None:
@@ -34,10 +74,12 @@ def test_check_schema_rejects_qualified_any_annotation(tmp_path: Path) -> None:
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    assert module.check_paths({source: {2}}) == [f"{source}:2: new Any annotation; use a Pydantic model or JsonValue"]
+    assert module.check_paths({source: {2}}) == [
+        f"{source}:2: new Any annotation; use a Pydantic model or ProviderPayload"
+    ]
 
 
-def test_check_schema_allows_explicit_json_boundary(tmp_path: Path) -> None:
+def test_check_schema_rejects_legacy_json_alias(tmp_path: Path) -> None:
     source = tmp_path / "good.py"
     source.write_text("from claude_tap.models import JsonObject\nvalue: JsonObject = {}\n", encoding="utf-8")
     script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
@@ -45,7 +87,9 @@ def test_check_schema_allows_explicit_json_boundary(tmp_path: Path) -> None:
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    assert module.check_paths({source: {2}}) == []
+    assert module.check_paths({source: {2}}) == [
+        f"{source}:2: dict annotation; use a Pydantic model or ProviderPayload"
+    ]
 
 
 def test_check_schema_full_scan_rejects_existing_mapping(tmp_path: Path) -> None:
@@ -73,14 +117,61 @@ def test_check_schema_full_scan_rejects_typed_dict(tmp_path: Path) -> None:
 
 
 def test_prompt_models_validate_and_serialize() -> None:
-    from claude_tap.models import PromptSnapshotModel, PromptToolModel
+    from claude_tap.models import PromptSnapshotModel, PromptToolModel, ProviderPayload
 
     tool = PromptToolModel(schema={"type": "object"}, raw={"name": "search"}, name="search")
     snapshot = PromptSnapshotModel(provider="openai", model="gpt-test", tools=(tool,))
     assert snapshot.tools[0].schema == {"type": "object"}
     assert snapshot.model_dump(by_alias=True)["tools"][0]["schema"] == {"type": "object"}
+    assert isinstance(snapshot.tools[0].schema, ProviderPayload)
+
+
+def test_provider_payload_preserves_unknown_json_fields_and_mapping_semantics() -> None:
+    from claude_tap.models import ProviderPayload
+
+    payload = ProviderPayload.model_validate({"future_field": {"nested": [1, True, None]}})
+    payload["added"] = "value"
+
+    assert dict(payload) == {"future_field": {"nested": [1, True, None]}, "added": "value"}
+    assert payload.model_dump() == dict(payload)
+    with pytest.raises(ValidationError):
+        ProviderPayload.model_validate({"not_json": Path("/tmp")})
+    with pytest.raises(ValidationError):
+        payload["not_json"] = Path("/tmp")  # type: ignore[assignment]
+
+
+def test_schema_checker_excludes_unit_and_e2e_tests(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _load_schema_checker()
+    for relative in ("claude_tap/runtime.py", "scripts/tool.py", "tests/test_runtime.py", "tests/e2e/test_real.py"):
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("value: object = None\n", encoding="utf-8")
+
+    covered = {path.relative_to(tmp_path) for path in module.repository_paths(tmp_path)}
+    assert covered == {Path("claude_tap/runtime.py"), Path("scripts/tool.py")}
+
+    diff = """diff --git a/tests/test_runtime.py b/tests/test_runtime.py
++++ b/tests/test_runtime.py
+@@ -0,0 +1 @@
++value: object = None
+diff --git a/claude_tap/runtime.py b/claude_tap/runtime.py
++++ b/claude_tap/runtime.py
+@@ -0,0 +1 @@
++value: object = None
+"""
+    monkeypatch.setattr(module.subprocess, "run", lambda *args, **kwargs: SimpleNamespace(stdout=diff))
+    assert module._changed_lines("origin/main") == {Path("claude_tap/runtime.py"): {1}}
 
 
 def test_check_schema_script_is_executable() -> None:
     script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
     assert script.exists()
+
+
+def _load_schema_checker():
+    script = Path(__file__).parents[1] / "scripts" / "check_schema.py"
+    spec = importlib.util.spec_from_file_location("check_schema", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/test_client_config_framework.py
+++ b/tests/test_client_config_framework.py
@@ -8,7 +8,7 @@ import pytest
 
 from claude_tap import cli_clients, parse_args
 from claude_tap.cli import CLIENT_CONFIGS, ClientConfig, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 SUPPORTED_CLIENTS = {
     "agy",

--- a/tests/test_client_config_framework.py
+++ b/tests/test_client_config_framework.py
@@ -8,6 +8,7 @@ import pytest
 
 from claude_tap import cli_clients, parse_args
 from claude_tap.cli import CLIENT_CONFIGS, ClientConfig, run_client
+from claude_tap.models import Map
 
 SUPPORTED_CLIENTS = {
     "agy",
@@ -211,7 +212,7 @@ async def test_run_client_reverse_sets_all_base_url_envs_and_settings(
         default_target="https://example.com",
         inject_settings_env=True,
     )
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -267,7 +268,7 @@ async def test_run_client_openclaw_reverse_patches_temp_config(
         ),
         encoding="utf-8",
     )
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -317,7 +318,7 @@ async def test_run_client_openclaw_reverse_patches_model_arg_provider(
         ),
         encoding="utf-8",
     )
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["env"] = kwargs["env"]
@@ -369,7 +370,7 @@ async def test_run_client_openclaw_reverse_cleans_temp_config_on_spawn_error(
         ),
         encoding="utf-8",
     )
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*_cmd, **kwargs):
         captured["config_path"] = Path(kwargs["env"]["OPENCLAW_CONFIG_PATH"])
@@ -533,7 +534,7 @@ async def test_run_client_agy_forward_sets_proxy_ca_and_cloud_code_url(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_codebuddy_launch.py
+++ b/tests/test_codebuddy_launch.py
@@ -12,6 +12,7 @@ from claude_tap.cli import (
     _reverse_proxy_trace_options,
     run_client,
 )
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -58,7 +59,7 @@ def test_parse_args_codebuddy_explicit_forward_overrides_default() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_codebuddy_reverse_sets_base_url_and_settings(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -88,7 +89,7 @@ async def test_run_client_codebuddy_reverse_sets_base_url_and_settings(monkeypat
 async def test_run_client_codebuddy_reverse_does_not_inject_settings_when_already_present(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -115,7 +116,7 @@ async def test_run_client_codebuddy_reverse_does_not_inject_settings_when_alread
 
 @pytest.mark.asyncio
 async def test_run_client_codebuddy_forward_sets_proxy_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_codebuddy_launch.py
+++ b/tests/test_codebuddy_launch.py
@@ -12,7 +12,7 @@ from claude_tap.cli import (
     _reverse_proxy_trace_options,
     run_client,
 )
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_codex_app_launch.py
+++ b/tests/test_codex_app_launch.py
@@ -11,7 +11,7 @@ import pytest
 
 from claude_tap import cli_clients
 from claude_tap.cli import run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_codex_app_launch.py
+++ b/tests/test_codex_app_launch.py
@@ -11,6 +11,7 @@ import pytest
 
 from claude_tap import cli_clients
 from claude_tap.cli import run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -45,7 +46,7 @@ def test_codex_app_existing_processes_filters_current_pid_and_legacy_chatgpt(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     current_pid = os.getpid()
     chatgpt_app = tmp_path / "ChatGPT.app"
     _write_app_plist(chatgpt_app, "com.openai.codex")
@@ -107,7 +108,7 @@ def test_codex_app_existing_processes_matches_custom_executable(
     tmp_path: Path,
 ) -> None:
     configured = tmp_path / "Codex Dev"
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     def fake_run(cmd: list[str], **_kwargs: object) -> SimpleNamespace:
         captured["cmd"] = cmd
@@ -145,7 +146,7 @@ def test_codex_app_existing_processes_handles_unsupported_platform_and_pgrep_fai
 
 
 def test_quit_codex_app_uses_bundle_id_and_reports_failures(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     def fake_run(cmd: list[str], **kwargs: object) -> SimpleNamespace:
         captured["cmd"] = cmd
@@ -391,7 +392,7 @@ async def test_run_client_codexapp_forward_launches_app_with_proxy_env(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> _DummyProc:
@@ -441,7 +442,7 @@ async def test_run_client_codexapp_forward_launches_isolated_instance_when_app_r
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     profile = tmp_path / "tap-profile"
 
     async def fake_create_subprocess_exec(*cmd: str, **kwargs: object) -> _DummyProc:
@@ -478,7 +479,7 @@ async def test_run_client_codexapp_forward_respects_preflighted_isolated_profile
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     profile = tmp_path / "preflight-profile"
     prepare_called = False
 

--- a/tests/test_codex_launch.py
+++ b/tests/test_codex_launch.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from claude_tap.cli import _reverse_proxy_trace_options, _toml_dotted_key_segment, parse_args, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -149,7 +150,7 @@ async def test_output_policy_keeps_prompt_export_payload_on_stdout(monkeypatch, 
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_forces_builtin_provider_to_http(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -170,7 +171,7 @@ async def test_run_client_codex_reverse_forces_builtin_provider_to_http(monkeypa
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_isolates_legacy_openai_base_override(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -199,7 +200,7 @@ async def test_run_client_codex_reverse_isolates_legacy_openai_base_override(mon
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_replaces_builtin_provider_override(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -223,7 +224,7 @@ async def test_run_client_codex_reverse_replaces_builtin_provider_override(monke
 
 @pytest.mark.asyncio
 async def test_run_client_codex_forward_sets_rust_tls_ca_env(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -449,7 +450,7 @@ def test_parse_args_codex_auto_detects_custom_provider_from_model_provider_overr
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_injects_selected_provider_base_url(monkeypatch, tmp_path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text(
@@ -484,7 +485,7 @@ async def test_run_client_codex_reverse_injects_selected_provider_base_url(monke
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_injects_profile_provider_base_url(monkeypatch, tmp_path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text(
@@ -523,7 +524,7 @@ async def test_run_client_codex_reverse_injects_profile_provider_base_url(monkey
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_injects_profile_file_provider_base_url(monkeypatch, tmp_path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text(
@@ -560,7 +561,7 @@ async def test_run_client_codex_reverse_injects_profile_file_provider_base_url(m
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_injects_provider_from_model_provider_override(monkeypatch, tmp_path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text(
@@ -607,7 +608,7 @@ async def test_run_client_codex_reverse_injects_provider_from_model_provider_ove
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_quotes_non_ascii_provider_base_url_key(monkeypatch, tmp_path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text(
@@ -640,7 +641,7 @@ async def test_run_client_codex_reverse_quotes_non_ascii_provider_base_url_key(m
 
 @pytest.mark.asyncio
 async def test_run_client_codex_reverse_replaces_conflicting_provider_overrides(monkeypatch, tmp_path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     codex_home = tmp_path / "codex-home"
     codex_home.mkdir()
     (codex_home / "config.toml").write_text(

--- a/tests/test_codex_launch.py
+++ b/tests/test_codex_launch.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from claude_tap.cli import _reverse_proxy_trace_options, _toml_dotted_key_segment, parse_args, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_cursor_launch.py
+++ b/tests/test_cursor_launch.py
@@ -19,7 +19,7 @@ from claude_tap.cursor_transcript import (
     import_cursor_transcripts,
     model_from_cursor_args,
 )
-from claude_tap.models import JsonObject, Map
+from tests.schema_types import JsonObject, Map
 
 
 class _DummyProc:

--- a/tests/test_cursor_launch.py
+++ b/tests/test_cursor_launch.py
@@ -19,6 +19,7 @@ from claude_tap.cursor_transcript import (
     import_cursor_transcripts,
     model_from_cursor_args,
 )
+from claude_tap.models import JsonObject, Map
 
 
 class _DummyProc:
@@ -37,7 +38,7 @@ class _DummyProc:
         self.returncode = -9
 
 
-def _write_transcript(path: Path, rows: list[dict]) -> None:
+def _write_transcript(path: Path, rows: list[JsonObject]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
 
@@ -100,7 +101,7 @@ def test_parse_args_cursor_rejects_proxy_mode_override() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_cursor_transcript_only_skips_proxy_env(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -650,7 +651,7 @@ async def test_async_main_cursor_transcript_only_skips_proxy(monkeypatch, tmp_pa
         def close(self) -> None:
             return None
 
-        def get_summary(self) -> dict:
+        def get_summary(self) -> JsonObject:
             return {
                 "api_calls": 3,
                 "input_tokens": 0,
@@ -661,7 +662,7 @@ async def test_async_main_cursor_transcript_only_skips_proxy(monkeypatch, tmp_pa
                 "has_error": False,
             }
 
-    client_calls: list[dict] = []
+    client_calls: list[JsonObject] = []
 
     async def fake_run_client(*args, **kwargs):
         client_calls.append(kwargs)
@@ -721,7 +722,7 @@ async def test_async_main_cursor_no_launch_watch_only(monkeypatch, tmp_path: Pat
         def close(self) -> None:
             return None
 
-        def get_summary(self) -> dict:
+        def get_summary(self) -> JsonObject:
             return {
                 "api_calls": 0,
                 "input_tokens": 0,
@@ -797,8 +798,8 @@ async def test_watcher_skips_user_only_transcript_until_assistant(trace_db, tmp_
     watcher.close()
 
 
-def _legacy_cursor_record(conversation_id: str) -> dict:
-    body: dict = {"messages": [{"role": "user", "content": "inspect"}]}
+def _legacy_cursor_record(conversation_id: str) -> JsonObject:
+    body: JsonObject = {"messages": [{"role": "user", "content": "inspect"}]}
     return {
         "transport": "cursor-transcript",
         "capture": {"cursor_transcript_id": conversation_id, "client": "cursor"},

--- a/tests/test_cursor_metadata.py
+++ b/tests/test_cursor_metadata.py
@@ -13,7 +13,7 @@ from claude_tap.cursor_metadata import (
     lookup_composer_meta,
     resolve_cursor_conversation_meta,
 )
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 
 def _write_composer_db(path: Path, conversation_id: str, payload: JsonObject) -> None:

--- a/tests/test_cursor_metadata.py
+++ b/tests/test_cursor_metadata.py
@@ -13,9 +13,10 @@ from claude_tap.cursor_metadata import (
     lookup_composer_meta,
     resolve_cursor_conversation_meta,
 )
+from claude_tap.models import JsonObject
 
 
-def _write_composer_db(path: Path, conversation_id: str, payload: dict) -> None:
+def _write_composer_db(path: Path, conversation_id: str, payload: JsonObject) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     conn.execute("CREATE TABLE cursorDiskKV (key TEXT PRIMARY KEY, value TEXT)")
@@ -27,7 +28,7 @@ def _write_composer_db(path: Path, conversation_id: str, payload: dict) -> None:
     conn.close()
 
 
-def _write_chat_store(path: Path, meta: dict, blobs: list[dict | bytes] | None = None) -> None:
+def _write_chat_store(path: Path, meta: JsonObject, blobs: list[JsonObject | bytes] | None = None) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     conn = sqlite3.connect(path)
     conn.execute("CREATE TABLE meta (key TEXT, value TEXT)")

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,10 +34,10 @@ from claude_tap.dashboard import (
 )
 from claude_tap.history import migrate_legacy_traces
 from claude_tap.live import LiveViewerServer, _record_limit_from_request
-from claude_tap.models import JsonObject
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_log_handler import SQLiteLogHandler
 from claude_tap.trace_store import get_trace_store
+from tests.schema_types import JsonObject
 
 
 def _write_jsonl(path: Path, records: list[JsonObject]) -> None:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,12 +34,13 @@ from claude_tap.dashboard import (
 )
 from claude_tap.history import migrate_legacy_traces
 from claude_tap.live import LiveViewerServer, _record_limit_from_request
+from claude_tap.models import JsonObject
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_log_handler import SQLiteLogHandler
 from claude_tap.trace_store import get_trace_store
 
 
-def _write_jsonl(path: Path, records: list[dict]) -> None:
+def _write_jsonl(path: Path, records: list[JsonObject]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
         "\n".join(json.dumps(record, ensure_ascii=False, separators=(",", ":")) for record in records) + "\n",
@@ -65,7 +66,7 @@ def test_dashboard_lists_sessions_by_normalized_updated_at(trace_db) -> None:
     assert [session["id"] for session in list_trace_sessions()][:2] == [newer, older]
 
 
-def _anthropic_record(turn: int = 1) -> dict:
+def _anthropic_record(turn: int = 1) -> JsonObject:
     return {
         "timestamp": "2026-05-20T08:00:00+00:00",
         "request_id": "req_claude",
@@ -93,7 +94,7 @@ def _anthropic_record(turn: int = 1) -> dict:
     }
 
 
-def _antigravity_record() -> dict:
+def _antigravity_record() -> JsonObject:
     return {
         "timestamp": "2026-05-20T09:00:00+00:00",
         "request_id": "req_agy",
@@ -120,12 +121,12 @@ def _antigravity_record() -> dict:
     }
 
 
-def _bedrock_frame(payload: dict) -> str:
+def _bedrock_frame(payload: JsonObject) -> str:
     encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
     return "\x00\x00binary-prefix" + json.dumps({"bytes": encoded, "p": "abcdefghijk"}) + "\ufffd"
 
 
-def _bedrock_stream_record() -> dict:
+def _bedrock_stream_record() -> JsonObject:
     body = "".join(
         [
             _bedrock_frame(

--- a/tests/test_diff_matching.py
+++ b/tests/test_diff_matching.py
@@ -14,6 +14,8 @@ messages, then B extends A's conversation thread and they should be diffed toget
 import hashlib
 import json
 
+from claude_tap.models import JsonObject
+
 # ── Test data: real trace from trace_20260218_083822.jsonl ──
 # Simplified to essential fields for testing
 
@@ -133,7 +135,7 @@ NAIVE_SAME_MODEL_PARENT = {
 }
 
 
-def _msg_hash(msg: dict) -> str:
+def _msg_hash(msg: JsonObject) -> str:
     """Hash a message by role + content for comparison."""
     content = msg.get("content", "")
     if isinstance(content, list):
@@ -141,7 +143,7 @@ def _msg_hash(msg: dict) -> str:
     return hashlib.md5(f"{msg.get('role', '')}:{content}".encode()).hexdigest()[:8]
 
 
-def _get_msg_hashes(entry: dict) -> list[str]:
+def _get_msg_hashes(entry: JsonObject) -> list[str]:
     """Get message hashes for an entry."""
     return [_msg_hash(m) for m in entry.get("messages", [])]
 
@@ -153,7 +155,7 @@ def _is_prefix_of(shorter: list[str], longer: list[str]) -> bool:
     return shorter == longer[: len(shorter)]
 
 
-def find_diff_parent_by_prefix(entries: list[dict], idx: int) -> int | None:
+def find_diff_parent_by_prefix(entries: list[JsonObject], idx: int) -> int | None:
     """Find the best diff parent for entry at idx using message prefix matching.
 
     Returns the index of the entry whose messages are the longest prefix
@@ -182,7 +184,7 @@ def find_diff_parent_by_prefix(entries: list[dict], idx: int) -> int | None:
     return best_parent
 
 
-def find_next_by_prefix(entries: list[dict], idx: int) -> int | None:
+def find_next_by_prefix(entries: list[JsonObject], idx: int) -> int | None:
     """Find the next entry whose messages start with entries[idx]'s messages as prefix.
 
     Mirrors the JS findNextSameModel() — picks the closest (smallest) extension.
@@ -205,7 +207,7 @@ def find_next_by_prefix(entries: list[dict], idx: int) -> int | None:
     return best_idx
 
 
-def compute_nav_button_states(entries: list[dict], cur_idx: int) -> tuple[bool, bool]:
+def compute_nav_button_states(entries: list[JsonObject], cur_idx: int) -> tuple[bool, bool]:
     """Compute whether prev/next nav buttons should be enabled for the diff at cur_idx.
 
     Mirrors the JS updateNavButtons() logic after the bug fix.
@@ -231,15 +233,15 @@ def compute_nav_button_states(entries: list[dict], cur_idx: int) -> tuple[bool, 
     return (prev_enabled, next_enabled)
 
 
-def _response_id(entry: dict) -> str:
+def _response_id(entry: JsonObject) -> str:
     return entry.get("response_id", "")
 
 
-def _previous_response_id(entry: dict) -> str:
+def _previous_response_id(entry: JsonObject) -> str:
     return entry.get("previous_response_id", "")
 
 
-def _codex_thread_key(entry: dict) -> str:
+def _codex_thread_key(entry: JsonObject) -> str:
     metadata = entry.get("client_metadata") or {}
     turn_metadata = metadata.get("x-codex-turn-metadata") or {}
     if isinstance(turn_metadata, str):
@@ -247,7 +249,7 @@ def _codex_thread_key(entry: dict) -> str:
     return f"{turn_metadata.get('session_id', '')}:{turn_metadata.get('thread_id', '')}"
 
 
-def find_diff_parent_with_response_context(entries: list[dict], idx: int) -> int | None:
+def find_diff_parent_with_response_context(entries: list[JsonObject], idx: int) -> int | None:
     """Mirror viewer parent matching: response id, Codex thread, then prefix."""
     previous_id = _previous_response_id(entries[idx])
     if previous_id:

--- a/tests/test_diff_matching.py
+++ b/tests/test_diff_matching.py
@@ -14,7 +14,7 @@ messages, then B extends A's conversation thread and they should be diffed toget
 import hashlib
 import json
 
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 # ── Test data: real trace from trace_20260218_083822.jsonl ──
 # Simplified to essential fields for testing

--- a/tests/test_dsh_launch.py
+++ b/tests/test_dsh_launch.py
@@ -7,7 +7,7 @@ import pytest
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_trace_options, run_client
 from claude_tap.cli_clients import _detect_dsh_target, _node_supports_env_proxy
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_dsh_launch.py
+++ b/tests/test_dsh_launch.py
@@ -7,6 +7,7 @@ import pytest
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_trace_options, run_client
 from claude_tap.cli_clients import _detect_dsh_target, _node_supports_env_proxy
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -50,7 +51,7 @@ def test_parse_args_dsh_defaults_to_forward_mode() -> None:
 async def test_run_client_dsh_forward_enables_node_proxy_and_preserves_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -99,7 +100,7 @@ async def test_run_client_dsh_forward_rejects_node_without_env_proxy_support(
 
 
 def test_node_supports_env_proxy_probes_node_on_path(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
@@ -118,7 +119,7 @@ def test_node_supports_env_proxy_probes_node_on_path(monkeypatch: pytest.MonkeyP
 async def test_run_client_dsh_reverse_sets_base_url_and_preserves_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import pytest
 from yarl import URL
 
+from claude_tap.models import JsonObject, Map
 from claude_tap.trace import TraceWriter
 from tests.conftest import e2e_env, read_proxy_log, read_trace_records
 
@@ -1683,7 +1684,7 @@ async def test_async_main_live_viewer_respects_tap_host(monkeypatch, tmp_path):
     """Shared dashboard startup should honor the configured tap host."""
     from claude_tap import async_main, parse_args
 
-    dashboard_calls: list[dict[str, object]] = []
+    dashboard_calls: list[Map[str, object]] = []
 
     async def fake_run_client(*args, **kwargs):
         return 0
@@ -2694,7 +2695,7 @@ def test_kimi_code_client_reverse_proxy():
 
 def test_codex_zstd_request_body():
     """Verify the proxy decompresses zstd-encoded request bodies from Codex CLI."""
-    received_bodies: list[dict] = []
+    received_bodies: list[JsonObject] = []
 
     async def handler(request):
         body = await request.json()
@@ -4438,7 +4439,7 @@ async def test_forward_proxy_flushes_each_codexapp_websocket_response_before_clo
         )
         proxy_port = await server.start()
 
-        async def wait_for_records(expected: int) -> list[dict]:
+        async def wait_for_records(expected: int) -> list[JsonObject]:
             for _ in range(100):
                 records = store.load_records(session_id)
                 if len(records) >= expected:
@@ -4663,7 +4664,7 @@ async def test_forward_proxy_connect_websocket_honors_env_proxy(monkeypatch):
             lambda _url: (URL("http://proxy.local:8080"), aiohttp.BasicAuth("user", "pass")),
         )
 
-        ws_connect_calls: list[dict] = []
+        ws_connect_calls: list[JsonObject] = []
         original_ws_connect = session.ws_connect
 
         async def _spy_ws_connect(*args, **kwargs):

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -24,9 +24,9 @@ from pathlib import Path
 import pytest
 from yarl import URL
 
-from claude_tap.models import JsonObject, Map
 from claude_tap.trace import TraceWriter
 from tests.conftest import e2e_env, read_proxy_log, read_trace_records
+from tests.schema_types import JsonObject, Map
 
 
 def _writer_for_dir(tmpdir: Path):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,7 +8,7 @@ import json
 import pytest
 
 from claude_tap.export import export_main
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 
 def _write_trace(tmp_path):

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -8,6 +8,7 @@ import json
 import pytest
 
 from claude_tap.export import export_main
+from claude_tap.models import JsonObject
 
 
 def _write_trace(tmp_path):
@@ -194,7 +195,7 @@ def test_export_compact_trace_is_standalone_and_html_renderable(tmp_path, capsys
     assert f"Exported 3 turns to {compact_path}" in capsys.readouterr().out
 
 
-def _bedrock_frame(event: dict) -> str:
+def _bedrock_frame(event: JsonObject) -> str:
     payload = json.dumps(event).encode("utf-8")
     return json.dumps({"bytes": base64.b64encode(payload).decode("ascii")})
 

--- a/tests/test_forward_proxy.py
+++ b/tests/test_forward_proxy.py
@@ -6,7 +6,7 @@ import gzip
 import json
 import zlib
 from pathlib import Path
-from typing import Any, Callable
+from typing import Callable
 
 import pytest
 
@@ -22,7 +22,7 @@ except ImportError:
 
 
 class _UnexpectedSession:
-    async def request(self, **_kwargs: Any) -> None:
+    async def request(self, **_kwargs: object) -> None:
         raise AssertionError("capture-only mode must not contact upstream")
 
 

--- a/tests/test_gemini_launch.py
+++ b/tests/test_gemini_launch.py
@@ -7,6 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_trace_options, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -53,7 +54,7 @@ def test_parse_args_gemini_explicit_reverse_overrides_default() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_gemini_forward_sets_proxy_ca_and_skips_base_url_envs(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -81,7 +82,7 @@ async def test_run_client_gemini_forward_sets_proxy_ca_and_skips_base_url_envs(m
 
 @pytest.mark.asyncio
 async def test_run_client_gemini_reverse_sets_both_base_url_envs(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_gemini_launch.py
+++ b/tests/test_gemini_launch.py
@@ -7,7 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_trace_options, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_gemini_viewer.py
+++ b/tests/test_gemini_viewer.py
@@ -6,9 +6,9 @@ from pathlib import Path
 
 import pytest
 
-from claude_tap.models import JsonObject
 from claude_tap.usage import normalize_usage
 from claude_tap.viewer import _extract_metadata, _extract_request_messages, _generate_html_viewer
+from tests.schema_types import JsonObject
 
 pw_missing = False
 try:

--- a/tests/test_gemini_viewer.py
+++ b/tests/test_gemini_viewer.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from claude_tap.models import JsonObject
 from claude_tap.usage import normalize_usage
 from claude_tap.viewer import _extract_metadata, _extract_request_messages, _generate_html_viewer
 
@@ -16,11 +17,11 @@ except ImportError:
     pw_missing = True
 
 
-def _sse_frame(payload: dict) -> str:
+def _sse_frame(payload: JsonObject) -> str:
     return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
-def _gemini_record() -> dict:
+def _gemini_record() -> JsonObject:
     return {
         "timestamp": "2026-05-13T12:00:00+00:00",
         "request_id": "req_gemini",
@@ -207,7 +208,7 @@ def test_extract_metadata_understands_gemini_system_tools_output_and_usage() -> 
     assert meta["cache_read_input_tokens"] == 40
 
 
-def _direct_gemini_native_record() -> dict:
+def _direct_gemini_native_record() -> JsonObject:
     record = json.loads(json.dumps(_gemini_record()))
     record["request"]["path"] = "/v1beta/models/gemini-3.5-flash:generateContent"
     record["request"]["body"] = record["request"]["body"]["request"]

--- a/tests/test_grok_launch.py
+++ b/tests/test_grok_launch.py
@@ -7,8 +7,8 @@ import pytest
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_path_prefixes, _reverse_proxy_trace_options, run_client
 from claude_tap.cli_clients import _detect_grok_target
-from claude_tap.models import Map
 from claude_tap.proxy import _is_allowed_path, _matches_path_prefixes
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_grok_launch.py
+++ b/tests/test_grok_launch.py
@@ -7,6 +7,7 @@ import pytest
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_path_prefixes, _reverse_proxy_trace_options, run_client
 from claude_tap.cli_clients import _detect_grok_target
+from claude_tap.models import Map
 from claude_tap.proxy import _is_allowed_path, _matches_path_prefixes
 
 
@@ -68,7 +69,7 @@ def test_parse_args_grok_defaults_to_reverse_mode() -> None:
 async def test_run_client_grok_reverse_sets_chat_proxy_base_url_and_preserves_args(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_hermes_launch.py
+++ b/tests/test_hermes_launch.py
@@ -7,7 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, ClientConfig, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_hermes_launch.py
+++ b/tests/test_hermes_launch.py
@@ -7,6 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, ClientConfig, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -81,7 +82,7 @@ def test_parse_args_codex_default_unchanged() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_hermes_forward_sets_python_ca_env(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -105,7 +106,7 @@ async def test_run_client_hermes_forward_sets_python_ca_env(monkeypatch) -> None
 @pytest.mark.asyncio
 async def test_run_client_codex_forward_still_sets_existing_ca_env(monkeypatch) -> None:
     """Regression: codex still gets SSL_CERT_FILE and CODEX_CA_CERTIFICATE."""
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -132,8 +133,8 @@ async def test_run_client_codex_forward_still_sets_existing_ca_env(monkeypatch) 
 # ---------------------------------------------------------------------------
 
 
-async def _capture_cmd(monkeypatch, which: str = "/tmp/hermes") -> dict[str, object]:
-    captured: dict[str, object] = {}
+async def _capture_cmd(monkeypatch, which: str = "/tmp/hermes") -> Map[str, object]:
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -267,7 +268,7 @@ async def test_run_client_codex_not_affected_by_hermes_rewrite(monkeypatch) -> N
 
 @pytest.mark.asyncio
 async def test_run_client_hermes_reverse_sets_openai_base_url(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -295,7 +296,7 @@ async def test_run_client_hermes_reverse_sets_openai_base_url(monkeypatch) -> No
 
 @pytest.mark.asyncio
 async def test_run_client_hermes_capture_only_reverse_sets_multi_provider_urls(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_kimi_code_launch.py
+++ b/tests/test_kimi_code_launch.py
@@ -24,7 +24,7 @@ from claude_tap.cli_clients import (
     _reverse_proxy_trace_options,
     run_client,
 )
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_kimi_code_launch.py
+++ b/tests/test_kimi_code_launch.py
@@ -24,6 +24,7 @@ from claude_tap.cli_clients import (
     _reverse_proxy_trace_options,
     run_client,
 )
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -281,7 +282,7 @@ max_context_size = 1000
 async def test_run_client_kimi_code_reverse_sets_kimi_code_home(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     home = tmp_path / "source-home"
     home.mkdir()
     (home / "config.toml").write_text(
@@ -323,7 +324,7 @@ api_key = "sk-test"
 async def test_run_client_kimi_code_reverse_rewrites_config_file_arg(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     home = tmp_path / "source-home"
     home.mkdir()
     override_config = tmp_path / "override.toml"
@@ -368,7 +369,7 @@ api_key = "sk-test"
 async def test_run_client_kimi_code_reverse_rewrites_model_env_override(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     home = tmp_path / "source-home"
     home.mkdir()
     monkeypatch.setenv("KIMI_CODE_HOME", str(home))
@@ -395,7 +396,7 @@ async def test_run_client_kimi_code_reverse_rewrites_model_env_override(
 async def test_run_client_kimi_code_reverse_drops_inactive_model_base_url(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     home = tmp_path / "source-home"
     home.mkdir()
     monkeypatch.setenv("KIMI_CODE_HOME", str(home))
@@ -421,7 +422,7 @@ async def test_run_client_kimi_code_reverse_drops_inactive_model_base_url(
 async def test_run_client_kimi_code_reverse_does_not_proxy_non_kimi_model_env_without_base_url(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     home = tmp_path / "source-home"
     home.mkdir()
     monkeypatch.setenv("KIMI_CODE_HOME", str(home))
@@ -449,7 +450,7 @@ async def test_run_client_kimi_code_reverse_does_not_proxy_non_kimi_model_env_wi
 async def test_run_client_kimi_code_model_arg_clears_model_env_override(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     home = tmp_path / "source-home"
     home.mkdir()
     (home / "config.toml").write_text(

--- a/tests/test_kimi_launch.py
+++ b/tests/test_kimi_launch.py
@@ -6,6 +6,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_trace_options, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -51,7 +52,7 @@ def test_parse_args_accepts_every_registered_client(monkeypatch, tmp_path) -> No
 
 @pytest.mark.asyncio
 async def test_run_client_kimi_reverse_sets_kimi_base_url(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     for key in ("MOONSHOT_BASE_URL", "OPENAI_BASE_URL", "OPENROUTER_BASE_URL"):
         monkeypatch.delenv(key, raising=False)
 
@@ -77,7 +78,7 @@ async def test_run_client_kimi_reverse_sets_kimi_base_url(monkeypatch) -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_kimi_capture_only_reverse_sets_multi_provider_urls(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["env"] = kwargs["env"]

--- a/tests/test_kimi_launch.py
+++ b/tests/test_kimi_launch.py
@@ -6,7 +6,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, _reverse_proxy_trace_options, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -15,7 +15,7 @@ from claude_tap.macos_app import (
     build_proxy_command,
     parse_macos_app_args,
 )
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_macos_app.py
+++ b/tests/test_macos_app.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -16,6 +15,7 @@ from claude_tap.macos_app import (
     build_proxy_command,
     parse_macos_app_args,
 )
+from claude_tap.models import Map
 
 
 @pytest.fixture(autouse=True)
@@ -177,7 +177,7 @@ def test_monitor_controller_reuses_healthy_dashboard_and_starts_proxies(tmp_path
 
 
 def test_monitor_controller_spawns_dashboard_process(tmp_path: Path) -> None:
-    spawned: list[tuple[list[str], dict[str, object]]] = []
+    spawned: list[tuple[list[str], Map[str, object]]] = []
 
     class FakeProcess:
         def poll(self) -> int | None:
@@ -209,7 +209,7 @@ def test_monitor_controller_spawns_dashboard_process(tmp_path: Path) -> None:
 
 def test_monitor_controller_start_spawns_proxies_and_enables_global_injection(tmp_path: Path) -> None:
     spawned: list[list[str]] = []
-    injected: list[tuple[int, int, list[dict[str, object]]]] = []
+    injected: list[tuple[int, int, list[Map[str, object]]]] = []
 
     class FakeProcess:
         def __init__(self, pid: int) -> None:
@@ -258,7 +258,7 @@ def test_monitor_controller_start_spawns_proxies_and_enables_global_injection(tm
 
 def test_monitor_controller_reuses_healthy_proxy_instead_of_spawning_duplicate(tmp_path: Path) -> None:
     spawned: list[list[str]] = []
-    injected: list[tuple[int, int, list[dict[str, object]]]] = []
+    injected: list[tuple[int, int, list[Map[str, object]]]] = []
 
     class FakeProcess:
         def __init__(self, pid: int) -> None:
@@ -806,7 +806,7 @@ def test_menu_app_open_dashboard_active_monitor_after_relaunch_does_not_confirm(
 class FakeObjC:
     def __init__(self) -> None:
         self.calls: list[tuple[int, str, tuple[object, ...]]] = []
-        self.strings: dict[int, str] = {}
+        self.strings: Map[int, str] = {}
         self._next = 100
         self.objc = FakeRuntime(self)
 
@@ -832,8 +832,8 @@ class FakeObjC:
         self,
         receiver: int,
         selector: str,
-        _restype: Any = None,
-        _argtypes: list[Any] | None = None,
+        _restype: object = None,
+        _argtypes: list[object] | None = None,
         *args: object,
     ) -> int:
         self.calls.append((receiver, selector, args))
@@ -1044,7 +1044,7 @@ def test_menu_callbacks_forward_to_active_app(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_main_entry_routes_macos_app_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
-    called: dict[str, object] = {}
+    called: Map[str, object] = {}
 
     def fake_macos_main(argv: list[str]) -> int:
         called["argv"] = argv

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -11,6 +11,7 @@ import pytest
 from claude_tap import macos_bundle
 from claude_tap.cli import main_entry
 from claude_tap.macos_bundle import build_macos_app_bundle
+from claude_tap.models import Map
 
 
 def test_build_macos_app_bundle_writes_double_clickable_app(tmp_path: Path) -> None:
@@ -43,7 +44,7 @@ def test_build_macos_app_bundle_writes_double_clickable_app(tmp_path: Path) -> N
 
 
 def test_build_macos_app_bundle_uses_native_launcher(tmp_path: Path) -> None:
-    compiled: dict[str, str | Path] = {}
+    compiled: Map[str, str | Path] = {}
 
     def fake_compile(source: str, output_path: Path) -> None:
         compiled["source"] = source
@@ -70,7 +71,7 @@ def test_build_macos_app_bundle_uses_native_launcher(tmp_path: Path) -> None:
 
 
 def test_build_macos_app_bundle_can_embed_pyinstaller_executable(tmp_path: Path) -> None:
-    compiled: dict[str, str] = {}
+    compiled: Map[str, str] = {}
 
     def fake_compile(source: str, output_path: Path) -> None:
         compiled["source"] = source
@@ -101,7 +102,7 @@ def test_build_macos_app_bundle_can_embed_pyinstaller_executable(tmp_path: Path)
 def test_build_macos_app_main_uses_installed_mode(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    built: dict[str, object] = {}
+    built: Map[str, object] = {}
 
     def fake_build(app_path: Path, **kwargs: object) -> Path:
         built["app_path"] = app_path
@@ -119,7 +120,7 @@ def test_build_macos_app_main_uses_installed_mode(
 
 
 def test_build_macos_app_bundle_self_contained_disables_source_root(tmp_path: Path) -> None:
-    compiled: dict[str, str] = {}
+    compiled: Map[str, str] = {}
 
     def fake_compile(source: str, output_path: Path) -> None:
         compiled["source"] = source
@@ -215,7 +216,7 @@ def test_c_string_literal_escapes_quotes_backslashes_and_utf8() -> None:
 
 
 def test_main_entry_routes_build_macos_app_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
-    called: dict[str, object] = {}
+    called: Map[str, object] = {}
 
     def fake_build_main(argv: list[str]) -> int:
         called["argv"] = argv

--- a/tests/test_macos_bundle.py
+++ b/tests/test_macos_bundle.py
@@ -11,7 +11,7 @@ import pytest
 from claude_tap import macos_bundle
 from claude_tap.cli import main_entry
 from claude_tap.macos_bundle import build_macos_app_bundle
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 def test_build_macos_app_bundle_writes_double_clickable_app(tmp_path: Path) -> None:

--- a/tests/test_mimocode_launch.py
+++ b/tests/test_mimocode_launch.py
@@ -7,6 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -48,7 +49,7 @@ def test_parse_args_mimocode_explicit_reverse_overrides_default() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_mimocode_forward_sets_node_ca_env(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -71,7 +72,7 @@ async def test_run_client_mimocode_forward_sets_node_ca_env(monkeypatch) -> None
 
 @pytest.mark.asyncio
 async def test_run_client_mimocode_reverse_sets_anthropic_base_url(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     for key in ("OPENAI_BASE_URL", "GOOGLE_GEMINI_BASE_URL"):
         monkeypatch.delenv(key, raising=False)
 
@@ -98,7 +99,7 @@ async def test_run_client_mimocode_reverse_sets_anthropic_base_url(monkeypatch) 
 
 @pytest.mark.asyncio
 async def test_run_client_mimocode_reverse_extends_no_proxy_for_localhost(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     monkeypatch.setenv("HTTP_PROXY", "http://proxy.example:8080")
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.example:8080")
     monkeypatch.setenv("NO_PROXY", "corp.example")
@@ -125,7 +126,7 @@ async def test_run_client_mimocode_reverse_extends_no_proxy_for_localhost(monkey
 
 @pytest.mark.asyncio
 async def test_run_client_mimocode_capture_only_reverse_sets_multi_provider_urls(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_mimocode_launch.py
+++ b/tests/test_mimocode_launch.py
@@ -7,7 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_nav_browser.py
+++ b/tests/test_nav_browser.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 pw_missing = False
 try:

--- a/tests/test_nav_browser.py
+++ b/tests/test_nav_browser.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 
+from claude_tap.models import JsonObject
+
 pw_missing = False
 try:
     from playwright.sync_api import sync_playwright  # noqa: F401
@@ -25,7 +27,7 @@ pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
 # This gives us 3 diff pairs to navigate between.
 
 
-def _make_entry(turn: int, messages: list[dict]) -> dict:
+def _make_entry(turn: int, messages: list[JsonObject]) -> JsonObject:
     """Build a trace entry matching the real JSONL format."""
     return {
         "timestamp": f"2026-02-24T20:00:0{turn}",
@@ -147,7 +149,7 @@ class TestDiffNavInBrowser:
         page.evaluate("document.querySelector('.act-btn:nth-child(3)').click()")
         page.wait_for_selector(".diff-overlay", timeout=3000)
 
-    def _get_nav_state(self, page) -> dict:
+    def _get_nav_state(self, page) -> JsonObject:
         """Get the current state of the diff nav buttons."""
         return page.evaluate("""() => {
             const overlay = document.querySelector('.diff-overlay');

--- a/tests/test_opencode_launch.py
+++ b/tests/test_opencode_launch.py
@@ -7,6 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -61,7 +62,7 @@ def test_parse_args_codex_default_proxy_mode_unchanged() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_opencode_forward_sets_node_ca_env(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -83,7 +84,7 @@ async def test_run_client_opencode_forward_sets_node_ca_env(monkeypatch) -> None
 
 @pytest.mark.asyncio
 async def test_run_client_opencode_reverse_sets_anthropic_base_url(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     for key in ("OPENAI_BASE_URL", "GOOGLE_GEMINI_BASE_URL"):
         monkeypatch.delenv(key, raising=False)
 
@@ -109,7 +110,7 @@ async def test_run_client_opencode_reverse_sets_anthropic_base_url(monkeypatch) 
 
 @pytest.mark.asyncio
 async def test_run_client_opencode_capture_only_reverse_sets_multi_provider_urls(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_opencode_launch.py
+++ b/tests/test_opencode_launch.py
@@ -7,7 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_perf_viewer.py
+++ b/tests/test_perf_viewer.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from claude_tap.models import JsonObject
+from tests.schema_types import JsonObject
 
 pw_missing = False
 try:

--- a/tests/test_perf_viewer.py
+++ b/tests/test_perf_viewer.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 import pytest
 
+from claude_tap.models import JsonObject
+
 pw_missing = False
 try:
     from playwright.sync_api import sync_playwright  # noqa: F401
@@ -22,7 +24,7 @@ pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
 LARGE_TRACE = Path(__file__).parent.parent / ".traces" / "trace_20260228_212004.jsonl"
 
 
-def _make_entry(turn: int, messages: list[dict]) -> dict:
+def _make_entry(turn: int, messages: list[JsonObject]) -> JsonObject:
     """Build a trace entry matching the real JSONL format."""
     return {
         "timestamp": f"2026-02-24T20:00:{turn:02d}",

--- a/tests/test_pi_launch.py
+++ b/tests/test_pi_launch.py
@@ -7,7 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_pi_launch.py
+++ b/tests/test_pi_launch.py
@@ -7,6 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -53,7 +54,7 @@ def test_parse_args_pi_explicit_reverse_overrides_default() -> None:
 
 @pytest.mark.asyncio
 async def test_run_client_pi_forward_sets_proxy_ca_and_preserves_args(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -98,7 +99,7 @@ async def test_run_client_pi_forward_sets_proxy_ca_and_preserves_args(monkeypatc
 
 @pytest.mark.asyncio
 async def test_run_client_pi_reverse_sets_openai_base_url_without_codex_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_prompt_snapshot.py
+++ b/tests/test_prompt_snapshot.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from claude_tap.models import JsonObject
 from claude_tap.prompt_snapshot import infer_provider, render_prompt_markdown, snapshot_from_records
 
 
-def _record(path: str, body: dict, *, turn: int = 1) -> dict:
+def _record(path: str, body: JsonObject, *, turn: int = 1) -> JsonObject:
     return {
         "timestamp": "2026-05-21T10:00:00+00:00",
         "request_id": f"req_{turn}",

--- a/tests/test_prompt_snapshot.py
+++ b/tests/test_prompt_snapshot.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from claude_tap.models import JsonObject
 from claude_tap.prompt_snapshot import infer_provider, render_prompt_markdown, snapshot_from_records
+from tests.schema_types import JsonObject
 
 
 def _record(path: str, body: JsonObject, *, turn: int = 1) -> JsonObject:

--- a/tests/test_qoder_launch.py
+++ b/tests/test_qoder_launch.py
@@ -7,6 +7,7 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
+from claude_tap.models import Map
 from claude_tap.proxy import _build_record
 
 
@@ -94,7 +95,7 @@ def test_qoder_trace_headers_redact_request_identity_and_response_cookie() -> No
 
 @pytest.mark.asyncio
 async def test_run_client_qoder_forward_sets_proxy_ca_and_preserves_args(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
     ca_path = Path("/tmp/test-ca.pem")
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
@@ -132,7 +133,7 @@ async def test_run_client_qoder_forward_sets_proxy_ca_and_preserves_args(monkeyp
 
 @pytest.mark.asyncio
 async def test_run_client_qoder_reverse_sets_structural_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_qoder_launch.py
+++ b/tests/test_qoder_launch.py
@@ -7,8 +7,8 @@ import pytest
 
 from claude_tap import parse_args
 from claude_tap.cli import CLIENT_CONFIGS, run_client
-from claude_tap.models import Map
 from claude_tap.proxy import _build_record
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_search_browser.py
+++ b/tests/test_search_browser.py
@@ -10,8 +10,8 @@ from pathlib import Path
 
 import pytest
 
-from claude_tap.models import JsonObject, Map
 from claude_tap.viewer import _generate_html_viewer
+from tests.schema_types import JsonObject, Map
 
 pw_missing = False
 try:

--- a/tests/test_search_browser.py
+++ b/tests/test_search_browser.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from claude_tap.models import JsonObject, Map
 from claude_tap.viewer import _generate_html_viewer
 
 pw_missing = False
@@ -39,7 +40,7 @@ _STOPWORDS = {
 }
 
 
-def _load_entries(trace_file: Path) -> list[dict]:
+def _load_entries(trace_file: Path) -> list[JsonObject]:
     lines = trace_file.read_text(encoding="utf-8").splitlines()
     return [json.loads(line) for line in lines if line.strip()]
 
@@ -59,7 +60,7 @@ def _pick_real_trace_file() -> Path:
     return candidates[0]
 
 
-def _normalize_messages_for_diff(body: dict | None) -> list[dict]:
+def _normalize_messages_for_diff(body: JsonObject | None) -> list[JsonObject]:
     if not body:
         return []
     if isinstance(body.get("messages"), list) and body["messages"]:
@@ -93,7 +94,7 @@ def _normalize_content_text(content) -> str:
     return json.dumps(content, ensure_ascii=False)
 
 
-def _msg_hash(msg: dict) -> str:
+def _msg_hash(msg: JsonObject) -> str:
     role = msg.get("role", "")
     text = _normalize_content_text(msg.get("content"))
     return f"{role}:{text[:500]}"
@@ -105,7 +106,7 @@ def _is_prefix_of(shorter: list[str], longer: list[str]) -> bool:
     return all(shorter[i] == longer[i] for i in range(len(shorter)))
 
 
-def _find_prev_same_model(entries: list[dict], idx: int) -> int:
+def _find_prev_same_model(entries: list[JsonObject], idx: int) -> int:
     target = entries[idx]
     target_body = target.get("request", {}).get("body") or {}
     target_hashes = [_msg_hash(msg) for msg in _normalize_messages_for_diff(target_body)]
@@ -131,7 +132,7 @@ def _find_prev_same_model(entries: list[dict], idx: int) -> int:
     return -1
 
 
-def _score_diff_messages(old_msgs: list[dict], new_msgs: list[dict]) -> int:
+def _score_diff_messages(old_msgs: list[JsonObject], new_msgs: list[JsonObject]) -> int:
     prefix = 0
     while prefix < len(old_msgs) and prefix < len(new_msgs):
         if _msg_hash(old_msgs[prefix]) != _msg_hash(new_msgs[prefix]):
@@ -180,7 +181,7 @@ def _pick_real_trace_file_for_diff() -> tuple[Path, int]:
     pytest.skip("No real multi-turn trace file with a message diff target found in .traces/")
 
 
-def _extract_messages(body: dict | None) -> list[str]:
+def _extract_messages(body: JsonObject | None) -> list[str]:
     if not body:
         return []
     texts: list[str] = []
@@ -207,7 +208,7 @@ def _extract_messages(body: dict | None) -> list[str]:
     return texts
 
 
-def _pick_message_term(entries: list[dict]) -> tuple[str, int]:
+def _pick_message_term(entries: list[JsonObject]) -> tuple[str, int]:
     for idx, entry in enumerate(entries):
         texts = _extract_messages(entry.get("request", {}).get("body", {}))
         for text in texts:
@@ -218,10 +219,10 @@ def _pick_message_term(entries: list[dict]) -> tuple[str, int]:
     return "model", 0
 
 
-def _pick_cross_entry_term(entries: list[dict]) -> str:
+def _pick_cross_entry_term(entries: list[JsonObject]) -> str:
     entry_texts = [json.dumps(entry, ensure_ascii=False).lower() for entry in entries]
-    by_entry_count: dict[str, int] = {}
-    total_counts: dict[str, int] = {}
+    by_entry_count: Map[str, int] = {}
+    total_counts: Map[str, int] = {}
 
     for text in entry_texts:
         seen = set()
@@ -249,7 +250,7 @@ def _pick_cross_entry_term(entries: list[dict]) -> str:
 
 
 @pytest.fixture(scope="module")
-def trace_entries() -> tuple[Path, list[dict], str, tuple[str, int]]:
+def trace_entries() -> tuple[Path, list[JsonObject], str, tuple[str, int]]:
     trace_file = _pick_real_trace_file()
     entries = _load_entries(trace_file)
     cross_term = _pick_cross_entry_term(entries)

--- a/tests/test_shared_dashboard.py
+++ b/tests/test_shared_dashboard.py
@@ -7,7 +7,6 @@ from pathlib import Path
 import pytest
 from aiohttp import web
 
-from claude_tap.models import Map
 from claude_tap.shared_dashboard import (
     CLAUDE_TAP_VERSION,
     DEFAULT_DASHBOARD_PORT,
@@ -30,6 +29,7 @@ from claude_tap.shared_dashboard import (
     stop_shared_dashboard,
 )
 from claude_tap.trace_store import resolve_db_path
+from tests.schema_types import Map
 
 
 async def _start_test_app(app: web.Application) -> tuple[web.AppRunner, int]:

--- a/tests/test_shared_dashboard.py
+++ b/tests/test_shared_dashboard.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from aiohttp import web
 
+from claude_tap.models import Map
 from claude_tap.shared_dashboard import (
     CLAUDE_TAP_VERSION,
     DEFAULT_DASHBOARD_PORT,
@@ -141,7 +142,7 @@ def test_dashboard_spawn_lock(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -
 
 
 def test_spawn_dashboard_subprocess(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    spawned_args: list[tuple[list[str], dict[str, object]]] = []
+    spawned_args: list[tuple[list[str], Map[str, object]]] = []
 
     class FakePopen:
         def __init__(self, cmd: list[str], **kwargs: object) -> None:
@@ -168,7 +169,7 @@ def test_spawn_dashboard_subprocess_hides_windows_console(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     class FakeStartupInfo:
         def __init__(self) -> None:
@@ -341,7 +342,7 @@ async def test_stop_shared_dashboard_rejects_unhealthy_or_forbidden_server() -> 
 async def test_stop_shared_dashboard_handles_post_client_error(monkeypatch: pytest.MonkeyPatch) -> None:
     import aiohttp
 
-    async def healthy(*_args: object, **_kwargs: object) -> tuple[int, dict[str, str]]:
+    async def healthy(*_args: object, **_kwargs: object) -> tuple[int, Map[str, str]]:
         return 200, {"quit_token": "test-token"}
 
     class FailingSession:

--- a/tests/test_trace_store_compaction.py
+++ b/tests/test_trace_store_compaction.py
@@ -13,6 +13,7 @@ from claude_tap.compact_trace import (
     load_compact_trace,
     make_blob_ref,
 )
+from claude_tap.models import JsonObject
 from claude_tap.trace_store import (
     COMPACT_RECORD_MARKER,
     TraceStore,
@@ -20,7 +21,7 @@ from claude_tap.trace_store import (
 )
 
 
-def _large_codex_record(index: int, *, instructions: str, tools: list[dict]) -> dict:
+def _large_codex_record(index: int, *, instructions: str, tools: list[JsonObject]) -> JsonObject:
     return {
         "timestamp": f"2026-05-30T04:00:{index:02d}+00:00",
         "turn": index,
@@ -65,7 +66,7 @@ def _large_codex_record(index: int, *, instructions: str, tools: list[dict]) -> 
     }
 
 
-def _large_message_item(index: int) -> dict:
+def _large_message_item(index: int) -> JsonObject:
     return {
         "role": "user" if index % 2 else "assistant",
         "content": [
@@ -77,7 +78,7 @@ def _large_message_item(index: int) -> dict:
     }
 
 
-def _messages_record(index: int, messages: list[dict]) -> dict:
+def _messages_record(index: int, messages: list[JsonObject]) -> JsonObject:
     return {
         "timestamp": f"2026-06-11T08:00:{index:02d}+00:00",
         "turn": index,
@@ -99,7 +100,7 @@ def _messages_record(index: int, messages: list[dict]) -> dict:
     }
 
 
-def _responses_input_record(index: int, input_items: list[dict]) -> dict:
+def _responses_input_record(index: int, input_items: list[JsonObject]) -> JsonObject:
     return {
         "timestamp": f"2026-06-11T08:01:{index:02d}+00:00",
         "turn": index,
@@ -121,7 +122,7 @@ def _responses_input_record(index: int, input_items: list[dict]) -> dict:
     }
 
 
-def _raw_record_payloads(db_path) -> list[dict]:
+def _raw_record_payloads(db_path) -> list[JsonObject]:
     conn = sqlite3.connect(db_path)
     rows = conn.execute("SELECT payload_json FROM records ORDER BY record_index").fetchall()
     return [json.loads(row[0]) for row in rows]

--- a/tests/test_trace_store_compaction.py
+++ b/tests/test_trace_store_compaction.py
@@ -13,12 +13,12 @@ from claude_tap.compact_trace import (
     load_compact_trace,
     make_blob_ref,
 )
-from claude_tap.models import JsonObject
 from claude_tap.trace_store import (
     COMPACT_RECORD_MARKER,
     TraceStore,
     get_trace_store,
 )
+from tests.schema_types import JsonObject
 
 
 def _large_codex_record(index: int, *, instructions: str, tools: list[JsonObject]) -> JsonObject:

--- a/tests/test_trace_store_locking.py
+++ b/tests/test_trace_store_locking.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from claude_tap.cli import _create_trace_writer
+from claude_tap.models import JsonObject
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_store import TraceStore
 from tests.conftest import e2e_env, trace_db_path
@@ -56,7 +57,7 @@ finally:
 """
 
 
-def _record(index: int) -> dict:
+def _record(index: int) -> JsonObject:
     return {
         "timestamp": f"2026-07-12T08:00:{index:02d}+00:00",
         "turn": index,

--- a/tests/test_trace_store_locking.py
+++ b/tests/test_trace_store_locking.py
@@ -16,10 +16,10 @@ from pathlib import Path
 import pytest
 
 from claude_tap.cli import _create_trace_writer
-from claude_tap.models import JsonObject
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_store import TraceStore
 from tests.conftest import e2e_env, trace_db_path
+from tests.schema_types import JsonObject
 from tests.test_e2e import PROJECT_ROOT, run_fake_upstream_in_thread
 
 FAKE_LOCKING_CLIENT_SCRIPT = r"""#!/usr/bin/env python3

--- a/tests/test_translate_i18n.py
+++ b/tests/test_translate_i18n.py
@@ -5,6 +5,8 @@ import json
 import sys
 from pathlib import Path
 
+from claude_tap.models import Map
+
 SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "translate_i18n.py"
 SPEC = importlib.util.spec_from_file_location("translate_i18n", SCRIPT_PATH)
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -120,7 +122,7 @@ const I18N = {
 
 
 def test_request_openrouter_translation_adds_fullwidth_instruction_for_ja(monkeypatch) -> None:
-    captured_payload: dict[str, object] = {}
+    captured_payload: Map[str, object] = {}
 
     class FakeResponse:
         def __enter__(self) -> "FakeResponse":

--- a/tests/test_translate_i18n.py
+++ b/tests/test_translate_i18n.py
@@ -5,7 +5,7 @@ import json
 import sys
 from pathlib import Path
 
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "translate_i18n.py"
 SPEC = importlib.util.spec_from_file_location("translate_i18n", SCRIPT_PATH)

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -12,6 +12,7 @@ from claude_tap.cli import (
     parse_update_args,
     update_main,
 )
+from claude_tap.models import Map
 
 
 def test_detect_installer_uses_uv_tool_environment(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -91,7 +92,7 @@ def test_update_main_dry_run_prints_command(
 
 
 def test_update_main_runs_selected_command(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     def fake_run(cmd, **kwargs):
         captured["cmd"] = cmd
@@ -106,7 +107,7 @@ def test_update_main_runs_selected_command(monkeypatch: pytest.MonkeyPatch) -> N
 
 
 def test_update_main_hides_windows_console(monkeypatch: pytest.MonkeyPatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     class FakeStartupInfo:
         def __init__(self) -> None:
@@ -151,7 +152,7 @@ def test_update_main_reports_missing_uv(monkeypatch: pytest.MonkeyPatch, capsys:
 
 
 def test_main_entry_routes_update_subcommand(monkeypatch: pytest.MonkeyPatch) -> None:
-    called: dict[str, object] = {}
+    called: Map[str, object] = {}
 
     def fake_update_main(argv):
         called["argv"] = argv

--- a/tests/test_update_command.py
+++ b/tests/test_update_command.py
@@ -12,7 +12,7 @@ from claude_tap.cli import (
     parse_update_args,
     update_main,
 )
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 def test_detect_installer_uses_uv_tool_environment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_viewer_contracts.py
+++ b/tests/test_viewer_contracts.py
@@ -14,8 +14,8 @@ from pathlib import Path
 import pytest
 
 from claude_tap.compact_trace import build_compact_trace_bundle
-from claude_tap.models import JsonObject, Map
 from claude_tap.viewer import _generate_html_viewer, _generate_html_viewer_from_compact_bundle, _read_viewer_template
+from tests.schema_types import JsonObject, Map
 
 pw_missing = False
 try:

--- a/tests/test_viewer_contracts.py
+++ b/tests/test_viewer_contracts.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import pytest
 
 from claude_tap.compact_trace import build_compact_trace_bundle
+from claude_tap.models import JsonObject, Map
 from claude_tap.viewer import _generate_html_viewer, _generate_html_viewer_from_compact_bundle, _read_viewer_template
 
 pw_missing = False
@@ -22,7 +22,7 @@ try:
     from playwright.sync_api import Page, sync_playwright  # noqa: F401
 except ImportError:
     pw_missing = True
-    Page = Any  # type: ignore[assignment,misc]
+    Page = object
 
 pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
 
@@ -30,24 +30,24 @@ pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
 @dataclass(frozen=True)
 class ViewerContractCase:
     name: str
-    records: tuple[dict[str, Any], ...]
+    records: tuple[Map[str, object], ...]
     expected_sections: tuple[str, ...]
     expected_system: str | None
     expected_roles: tuple[str, ...]
     expected_tools: tuple[str, ...]
     expected_output_types: tuple[str, ...]
-    expected_usage: dict[str, int]
+    expected_usage: Map[str, int]
     required_detail_text: tuple[str, ...]
     min_stream_events: int = 0
     entry_index: int = 0
     expected_sidebar_label: str | None = None
 
 
-def _sse_frame(payload: dict[str, Any]) -> str:
+def _sse_frame(payload: Map[str, object]) -> str:
     return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
-def _anthropic_messages_record() -> dict[str, Any]:
+def _anthropic_messages_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T13:20:00+00:00",
         "request_id": "req_anthropic_contract",
@@ -108,7 +108,7 @@ def _anthropic_messages_record() -> dict[str, Any]:
     }
 
 
-def _responses_record() -> dict[str, Any]:
+def _responses_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T13:21:00+00:00",
         "request_id": "req_responses_contract",
@@ -158,7 +158,7 @@ def _responses_record() -> dict[str, Any]:
     }
 
 
-def _responses_empty_input_record() -> dict[str, Any]:
+def _responses_empty_input_record() -> Map[str, object]:
     record = _responses_record()
     record["request_id"] = "req_responses_empty_input"
     record["request"]["body"]["input"] = []
@@ -166,7 +166,7 @@ def _responses_empty_input_record() -> dict[str, Any]:
     return record
 
 
-def _codex_websocket_record() -> dict[str, Any]:
+def _codex_websocket_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T13:22:00+00:00",
         "request_id": "req_codex_ws_contract",
@@ -233,7 +233,7 @@ def _codex_websocket_record() -> dict[str, Any]:
     }
 
 
-def _content_block_boundary_record() -> dict[str, Any]:
+def _content_block_boundary_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-24T07:20:00+00:00",
         "request_id": "req_content_block_boundary_contract",
@@ -304,14 +304,14 @@ def _content_block_boundary_record() -> dict[str, Any]:
     }
 
 
-def _codex_reverse_websocket_record() -> dict[str, Any]:
+def _codex_reverse_websocket_record() -> Map[str, object]:
     record = _codex_websocket_record()
     record["request_id"] = "req_codex_reverse_ws_contract"
     record["request"]["path"] = "/v1/responses"
     return record
 
 
-def _chat_completions_record() -> dict[str, Any]:
+def _chat_completions_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T13:23:00+00:00",
         "request_id": "req_chat_contract",
@@ -393,7 +393,7 @@ def _chat_completions_record() -> dict[str, Any]:
     }
 
 
-def _opencode_chat_completions_record() -> dict[str, Any]:
+def _opencode_chat_completions_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T16:11:10+00:00",
         "request_id": "req_opencode_real_shape_contract",
@@ -571,7 +571,7 @@ def _opencode_chat_completions_record() -> dict[str, Any]:
     }
 
 
-def _opencode_openai_oauth_responses_record() -> dict[str, Any]:
+def _opencode_openai_oauth_responses_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T16:45:43+00:00",
         "request_id": "req_opencode_openai_oauth_responses_contract",
@@ -680,7 +680,7 @@ def _opencode_openai_oauth_responses_record() -> dict[str, Any]:
     }
 
 
-def _pi_openai_oauth_websocket_record() -> dict[str, Any]:
+def _pi_openai_oauth_websocket_record() -> Map[str, object]:
     system_prompt = (
         "You are an expert coding assistant operating inside pi, a coding agent harness. "
         "You help users by reading files, executing commands, editing code, and writing new files.\n\n"
@@ -847,7 +847,7 @@ def _pi_openai_oauth_websocket_record() -> dict[str, Any]:
     }
 
 
-def _gemini_record() -> dict[str, Any]:
+def _gemini_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T13:24:00+00:00",
         "request_id": "req_gemini_contract",
@@ -943,7 +943,7 @@ def _gemini_record() -> dict[str, Any]:
     }
 
 
-def _bedrock_converse_record() -> dict[str, Any]:
+def _bedrock_converse_record() -> Map[str, object]:
     return {
         "timestamp": "2026-05-13T13:30:00+00:00",
         "request_id": "req_bedrock_converse_contract",
@@ -1179,7 +1179,7 @@ def _contract_cases() -> tuple[ViewerContractCase, ...]:
     )
 
 
-def _runtime_smoke_records() -> tuple[dict[str, Any], ...]:
+def _runtime_smoke_records() -> tuple[Map[str, object], ...]:
     return (
         {
             "request_id": "req_empty_body",
@@ -1196,7 +1196,7 @@ def _runtime_smoke_records() -> tuple[dict[str, Any], ...]:
     )
 
 
-def _sidebar_order_records() -> tuple[dict[str, Any], ...]:
+def _sidebar_order_records() -> tuple[Map[str, object], ...]:
     base = {
         "duration_ms": 100,
         "request": {"method": "POST", "path": "/v1/messages", "headers": {}, "body": {}},
@@ -1219,19 +1219,19 @@ def _sidebar_order_records() -> tuple[dict[str, Any], ...]:
     return tuple(records)
 
 
-def _claude_code_session_round_records() -> tuple[dict[str, Any], ...]:
+def _claude_code_session_round_records() -> tuple[Map[str, object], ...]:
     model = "aws.claude-opus-4.6"
 
     def make_record(
         request_id: str,
         turn: int,
-        messages: list[dict[str, Any]],
-        response_content: list[dict[str, Any]],
+        messages: list[Map[str, object]],
+        response_content: list[Map[str, object]],
         *,
         system: str | None = None,
         stop_reason: str = "end_turn",
-    ) -> dict[str, Any]:
-        body: dict[str, Any] = {"model": model, "messages": messages}
+    ) -> Map[str, object]:
+        body: Map[str, object] = {"model": model, "messages": messages}
         if system is not None:
             body["system"] = system
         return {
@@ -1333,8 +1333,8 @@ def _claude_code_session_round_records() -> tuple[dict[str, Any], ...]:
     )
 
 
-def _codex_app_large_session_records() -> tuple[dict[str, Any], ...]:
-    records: list[dict[str, Any]] = []
+def _codex_app_large_session_records() -> tuple[Map[str, object], ...]:
+    records: list[Map[str, object]] = []
     session_id = "codex-session-alpha"
     prompts = [
         "Write Codex App runtime wiki",
@@ -1361,7 +1361,7 @@ def _codex_app_large_session_records() -> tuple[dict[str, Any], ...]:
                 "content": [{"type": "input_text", "text": "<environment_context>\nskip cwd\n</environment_context>"}],
             },
         ]
-        prior_messages: list[dict[str, Any]] = []
+        prior_messages: list[Map[str, object]] = []
         for prior_prompt in prompts[:prompt_index]:
             prior_messages.extend(
                 [
@@ -1382,7 +1382,7 @@ def _codex_app_large_session_records() -> tuple[dict[str, Any], ...]:
             "role": "user",
             "content": [{"type": "input_text", "text": prompt}],
         }
-        continuation_messages: list[dict[str, Any]] = []
+        continuation_messages: list[Map[str, object]] = []
         if step:
             continuation_messages = [
                 {
@@ -1442,7 +1442,7 @@ def _codex_app_large_session_records() -> tuple[dict[str, Any], ...]:
     return tuple(records)
 
 
-def _codex_display_turn_records() -> tuple[dict[str, Any], ...]:
+def _codex_display_turn_records() -> tuple[Map[str, object], ...]:
     return (
         {
             "timestamp": "2026-06-01T00:57:34.069390+00:00",
@@ -1585,7 +1585,7 @@ def _codex_display_turn_records() -> tuple[dict[str, Any], ...]:
     )
 
 
-def _codex_lazy_display_turn_records() -> tuple[dict[str, Any], ...]:
+def _codex_lazy_display_turn_records() -> tuple[Map[str, object], ...]:
     records = list(_codex_display_turn_records())
     for idx in range(60):
         records.append(
@@ -1606,7 +1606,7 @@ def _codex_lazy_display_turn_records() -> tuple[dict[str, Any], ...]:
     return tuple(records)
 
 
-def _codex_direct_generate_false_records() -> tuple[dict[str, Any], ...]:
+def _codex_direct_generate_false_records() -> tuple[Map[str, object], ...]:
     visible = json.loads(json.dumps(_responses_record()))
     visible["request_id"] = "req_direct_visible"
     visible["turn"] = 2
@@ -1642,8 +1642,8 @@ def _codex_direct_generate_false_records() -> tuple[dict[str, Any], ...]:
     )
 
 
-def _codex_lazy_event_generate_false_records() -> tuple[dict[str, Any], ...]:
-    records: list[dict[str, Any]] = [
+def _codex_lazy_event_generate_false_records() -> tuple[Map[str, object], ...]:
+    records: list[Map[str, object]] = [
         {
             "timestamp": "2026-06-01T02:10:00.000000+00:00",
             "request_id": "req_event_prefetch",
@@ -1764,14 +1764,14 @@ def _codex_lazy_event_generate_false_records() -> tuple[dict[str, Any], ...]:
     return tuple(records)
 
 
-def _write_trace(trace_path: Path, records: tuple[dict[str, Any], ...]) -> None:
+def _write_trace(trace_path: Path, records: tuple[Map[str, object], ...]) -> None:
     trace_path.write_text(
         "".join(json.dumps(record, ensure_ascii=False) + "\n" for record in records),
         encoding="utf-8",
     )
 
 
-def _generate_case_html(tmp_path: Path, name: str, records: tuple[dict[str, Any], ...]) -> Path:
+def _generate_case_html(tmp_path: Path, name: str, records: tuple[Map[str, object], ...]) -> Path:
     trace_path = tmp_path / f"{name}.jsonl"
     html_path = tmp_path / f"{name}.html"
     _write_trace(trace_path, records)
@@ -1779,7 +1779,7 @@ def _generate_case_html(tmp_path: Path, name: str, records: tuple[dict[str, Any]
     return html_path
 
 
-def _compact_contract_records() -> tuple[dict[str, Any], ...]:
+def _compact_contract_records() -> tuple[Map[str, object], ...]:
     records = []
     for turn in (1, 2):
         record = json.loads(json.dumps(_responses_record()))
@@ -3116,7 +3116,7 @@ def test_viewer_visual_layout_contracts_cover_css_modes(tmp_path: Path, chromium
             }"""
         )
 
-        def snapshot(width: int, height: int, theme: str, mobile: bool = False) -> dict:
+        def snapshot(width: int, height: int, theme: str, mobile: bool = False) -> JsonObject:
             page.set_viewport_size({"width": width, "height": height})
             page.evaluate("theme => document.documentElement.setAttribute('data-theme', theme)", theme)
             if mobile:
@@ -3205,12 +3205,12 @@ def test_viewer_session_identical_prompts_image_tags_and_early_title_generation(
     def make_record(
         request_id: str,
         turn: int,
-        messages: list[dict[str, Any]],
-        response_content: list[dict[str, Any]],
+        messages: list[Map[str, object]],
+        response_content: list[Map[str, object]],
         *,
         system: str | None = None,
-    ) -> dict[str, Any]:
-        body: dict[str, Any] = {"model": model, "messages": messages}
+    ) -> Map[str, object]:
+        body: Map[str, object] = {"model": model, "messages": messages}
         if system is not None:
             body["system"] = system
         return {

--- a/tests/test_viewer_non_dict_body.py
+++ b/tests/test_viewer_non_dict_body.py
@@ -13,8 +13,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from claude_tap.models import JsonObject
 from claude_tap.viewer import LAZY_THRESHOLD, _extract_metadata, _generate_html_viewer
+from tests.schema_types import JsonObject
 
 
 def _record(req_body, resp_body, *, request_id: str = "req_1", turn: int = 1) -> JsonObject:

--- a/tests/test_viewer_non_dict_body.py
+++ b/tests/test_viewer_non_dict_body.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from claude_tap.models import JsonObject
 from claude_tap.viewer import LAZY_THRESHOLD, _extract_metadata, _generate_html_viewer
 
 
-def _record(req_body, resp_body, *, request_id: str = "req_1", turn: int = 1) -> dict:
+def _record(req_body, resp_body, *, request_id: str = "req_1", turn: int = 1) -> JsonObject:
     return {
         "timestamp": "2026-05-04T03:00:00+00:00",
         "request_id": request_id,

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -16,7 +16,7 @@ import pytest
 
 from claude_tap.cli import run_client
 from claude_tap.history import _rel_posix
-from claude_tap.models import Map
+from tests.schema_types import Map
 
 
 class _DummyProc:

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -16,6 +16,7 @@ import pytest
 
 from claude_tap.cli import run_client
 from claude_tap.history import _rel_posix
+from claude_tap.models import Map
 
 
 class _DummyProc:
@@ -62,7 +63,7 @@ async def test_run_client_does_not_touch_sigtstp_when_absent(monkeypatch) -> Non
 
 @pytest.mark.asyncio
 async def test_run_client_passes_resolved_path_for_cmd_shim(monkeypatch) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -86,7 +87,7 @@ async def test_run_client_passes_resolved_path_for_cmd_shim(monkeypatch) -> None
 
 @pytest.mark.asyncio
 async def test_run_client_prefers_windows_cmd_sibling(monkeypatch, tmp_path: Path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd
@@ -156,7 +157,7 @@ async def test_run_client_executes_real_cmd_shim_on_windows(monkeypatch, tmp_pat
 
 @pytest.mark.asyncio
 async def test_run_client_uses_wrapper_provided_claude_binary(monkeypatch, tmp_path: Path) -> None:
-    captured: dict[str, object] = {}
+    captured: Map[str, object] = {}
 
     async def fake_create_subprocess_exec(*cmd, **kwargs):
         captured["cmd"] = cmd

--- a/tests/test_ws_proxy.py
+++ b/tests/test_ws_proxy.py
@@ -14,6 +14,7 @@ from aiohttp import web
 from yarl import URL
 
 from claude_tap.cli_clients import _extend_no_proxy
+from claude_tap.models import JsonObject
 from claude_tap.proxy import proxy_handler
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_store import get_trace_store, reset_trace_store
@@ -43,7 +44,7 @@ def _make_writer() -> tuple[object, str, TraceWriter]:
     return store, session_id, TraceWriter(session_id, store=store)
 
 
-def _load_records(store, session_id: str) -> list[dict]:
+def _load_records(store, session_id: str) -> list[JsonObject]:
     return store.load_records(session_id)
 
 
@@ -1005,7 +1006,7 @@ async def test_websocket_upstream_connect_does_not_override_proxy(trace_dir):
         strip_prefix="/v1",
     )
 
-    ws_connect_calls: list[dict] = []
+    ws_connect_calls: list[JsonObject] = []
     original_ws_connect = proxy_session.ws_connect
 
     async def _spy_ws_connect(*args, **kwargs):

--- a/tests/test_ws_proxy.py
+++ b/tests/test_ws_proxy.py
@@ -14,11 +14,11 @@ from aiohttp import web
 from yarl import URL
 
 from claude_tap.cli_clients import _extend_no_proxy
-from claude_tap.models import JsonObject
 from claude_tap.proxy import proxy_handler
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_store import get_trace_store, reset_trace_store
 from claude_tap.ws_proxy import _build_ws_record, _get_ws_proxy_settings
+from tests.schema_types import JsonObject
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -314,6 +323,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "cryptography" },
+    { name = "pydantic" },
 ]
 
 [package.optional-dependencies]
@@ -340,6 +350,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = "==3.11.1" },
     { name = "pexpect", marker = "extra == 'dev'", specifier = ">=4.9" },
+    { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
@@ -1509,6 +1520,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pyee"
 version = "13.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1632,6 +1760,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- migrate production annotations under `claude_tap/` and `scripts/` away from `Map`, `JsonObject`, `JsonValue`, bare `dict`, `Any`, `TypedDict`, and generic schema-less mappings
- introduce the Pydantic `ProviderPayload` boundary for provider-owned payloads, with mapping compatibility and `extra="allow"` for forward-compatible upstream fields
- keep unit-test and E2E fixture annotations outside the schema gate, as requested
- add repository stock scanning plus changed-line incremental schema enforcement; Ruff `ANN401` remains enabled for changed Python files

## Problem
The earlier boundary aliases (`Map`, `JsonObject`, and `JsonValue`) still represented dictionaries rather than validated models. They made the code look typed without giving business code a Pydantic boundary.

## Goal
Production code must use Pydantic models or explicitly parameterized scalar mappings. Provider payloads are validated at the named Pydantic boundary and preserve unknown upstream fields without exposing aliases as production annotations. Unit tests and E2E fixtures are intentionally excluded from this enforcement.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `python scripts/check_schema.py --base origin/main` (production stock scan plus incremental diff check)
- `uv run pytest tests/ -x --timeout=60` -> 1112 passed, 26 skipped
- isolated localhost `LiveViewerServer` plus temporary SQLite write/read validation; the active Talon SQLite was not opened or modified
- real trace-backed viewer evidence: [existing trace viewer screenshot](https://raw.githubusercontent.com/liaohch3/claude-tap/main/.agents/evidence/pr/trace-viewer-openai-compatible-usage-zero-alias.png)

## Results
Production annotation scans contain no `Map`, `JsonObject`, `JsonValue`, bare `dict`, `Any`, `TypedDict`, `Mapping`, `MutableMapping`, or `object` annotations. Test fixtures remain unchanged and are excluded from the stock and incremental schema paths. Runtime wire formats, prompt export output, and SQLite persistence behavior remain unchanged.
- `uv run pytest tests/test_check_coverage.py -q` -> 9 passed (coverage helper import regression)
