### PR TITLE
chore: ignore the coverage artifacts the CI recipe writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,13 @@ test-traces/
 *.cast
 timing.txt
 typescript.txt
+.pytest_cache/
+
+# Coverage data written by the CI recipe in .github/workflows/ci.yml
+.coverage
+.coverage.*
+coverage.json
+coverage.xml
 
 # IDE / Editor
 .idea/


### PR DESCRIPTION
## Summary

- Ignore `.coverage`, `.coverage.*`, `coverage.json`, `coverage.xml`, and `.pytest_cache/`.

The coverage gate in `.github/workflows/ci.yml:160-166` runs `coverage run --append`
four times and then `coverage json -o .coverage.json`, both writing to the repository
root. Reproducing that gate locally therefore leaves two untracked files, ~0.5 MB and
~0.9 MB, that a `git add .` would sweep into a commit. `.pytest_cache/` had the same
gap while `.ruff_cache/` was already covered.

Verified empirically: after a real `coverage run` + `coverage json`, both files are on
disk and `git status` reports only the `.gitignore` edit itself. Also confirmed no
regression in the other direction — all 616 files currently tracked on `main` were fed
through `git check-ignore --no-index` and none of them match the new patterns.

No runtime, viewer, client, or proxy code is touched.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Documentation
- [x] Test or tooling
- [ ] Maintenance

## Validation

- [x] `uv run ruff check .` — All checks passed
- [x] `uv run ruff format --check .` — 126 files already formatted
- [x] `uv run pytest tests/ -x --timeout=60` — 1202 passed, 26 skipped

## Evidence

- Screenshots / recordings / trace files: not applicable; this changes only `.gitignore`
  and no runtime, viewer, client, proxy, or UI behavior.

## Privacy

- [x] This PR does not include API keys, auth tokens, private prompts, raw trace files, or generated HTML viewers.