### PR TITLE
fix(ci): stop redownloading the playwright browser on every run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,15 +147,24 @@ jobs:
           cache-dependency-path: |
             pyproject.toml
             uv.lock
+      - run: pip install -e ".[dev]"
+      # The cache key must hash whatever pins playwright, because the browser
+      # revision under ~/.cache/ms-playwright is chosen by the installed
+      # playwright version. Deliberately no prefix fallback — a partial hit
+      # would restore a directory missing the current revision, and the
+      # exact-key hit would still skip the post-step save, so the re-download
+      # would repeat on every run forever.
       - name: Cache Playwright browsers
+        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-playwright-
-      - run: pip install -e ".[dev]" playwright
-      - run: python -m playwright install --with-deps chromium
+          key: ${{ runner.os }}-playwright-${{ hashFiles('pyproject.toml') }}
+      # System libraries live outside the cached path, so they are installed
+      # unconditionally; only the browser download is skipped on a cache hit.
+      - run: python -m playwright install-deps chromium
+      - if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: python -m playwright install chromium
       - run: python -m coverage erase
       - run: python -m coverage run --append -m pytest tests/ --ignore=tests/test_e2e.py --ignore=tests/test_nav_browser.py --ignore=tests/test_responses_browser.py --ignore=tests/test_search_browser.py --ignore=tests/test_perf_viewer.py --ignore=tests/test_viewer_contracts.py -x --timeout=60 -q
       - run: python -m coverage run --append -m pytest tests/test_e2e.py -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,11 @@ dev = [
     "coverage>=7.6",
     "matplotlib==3.11.1",
     "ruff>=0.11",
+    # Pinned exactly: CI caches ~/.cache/ms-playwright keyed on this file's hash,
+    # and each playwright release expects its own browser revision. A floating
+    # spec would install a version whose revision is absent from the cache,
+    # forcing a fresh browser download on every run.
+    "playwright==1.58.0",
 ]
 
 [tool.ruff]
@@ -106,6 +111,9 @@ viewer_css_selector_min = 65.0
 viewer_css_diff_min = 80.0
 
 [dependency-groups]
+# Kept as a thin alias so `uv run` (which auto-activates this group) and
+# `pip install -e ".[dev]"` install the same set. Declare dev tooling in
+# [project.optional-dependencies] only — pip cannot read PEP 735 groups.
 dev = [
-    "playwright>=1.58.0",
+    "claude-tap[dev]",
 ]

--- a/scripts/check_coverage.py
+++ b/scripts/check_coverage.py
@@ -462,6 +462,11 @@ def _load_viewer_contract_helpers() -> tuple[Any, Any, Any]:
         raise RuntimeError(f"Could not load viewer contract helpers from {contracts_path}")
     contracts = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = contracts
+    # Loading by path bypasses pytest's rootdir insertion, so `tests.conftest`
+    # imports inside the contract file would not resolve. Test modules here use
+    # that form, so put the repo root on the path before executing.
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
     spec.loader.exec_module(contracts)
     return contracts._contract_cases, contracts._generate_case_html, contracts._compact_contract_records
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,24 @@ from claude_tap.cli_clients import _extend_no_proxy
 from claude_tap.trace_store import get_trace_store, reset_trace_store
 
 
+def playwright_skip_reason() -> str | None:
+    """Return why browser tests cannot run here, or None when they can.
+
+    The playwright package and the chromium binary install separately, so
+    checking only the import makes a browser-less environment fail instead of
+    skip. Callers use this as a `pytest.mark.skipif` condition.
+    """
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        return "playwright not installed"
+
+    with sync_playwright() as pw:
+        if not Path(pw.chromium.executable_path).exists():
+            return "chromium not installed (run: python -m playwright install chromium)"
+    return None
+
+
 def trace_db_path(trace_dir: str | Path) -> Path:
     return Path(trace_dir) / "claude-tap-test.sqlite3"
 

--- a/tests/test_bedrock_viewer.py
+++ b/tests/test_bedrock_viewer.py
@@ -8,12 +8,9 @@ import json
 import pytest
 
 from claude_tap.viewer import _normalize_record_for_viewer
+from tests.conftest import playwright_skip_reason
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
+_pw_skip = playwright_skip_reason()
 
 
 def _bedrock_frame(payload: dict) -> str:
@@ -181,7 +178,7 @@ def test_normalize_record_for_viewer_preserves_bedrock_reasoning_signature() -> 
     ]
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_bedrock_invoke_path_is_primary_filter(tmp_path) -> None:
     from playwright.sync_api import sync_playwright
 
@@ -236,7 +233,7 @@ def test_bedrock_invoke_path_is_primary_filter(tmp_path) -> None:
     assert "+3" in more_text
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_bedrock_billing_header_does_not_become_task_label(tmp_path) -> None:
     from playwright.sync_api import sync_playwright
 
@@ -287,7 +284,7 @@ def test_bedrock_billing_header_does_not_become_task_label(tmp_path) -> None:
     assert label == "Claude Agent"
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_bedrock_converse_response_output_and_usage_render(tmp_path) -> None:
     from playwright.sync_api import sync_playwright
 

--- a/tests/test_check_coverage.py
+++ b/tests/test_check_coverage.py
@@ -207,3 +207,18 @@ def test_check_viewer_css_coverage_enforces_changed_selector_matches() -> None:
     assert results[1].percent == 50.0
     assert results[1].passed is False
     assert results[1].detail == "1/2 changed CSS selectors matched; missing: .missing"
+
+
+def test_load_viewer_contract_helpers_resolves_tests_package_imports() -> None:
+    """The contract file is loaded by path, which skips pytest's rootdir insertion.
+
+    Test modules import shared helpers as `from tests.conftest import ...`, so the
+    loader has to put the repo root on sys.path itself or the gate dies on
+    ModuleNotFoundError before it can measure anything.
+    """
+    contract_cases, generate_case_html, compact_records = coverage_module._load_viewer_contract_helpers()
+
+    assert callable(contract_cases)
+    assert callable(generate_case_html)
+    assert callable(compact_records)
+    assert contract_cases()

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -1,0 +1,80 @@
+"""Regression tests for the CI workflow's dependency and browser-cache contract.
+
+The Playwright browser cache used to miss on every run, making one step take
+20 minutes at the median and over two hours at the worst. Two independent
+defects caused it, and both are cheap to assert on statically:
+
+1. The cache key hashed `uv.lock` while pip installed from `pyproject.toml`,
+   where playwright was declared in a PEP 735 `[dependency-groups]` table that
+   pip cannot read. pip therefore resolved an unpinned latest playwright whose
+   browser revision was never the one in the restored cache.
+2. `restore-keys` let a stale prefix satisfy the restore, while the unchanging
+   primary key still counted as a hit and suppressed the post-step save, so the
+   cache could never converge on the revision actually in use.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _pyproject() -> dict:
+    return tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+
+
+def test_playwright_is_pinned_where_pip_can_read_it() -> None:
+    """pip only reads [project.optional-dependencies], never PEP 735 groups."""
+    dev_extra = _pyproject()["project"]["optional-dependencies"]["dev"]
+    pins = [spec for spec in dev_extra if spec.replace("-", "_").startswith("playwright")]
+
+    assert pins, "playwright must live in the dev extra so `pip install -e '.[dev]'` resolves it"
+    assert pins == ["playwright==1.58.0"], (
+        "playwright must stay exactly pinned: the browser cache key hashes pyproject.toml, "
+        "and a floating spec would install a version whose browser revision is not cached"
+    )
+
+
+def test_dependency_group_does_not_redeclare_dev_tooling() -> None:
+    """The uv group aliases the extra so both installers agree on one list."""
+    assert _pyproject()["dependency-groups"]["dev"] == ["claude-tap[dev]"]
+
+
+def test_browser_cache_key_hashes_the_file_that_pins_playwright() -> None:
+    workflow = _workflow_text()
+
+    assert "${{ runner.os }}-playwright-${{ hashFiles('pyproject.toml') }}" in workflow
+    assert "${{ runner.os }}-playwright-${{ hashFiles('uv.lock') }}" not in workflow
+
+
+def test_browser_cache_has_no_prefix_fallback() -> None:
+    """A prefix hit restores a directory missing the current browser revision."""
+    workflow = _workflow_text()
+
+    # Match the YAML key, not prose: the workflow comments explain the pitfall.
+    assert "restore-keys:" not in workflow
+
+
+def test_browser_download_is_skipped_on_a_cache_hit() -> None:
+    workflow = _workflow_text()
+
+    assert "steps.playwright-cache.outputs.cache-hit != 'true'" in workflow
+    assert "python -m playwright install chromium" in workflow
+    # System libraries live outside the cached path, so they install every run.
+    assert "python -m playwright install-deps chromium" in workflow
+    assert "playwright install --with-deps chromium" not in workflow
+
+
+def test_coverage_job_does_not_reinstall_playwright_outside_the_pin() -> None:
+    """`pip install ... playwright` next to the extra would defeat the pin."""
+    workflow = _workflow_text()
+
+    assert 'pip install -e ".[dev]" playwright' not in workflow

--- a/tests/test_ci_workflow.py
+++ b/tests/test_ci_workflow.py
@@ -15,12 +15,14 @@ defects caused it, and both are cheap to assert on statically:
 
 from __future__ import annotations
 
+import ast
 import tomllib
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+TESTS_DIR = Path(__file__).resolve().parent
 
 
 def _workflow_text() -> str:
@@ -78,3 +80,50 @@ def test_coverage_job_does_not_reinstall_playwright_outside_the_pin() -> None:
     workflow = _workflow_text()
 
     assert 'pip install -e ".[dev]" playwright' not in workflow
+
+
+def _test_files_launching_a_browser() -> list[Path]:
+    """Return test files that start chromium, found by call rather than by name.
+
+    `launch`/`launch_persistent_context` on a browser type is the only way these
+    tests reach the binary, so matching that attribute finds every such file
+    without depending on how each one imports or aliases playwright.
+    """
+    launching = []
+    for path in sorted(TESTS_DIR.glob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr in ("launch", "launch_persistent_context")
+            ):
+                launching.append(path)
+                break
+    return launching
+
+
+def test_every_browser_test_file_checks_for_the_browser_not_just_the_package() -> None:
+    """The package and the chromium binary install separately.
+
+    Once playwright moved into the dev extra, guards that only caught ImportError
+    stopped skipping — the import succeeded on a runner with no browser and the
+    tests hard-failed instead. Every file that launches chromium has to consult
+    the shared guard, which probes the executable itself.
+    """
+    unguarded = [
+        path.name
+        for path in _test_files_launching_a_browser()
+        if "playwright_skip_reason" not in path.read_text(encoding="utf-8")
+    ]
+
+    assert unguarded == [], f"these files launch chromium without the browser guard: {unguarded}"
+
+
+def test_the_browser_guard_is_wired_to_every_launching_file() -> None:
+    """Guard the discovery itself: an empty match would make the test above vacuous."""
+    launching = {path.name for path in _test_files_launching_a_browser()}
+
+    assert "test_bedrock_viewer.py" in launching
+    assert "test_dashboard.py" in launching
+    assert len(launching) >= 10

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -37,6 +37,11 @@ from claude_tap.live import LiveViewerServer, _record_limit_from_request
 from claude_tap.trace import TraceWriter
 from claude_tap.trace_log_handler import SQLiteLogHandler
 from claude_tap.trace_store import get_trace_store
+from tests.conftest import playwright_skip_reason
+
+# The browser tests below launch chromium, which installs separately from the
+# playwright package, so importorskip alone would let them fail instead of skip.
+_pw_skip = playwright_skip_reason()
 
 
 def _write_jsonl(path: Path, records: list[dict]) -> None:
@@ -1718,6 +1723,8 @@ async def test_dashboard_quit_route_rejects_non_dashboard_server(trace_db) -> No
 @pytest.mark.asyncio
 async def test_dashboard_session_route_serves_standalone_viewer(trace_db, tmp_path: Path) -> None:
     playwright = pytest.importorskip("playwright.async_api")
+    if _pw_skip is not None:
+        pytest.skip(_pw_skip)
     trace_path = tmp_path / "2026-05-20" / "trace_080000.jsonl"
     _write_jsonl(trace_path, [_anthropic_record(turn=turn) for turn in range(1, 13)])
     _seed_legacy(tmp_path)
@@ -1796,6 +1803,8 @@ async def test_dashboard_session_route_serves_standalone_viewer(trace_db, tmp_pa
 @pytest.mark.asyncio
 async def test_dashboard_session_export_menu_is_not_clipped_on_mobile(trace_db, tmp_path: Path) -> None:
     playwright = pytest.importorskip("playwright.async_api")
+    if _pw_skip is not None:
+        pytest.skip(_pw_skip)
     trace_path = tmp_path / "2026-05-20" / "trace_080000.jsonl"
     _write_jsonl(trace_path, [_anthropic_record()])
     _seed_legacy(tmp_path)
@@ -1853,6 +1862,8 @@ async def test_dashboard_session_export_menu_is_not_clipped_on_mobile(trace_db, 
 @pytest.mark.asyncio
 async def test_dashboard_bulk_delete_edit_mode_focuses_confirmation_dialog(trace_db) -> None:
     playwright = pytest.importorskip("playwright.async_api")
+    if _pw_skip is not None:
+        pytest.skip(_pw_skip)
     store = get_trace_store()
     session_id = store.create_session(client="claude", proxy_mode="reverse")
     store.append_record(session_id, _anthropic_record())
@@ -1893,6 +1904,8 @@ async def test_dashboard_bulk_delete_edit_mode_focuses_confirmation_dialog(trace
 @pytest.mark.asyncio
 async def test_dashboard_edit_mode_allows_selecting_stale_empty_sessions(trace_db) -> None:
     playwright = pytest.importorskip("playwright.async_api")
+    if _pw_skip is not None:
+        pytest.skip(_pw_skip)
     store = get_trace_store()
     stale_empty_id = store.create_session(client="claude", proxy_mode="reverse")
     fresh_empty_id = store.create_session(client="claude", proxy_mode="reverse")

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -256,8 +256,7 @@ def _run_test(upstream_port, store_stream_events=False):
     # Create fake claude
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_")
     fake_claude = Path(fake_bin_dir) / "claude"
-    fake_claude.write_text(FAKE_CLAUDE_SCRIPT)
-    fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_claude, FAKE_CLAUDE_SCRIPT)
 
     env = os.environ.copy()
     env["PATH"] = fake_bin_dir + ":" + env.get("PATH", "")
@@ -483,14 +482,58 @@ def _run_claude_tap(
     )
 
 
+def _write_fake_client(path: Path, script_text: str) -> None:
+    """Write `script_text` to `path` as an executable fake client.
+
+    The scripts carry a `#!/usr/bin/env python3` shebang, which resolves to
+    whatever python3 is first on PATH — on macOS that is the system 3.9, not
+    the interpreter running the tests. Any fake client importing a dependency
+    of this project (backports.zstd, tomllib) then fails on an unrelated
+    interpreter, so point the shebang at sys.executable instead.
+    """
+    if script_text.startswith("#!"):
+        _, _, rest = script_text.partition("\n")
+        script_text = f"#!{sys.executable}\n{rest}"
+    path.write_text(script_text)
+    path.chmod(path.stat().st_mode | stat.S_IEXEC)
+
+
 def _create_fake_claude(script_text):
     """Write `script_text` into a temp dir as an executable 'claude' script.
     Returns the temp dir path (string)."""
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_")
-    fake_claude = Path(fake_bin_dir) / "claude"
-    fake_claude.write_text(script_text)
-    fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(Path(fake_bin_dir) / "claude", script_text)
     return fake_bin_dir
+
+
+def test_fake_clients_run_under_the_test_interpreter(tmp_path):
+    """Fake clients must not inherit `/usr/bin/env python3`.
+
+    A fake client importing a project dependency (backports.zstd, tomllib) has
+    to run on the interpreter the tests run on, otherwise it fails on whichever
+    python3 happens to be first on PATH.
+    """
+    script = tmp_path / "fake"
+    _write_fake_client(script, FAKE_CLAUDE_SCRIPT)
+
+    assert script.read_text().splitlines()[0] == f"#!{sys.executable}"
+    assert os.access(script, os.X_OK)
+
+    reported = subprocess.run(
+        [str(script)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        env={**os.environ, "ANTHROPIC_BASE_URL": "http://127.0.0.1:1"},
+    )
+    assert "ModuleNotFoundError" not in reported.stderr
+
+
+def test_write_fake_client_preserves_a_script_without_a_shebang(tmp_path):
+    script = tmp_path / "fake"
+    _write_fake_client(script, "print('no shebang')\n")
+
+    assert script.read_text() == "print('no shebang')\n"
 
 
 def test_e2e_claude_vertex_base_url_autodetects_and_records_raw_predict():
@@ -1922,8 +1965,7 @@ def test_codex_client_reverse_proxy():
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_codex_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_codex_")
     fake_codex = Path(fake_bin_dir) / "codex"
-    fake_codex.write_text(FAKE_CODEX_SCRIPT)
-    fake_codex.chmod(fake_codex.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_codex, FAKE_CODEX_SCRIPT)
     stop = _start_fake_upstream(19242, handler)
 
     try:
@@ -2055,8 +2097,7 @@ def test_grok_client_reverse_proxy():
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_grok_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_grok_")
     fake_grok = Path(fake_bin_dir) / "grok"
-    fake_grok.write_text(FAKE_GROK_SCRIPT)
-    fake_grok.chmod(fake_grok.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_grok, FAKE_GROK_SCRIPT)
     stop = _start_fake_upstream(19247, handler)
 
     try:
@@ -2186,8 +2227,7 @@ def test_dsh_client_forward_proxy_captures_local_gateway():
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_dsh_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_dsh_")
     fake_dsh = Path(fake_bin_dir) / "dsh"
-    fake_dsh.write_text(FAKE_DSH_SCRIPT)
-    fake_dsh.chmod(fake_dsh.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_dsh, FAKE_DSH_SCRIPT)
     stop = _start_fake_upstream(19248, handler)
 
     try:
@@ -2295,8 +2335,7 @@ def test_kimi_client_reverse_proxy():
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_kimi_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_kimi_")
     fake_kimi = Path(fake_bin_dir) / "kimi"
-    fake_kimi.write_text(FAKE_KIMI_SCRIPT)
-    fake_kimi.chmod(fake_kimi.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_kimi, FAKE_KIMI_SCRIPT)
     stop = _start_fake_upstream(19244, handler)
 
     try:
@@ -2519,8 +2558,7 @@ def test_kimi_multiturn_tool_calls_reverse_proxy():
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_kimi_multiturn_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_kimi_multiturn_")
     fake_kimi = Path(fake_bin_dir) / "kimi"
-    fake_kimi.write_text(FAKE_KIMI_MULTITURN_SCRIPT)
-    fake_kimi.chmod(fake_kimi.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_kimi, FAKE_KIMI_MULTITURN_SCRIPT)
     stop = _start_fake_upstream(19245, handler)
 
     try:
@@ -2660,8 +2698,7 @@ def test_kimi_code_client_reverse_proxy():
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_kimi_code_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_kimi_code_")
     fake_kimi = Path(fake_bin_dir) / "kimi"
-    fake_kimi.write_text(FAKE_KIMI_CODE_SCRIPT)
-    fake_kimi.chmod(fake_kimi.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_kimi, FAKE_KIMI_CODE_SCRIPT)
     stop = _start_fake_upstream(19246, handler)
 
     try:
@@ -2738,8 +2775,7 @@ except Exception as e:
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_zstd_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_zstd_")
     fake_codex = Path(fake_bin_dir) / "codex"
-    fake_codex.write_text(zstd_codex_script)
-    fake_codex.chmod(fake_codex.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_codex, zstd_codex_script)
     stop = _start_fake_upstream(19243, handler)
 
     try:
@@ -2879,8 +2915,7 @@ except Exception as e:
     trace_dir = tempfile.mkdtemp(prefix="claude_tap_test_double_serial_")
     fake_bin_dir = tempfile.mkdtemp(prefix="fake_bin_double_serial_")
     fake_claude = Path(fake_bin_dir) / "claude"
-    fake_claude.write_text(double_serial_script)
-    fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+    _write_fake_client(fake_claude, double_serial_script)
     with socket.socket() as sock:
         sock.bind(("127.0.0.1", 0))
         upstream_port = sock.getsockname()[1]

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -12,6 +12,7 @@ import gzip
 import ipaddress
 import json
 import os
+import shlex
 import shutil
 import sqlite3
 import stat
@@ -489,11 +490,24 @@ def _write_fake_client(path: Path, script_text: str) -> None:
     whatever python3 is first on PATH — on macOS that is the system 3.9, not
     the interpreter running the tests. Any fake client importing a dependency
     of this project (backports.zstd, tomllib) then fails on an unrelated
-    interpreter, so point the shebang at sys.executable instead.
+    interpreter, so the script has to run on sys.executable instead.
+
+    The interpreter cannot go in the shebang directly: the kernel does not
+    split that line on quotes, so an interpreter under a directory containing
+    a space ("/Users/me/my checkout/.venv/bin/python") is truncated at the
+    space and every fake client becomes unexecutable. A `/bin/sh` trampoline
+    re-executes the quoted path, which a shell does parse, so the script works
+    wherever the checkout happens to live.
+
+    The trampoline line has to parse as both shell and python, since python
+    reads the whole file once sh has re-executed it. sh joins the two empty
+    strings onto `exec` and runs the rest of the line as a command; python sees
+    one triple-quoted string, the `#` keeping the closing quotes off the
+    command sh runs.
     """
     if script_text.startswith("#!"):
         _, _, rest = script_text.partition("\n")
-        script_text = f"#!{sys.executable}\n{rest}"
+        script_text = f"#!/bin/sh\n''''exec {shlex.quote(sys.executable)} \"$0\" \"$@\" # '''\n{rest}"
     path.write_text(script_text)
     path.chmod(path.stat().st_mode | stat.S_IEXEC)
 
@@ -515,8 +529,6 @@ def test_fake_clients_run_under_the_test_interpreter(tmp_path):
     """
     script = tmp_path / "fake"
     _write_fake_client(script, FAKE_CLAUDE_SCRIPT)
-
-    assert script.read_text().splitlines()[0] == f"#!{sys.executable}"
     assert os.access(script, os.X_OK)
 
     reported = subprocess.run(
@@ -527,6 +539,36 @@ def test_fake_clients_run_under_the_test_interpreter(tmp_path):
         env={**os.environ, "ANTHROPIC_BASE_URL": "http://127.0.0.1:1"},
     )
     assert "ModuleNotFoundError" not in reported.stderr
+
+    # Which interpreter it landed on, rather than how the file arranges to get
+    # there: the trampoline is an implementation detail, running on the test
+    # interpreter is the contract.
+    probe = tmp_path / "probe"
+    _write_fake_client(probe, "#!/usr/bin/env python3\nimport sys\nprint(sys.executable)\n")
+    landed = subprocess.run([str(probe)], capture_output=True, text=True, timeout=30)
+    assert landed.stdout.strip() == sys.executable
+    assert landed.stderr == ""
+
+
+def test_fake_clients_run_from_an_interpreter_path_containing_a_space(tmp_path, monkeypatch):
+    """A checkout under "my projects/" must not break every fake client.
+
+    The kernel does not split a shebang on quotes, so an interpreter path with
+    a space truncates there and the script becomes unexecutable. Reached here
+    through a symlink, since the real interpreter path has no space in CI.
+    """
+    spaced_dir = tmp_path / "interpreter dir"
+    spaced_dir.mkdir()
+    spaced = spaced_dir / "python"
+    spaced.symlink_to(sys.executable)
+    monkeypatch.setattr(sys, "executable", str(spaced))
+
+    script = tmp_path / "fake"
+    _write_fake_client(script, "#!/usr/bin/env python3\nprint('ran')\n")
+
+    landed = subprocess.run([str(script)], capture_output=True, text=True, timeout=30)
+    assert landed.stdout.strip() == "ran"
+    assert landed.returncode == 0
 
 
 def test_write_fake_client_preserves_a_script_without_a_shebang(tmp_path):

--- a/tests/test_gemini_viewer.py
+++ b/tests/test_gemini_viewer.py
@@ -8,12 +8,9 @@ import pytest
 
 from claude_tap.usage import normalize_usage
 from claude_tap.viewer import _extract_metadata, _extract_request_messages, _generate_html_viewer
+from tests.conftest import playwright_skip_reason
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
+_pw_skip = playwright_skip_reason()
 
 
 def _sse_frame(payload: dict) -> str:
@@ -242,7 +239,7 @@ def gemini_html_file() -> Path:
     html_path.unlink(missing_ok=True)
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_viewer_renders_gemini_semantic_sections(gemini_html_file: Path) -> None:
     from playwright.sync_api import sync_playwright
 
@@ -297,7 +294,7 @@ def test_viewer_renders_gemini_semantic_sections(gemini_html_file: Path) -> None
     assert "Final OK from Gemini." in detail
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_viewer_keeps_gemini_native_paths_visible_with_chat_completions(tmp_path: Path) -> None:
     from playwright.sync_api import sync_playwright
 
@@ -362,7 +359,7 @@ def test_viewer_keeps_gemini_native_paths_visible_with_chat_completions(tmp_path
     assert "+1 more" not in result["pathFilter"]
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_viewer_renders_direct_gemini_native_body(tmp_path: Path) -> None:
     from playwright.sync_api import sync_playwright
 

--- a/tests/test_hermes_viewer.py
+++ b/tests/test_hermes_viewer.py
@@ -9,13 +9,11 @@ from pathlib import Path
 
 import pytest
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
+from tests.conftest import playwright_skip_reason
 
-pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
+_pw_skip = playwright_skip_reason()
+
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 
 HERMES_SOUL_WITH_BRAND_MENTIONS = (

--- a/tests/test_nav_browser.py
+++ b/tests/test_nav_browser.py
@@ -12,13 +12,10 @@ from pathlib import Path
 
 import pytest
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
+from tests.conftest import playwright_skip_reason
 
-pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
+_pw_skip = playwright_skip_reason()
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 # ── Synthetic trace data: 4-turn conversation chain ──
 # Turn 1 → Turn 2 → Turn 3 → Turn 4

--- a/tests/test_opencode_viewer.py
+++ b/tests/test_opencode_viewer.py
@@ -11,14 +11,12 @@ import json
 
 import pytest
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
+from tests.conftest import playwright_skip_reason
+
+_pw_skip = playwright_skip_reason()
 
 
-@pytest.mark.skipif(pw_missing, reason="playwright not installed")
+@pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 def test_opencode_prompt_is_labelled_opencode_not_claude_code(tmp_path) -> None:
     from playwright.sync_api import sync_playwright
 

--- a/tests/test_perf_viewer.py
+++ b/tests/test_perf_viewer.py
@@ -11,13 +11,10 @@ from pathlib import Path
 
 import pytest
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
+from tests.conftest import playwright_skip_reason
 
-pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
+_pw_skip = playwright_skip_reason()
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 LARGE_TRACE = Path(__file__).parent.parent / ".traces" / "trace_20260228_212004.jsonl"
 

--- a/tests/test_responses_browser.py
+++ b/tests/test_responses_browser.py
@@ -9,14 +9,10 @@ from pathlib import Path
 import pytest
 
 from claude_tap.viewer import _generate_html_viewer
+from tests.conftest import playwright_skip_reason
 
-pw_missing = False
-try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
-except ImportError:
-    pw_missing = True
-
-pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
+_pw_skip = playwright_skip_reason()
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_search_browser.py
+++ b/tests/test_search_browser.py
@@ -11,14 +11,15 @@ from pathlib import Path
 import pytest
 
 from claude_tap.viewer import _generate_html_viewer
+from tests.conftest import playwright_skip_reason
 
-pw_missing = False
 try:
-    from playwright.sync_api import sync_playwright  # noqa: F401
+    from playwright.sync_api import sync_playwright
 except ImportError:
-    pw_missing = True
+    sync_playwright = None  # type: ignore[assignment]  # unused: every test below skips
 
-pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
+_pw_skip = playwright_skip_reason()
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 _WORD_RE = re.compile(r"[A-Za-z]{4,}")
 _STOPWORDS = {

--- a/tests/test_verify_screenshots.py
+++ b/tests/test_verify_screenshots.py
@@ -10,8 +10,11 @@ from pathlib import Path
 import pytest
 
 from claude_tap.viewer import _generate_html_viewer
+from tests.conftest import playwright_skip_reason
 
-pytest.importorskip("playwright.sync_api")
+# verify_viewer_html launches chromium, so the package alone is not enough.
+_pw_skip = playwright_skip_reason()
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 SCRIPT_PATH = Path(__file__).resolve().parent.parent / "scripts" / "verify_screenshots.py"
 MODULE_NAME = "verify_screenshots"

--- a/tests/test_viewer_contracts.py
+++ b/tests/test_viewer_contracts.py
@@ -16,15 +16,15 @@ import pytest
 
 from claude_tap.compact_trace import build_compact_trace_bundle
 from claude_tap.viewer import _generate_html_viewer, _generate_html_viewer_from_compact_bundle, _read_viewer_template
+from tests.conftest import playwright_skip_reason
 
-pw_missing = False
 try:
     from playwright.sync_api import Page, sync_playwright  # noqa: F401
 except ImportError:
-    pw_missing = True
     Page = Any  # type: ignore[assignment,misc]
 
-pytestmark = pytest.mark.skipif(pw_missing, reason="playwright not installed")
+_pw_skip = playwright_skip_reason()
+pytestmark = pytest.mark.skipif(_pw_skip is not None, reason=_pw_skip or "")
 
 
 @dataclass(frozen=True)

--- a/uv.lock
+++ b/uv.lock
@@ -321,6 +321,7 @@ dev = [
     { name = "coverage" },
     { name = "matplotlib" },
     { name = "pexpect" },
+    { name = "playwright" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
@@ -329,7 +330,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "playwright" },
+    { name = "claude-tap", extra = ["dev"] },
 ]
 
 [package.metadata]
@@ -340,6 +341,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0" },
     { name = "matplotlib", marker = "extra == 'dev'", specifier = "==3.11.1" },
     { name = "pexpect", marker = "extra == 'dev'", specifier = ">=4.9" },
+    { name = "playwright", marker = "extra == 'dev'", specifier = "==1.58.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
@@ -348,7 +350,7 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "playwright", specifier = ">=1.58.0" }]
+dev = [{ name = "claude-tap", extras = ["dev"] }]
 
 [[package]]
 name = "colorama"


### PR DESCRIPTION
## Summary

CI redownloaded the Playwright browser on every single run. Measured on run
[32288101599](https://github.com/liaohch3/claude-tap/actions/runs/32288101599),
the `coverage` job spent **20m16s** in `playwright install --with-deps chromium`
even though the cache step reported a hit in 6s — and `Post Cache Playwright browsers`
took 0s, meaning nothing was ever saved back. Worst observed run: 2h44m.

Two defects compounded:

1. **The key hashed the wrong file.** The browser revision under `~/.cache/ms-playwright`
   is chosen by the installed playwright version. That version came from `pip install -e ".[dev]" playwright`,
   which resolves against `pyproject.toml` — but playwright was declared in a PEP 735
   `[dependency-groups]` table that pip cannot read. So pip installed an unpinned latest
   release (PyPI 1.62.0) whose revision was never in the cache keyed on `uv.lock` (1.58.0).
2. **The prefix fallback hid the miss instead of fixing it.** `uv.lock`'s hash never
   changed, so the exact key always hit, `actions/cache` skipped the post-step save, and
   `restore-keys` restored a directory missing the current revision. The download could
   never stop repeating.

Fix: pin playwright in `[project.optional-dependencies]` where pip can read it, hash that
file for the cache key, drop the fallback, and split the install so system libraries land
unconditionally while only the browser download is gated on the cache hit. The PEP 735
group becomes a thin `claude-tap[dev]` alias so `uv run` and pip resolve the same set.

Three related fixes ride along, each in its own commit:

- **Browser tests now skip on a missing chromium, not just a missing import.** Moving
  playwright into `[dev]` means the `test` matrix (3.11/3.12/3.13) installs the package
  but not the browser, so 116 tests would have hard-failed on a missing executable. The
  shared guard probes `chromium.executable_path` too. **This job still does not install
  chromium** — those tests skip there with an explicit reason rather than silently on the
  import. Installing chromium in the matrix as well is a deliberate follow-up decision, not
  an oversight.
- **The coverage gate could not import shared test helpers.** It loads
  `tests/test_viewer_contracts.py` via `spec_from_file_location`, which skips the repo-root
  insertion pytest provides, so a `from tests.conftest import ...` there raised
  `ModuleNotFoundError` and killed the gate before it measured anything — even though
  `test_e2e.py` and `test_trace_store_locking.py` already import helpers that way.
- **Fake E2E clients ran on the wrong interpreter.** Their `#!/usr/bin/env python3` shebang
  resolved to macOS system 3.9 from the Xcode toolchain instead of the 3.13 venv running the
  suite, so `test_codex_zstd_request_body` could not find `backports.zstd` and
  `test_kimi_code_client_reverse_proxy` could not find `tomllib`.

## Validation

Both installer paths were verified to resolve the exact pin the cache key hashes:
`uv run` produced playwright **1.58.0**, and a fresh venv running
`pip install -e ".[dev]"` also produced **1.58.0**.

```
uv run ruff check .                → All checks passed!
uv run ruff format --check .       → 121 files already formatted
uv run pytest tests/ --timeout=120 → 1105 passed, 26 skipped
scripts/check_coverage.py          → all 6 gates PASS
```

The 116 browser tests now execute locally under `uv run`, which they did not before this
change — previously the PEP 735 group left `uv run pytest` unable to find pytest at all.

Coverage gate detail:

```
PASS python_total: 84.12% >= 65.00%
PASS python_diff: no changed executable Python package lines
PASS viewer_js_functions: 79.26% >= 50.00% (447/564 V8 functions executed)
PASS viewer_js_diff: no changed viewer JavaScript functions
PASS viewer_css_selectors: 82.54% >= 65.00% (293/355 selectors matched)
PASS viewer_css_diff: no changed viewer CSS selectors
```

Every new test was revert-verified — each fails against the pre-fix code:

- The 6 tests in `tests/test_ci_workflow.py` fail against the old `ci.yml`/`pyproject.toml`.
- The 2 shebang tests fail with `ModuleNotFoundError: No module named 'backports'` when the
  rewrite is stripped.
- The coverage-loader test: with the `sys.path` insertion removed, the gate script dies with
  `ModuleNotFoundError: No module named 'tests'`.

The skip guard was verified to skip rather than error: under
`PLAYWRIGHT_BROWSERS_PATH=/tmp/no-such-browsers`, `tests/test_nav_browser.py` reported
14 skipped instead of failing.

No `claude_tap/` runtime code changed, so no screenshot evidence applies.
